### PR TITLE
accept "label: false" as alternative to render field without a label

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -77,7 +77,7 @@ module BootstrapForm
       content_tag(:div, options) do
         html = ''
 
-        if label && label[:text] != :none
+        if label && (label[:text] != :none && label[:text] != false)
           label[:class] ||= 'control-label'
           label[:for] ||= '' if name.nil?
 

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -137,6 +137,7 @@ class BootstrapFormTest < ActionView::TestCase
   test "render the field without label" do
     expected = %{<div class=\"control-group\"><div class=\"controls\"><input id=\"user_email\" name=\"user[email]\" type=\"text\" value=\"steve@example.com\" /></div></div>}
     assert_equal expected, @builder.text_field(:email, label: :none)
+    assert_equal expected, @builder.text_field(:email, label: false)
   end
 
   test "adding prepend text" do


### PR DESCRIPTION
closes https://github.com/potenza/bootstrap_form/issues/20
