### PR TITLE
Allow the form object to be nil

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -66,10 +66,10 @@ module BootstrapForm
     end
 
     def control_group(name = nil, options = {}, &block)
-      has_name = !(name.nil? || object.errors[name].empty?)
+      errors_has_name = object.respond_to?(:errors) && !(name.nil? || object.errors[name].empty?)
 
       options[:class] ||= 'control-group'
-      options[:class] << ' error' if has_name
+      options[:class] << ' error' if errors_has_name
 
       label = options.delete(:label)
       _help = options.delete(:help)
@@ -87,7 +87,7 @@ module BootstrapForm
         html << content_tag(:div, class: 'controls') do
           controls = capture(&block)
 
-          help = has_name ? object.errors[name].join(', ') : _help
+          help = errors_has_name ? object.errors[name].join(', ') : _help
           controls << content_tag(:span, help, class: @help_class) if help
 
           controls.html_safe
@@ -117,7 +117,7 @@ module BootstrapForm
       options = args.extract_options!
       css = options[:class] || "alert alert-error"
 
-      if object.errors.full_messages.any?
+      if object.respond_to?(:errors) && object.errors.full_messages.any?
         content_tag :div, class: css do
           title
         end

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -302,5 +302,11 @@ class BootstrapFormTest < ActionView::TestCase
     expected = %{<form accept-charset=\"UTF-8\" action=\"/users\" class=\" form-vertical\" id=\"new_user\" method=\"post\"><div style=\"margin:0;padding:0;display:inline\"><input name=\"utf8\" type=\"hidden\" value=\"&#x2713;\" /></div><div class=\"control-group\"><label class=\"control-label\" for=\"user_address_attributes_street\">Street</label><div class=\"controls\"><input id=\"user_address_attributes_street\" name=\"user[address_attributes][street]\" size=\"30\" type=\"text\" value=\"123 Main Street\" /></div></div></form>}
     assert_equal expected, output
   end
+
+  test "allows the form object to be nil" do
+    builder = BootstrapForm::FormBuilder.new :other_model, nil, self, {}, nil
+    expected = %{<div class=\"control-group\"><label class=\"control-label\" for=\"other_model_email\">Email</label><div class=\"controls\"><input id=\"other_model_email\" name=\"other_model[email]\" size=\"30\" type=\"text\" /></div></div>}
+    assert_equal expected, builder.text_field(:email)
+  end
 end
 


### PR DESCRIPTION
I have a couple of scenarios in one of my apps where a form is created with something like form_for :person and the object may be nil. The only place this seems to cause an issue for bootstrap_form is where it checks for errors on the form object.

I also have a couple of places where form objects are not ActiveRecords so they don't implement the errors method. Whilst the correct long term solution to this is probably to make those classes into ActiveModels it seems like it is worth supporting this scenario too. This is why I have done the check with respond_to? rather than just nil?

Please can you look at this minor patch for this and consider merging it into the main repo.

Thanks,

-Michael
