### PR TITLE
Rendering block help texts inside span

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bootstrap_form (0.3.1)
+    bootstrap_form (0.3.2)
 
 GEM
   remote: http://rubygems.org/

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -7,12 +7,10 @@ module BootstrapForm
     delegate :content_tag, to: :@template
 
     def initialize(object_name, object, template, options, proc)
+      help = options.fetch(:help, nil)
+      @help_class = help.eql?(:block) ? 'help-block' : 'help-inline'
+
       super
-      @help_tag, @help_css = if options.fetch(:help, '').to_sym == :block
-        [:p, 'help-block']
-      else
-        [:span, 'help-inline']
-      end
     end
 
     FORM_HELPERS.each do |method_name|
@@ -89,7 +87,7 @@ module BootstrapForm
           controls = block.call
 
           help = has_name ? object.errors[name].join(', ') : _help
-          controls << content_tag(@help_tag, help, class: @help_css) if help
+          controls << content_tag(:span, help, class: @help_class) if help
 
           controls.html_safe
         end

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -262,7 +262,7 @@ class BootstrapFormTest < ActionView::TestCase
       f.text_field(:email, help: 'This is required')
     end
 
-    expected = %{<form accept-charset=\"UTF-8\" action=\"/users\" class=\" form-vertical\" id=\"new_user\" method=\"post\"><div style=\"margin:0;padding:0;display:inline\"><input name=\"utf8\" type=\"hidden\" value=\"&#x2713;\" /></div><div class=\"control-group\"><label class=\"control-label\" for=\"user_email\">Email</label><div class=\"controls\"><input id=\"user_email\" name=\"user[email]\" size=\"30\" type=\"text\" value=\"steve@example.com\" /><p class=\"help-block\">This is required</p></div></div></form>}
+    expected = %{<form accept-charset=\"UTF-8\" action=\"/users\" class=\" form-vertical\" id=\"new_user\" method=\"post\"><div style=\"margin:0;padding:0;display:inline\"><input name=\"utf8\" type=\"hidden\" value=\"&#x2713;\" /></div><div class=\"control-group\"><label class=\"control-label\" for=\"user_email\">Email</label><div class=\"controls\"><input id=\"user_email\" name=\"user[email]\" size=\"30\" type=\"text\" value=\"steve@example.com\" /><span class=\"help-block\">This is required</span></div></div></form>}
     assert_equal expected, output
   end
 
@@ -274,7 +274,7 @@ class BootstrapFormTest < ActionView::TestCase
       f.text_field(:email, help: 'This is required')
     end
 
-    expected = %{<form accept-charset=\"UTF-8\" action=\"/users\" class=\" form-vertical\" id=\"new_user\" method=\"post\"><div style=\"margin:0;padding:0;display:inline\"><input name=\"utf8\" type=\"hidden\" value=\"&#x2713;\" /></div><div class=\"control-group error\"><label class=\"control-label\" for=\"user_email\">Email</label><div class=\"controls\"><input id=\"user_email\" name=\"user[email]\" size=\"30\" type=\"text\" /><p class=\"help-block\">can't be blank, is too short (minimum is 5 characters)</p></div></div></form>}
+    expected = %{<form accept-charset=\"UTF-8\" action=\"/users\" class=\" form-vertical\" id=\"new_user\" method=\"post\"><div style=\"margin:0;padding:0;display:inline\"><input name=\"utf8\" type=\"hidden\" value=\"&#x2713;\" /></div><div class=\"control-group error\"><label class=\"control-label\" for=\"user_email\">Email</label><div class=\"controls\"><input id=\"user_email\" name=\"user[email]\" size=\"30\" type=\"text\" /><span class=\"help-block\">can't be blank, is too short (minimum is 5 characters)</span></div></div></form>}
     assert_equal expected, output
   end
 
@@ -286,7 +286,7 @@ class BootstrapFormTest < ActionView::TestCase
       f.text_field(:email, help: 'This is required')
     end
 
-    expected = %{<form accept-charset=\"UTF-8\" action=\"/users\" class=\"new_user\" id=\"new_user\" method=\"post\"><div style=\"margin:0;padding:0;display:inline\"><input name=\"utf8\" type=\"hidden\" value=\"&#x2713;\" /></div><div class=\"control-group error\"><div class=\"field_with_errors\"><label class=\"control-label\" for=\"user_email\">Email</label></div><div class=\"controls\"><div class=\"field_with_errors\"><input id=\"user_email\" name=\"user[email]\" size=\"30\" type=\"text\" /></div><p class=\"help-block\">can't be blank, is too short (minimum is 5 characters)</p></div></div></form>}
+    expected = %{<form accept-charset=\"UTF-8\" action=\"/users\" class=\"new_user\" id=\"new_user\" method=\"post\"><div style=\"margin:0;padding:0;display:inline\"><input name=\"utf8\" type=\"hidden\" value=\"&#x2713;\" /></div><div class=\"control-group error\"><div class=\"field_with_errors\"><label class=\"control-label\" for=\"user_email\">Email</label></div><div class=\"controls\"><div class=\"field_with_errors\"><input id=\"user_email\" name=\"user[email]\" size=\"30\" type=\"text\" /></div><span class=\"help-block\">can't be blank, is too short (minimum is 5 characters)</span></div></div></form>}
     assert_equal expected, output
   end
 end


### PR DESCRIPTION
Hi @potenza,

following the [bootstrap docs](http://twitter.github.com/bootstrap/base-css.html#forms), all help texts are `span` tags, and the gem is rendering block help text inside a `p` tag.

This PR fixes this.
