### PR TITLE
allow html content in check_box tag label

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -53,7 +53,7 @@ module BootstrapForm
       options = options.symbolize_keys!
 
       html = super(name, options.except(:label, :help, :inline), checked_value, unchecked_value)
-      html << ' ' + (options[:label] || object.class.human_attribute_name(name) || name.to_s.humanize)
+      html.concat(' ').concat(options[:label] || object.class.human_attribute_name(name) || name.to_s.humanize)
 
       if options[:inline]
         label(name, html, class: "checkbox-inline")


### PR DESCRIPTION
'  ' + options[:label] converts the type from ActiveSupport::SafeBuffer to String, appending to the left first prevents that
