### PR TITLE
Make name optional in FormBuilder#submit

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -76,7 +76,7 @@ module BootstrapForm
       end
     end
 
-    def submit(name, options = {})
+    def submit(name = nil, options = {})
       options.merge! class: 'btn btn-default' unless options.has_key? :class
       super name, options
     end


### PR DESCRIPTION
This change makes bootstrap_form's submit consistent with Rails' one. That way we can write `f.submit` and make Rails get the proper submit name from i18n backend.
