### PR TITLE
Change form option name of :style to :layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,12 @@ will grow to 100% of the available width.
 
 ### Inline Forms
 
-To use an inline-style form, use the `style: :inline` option. To hide labels,
+To use an inline-layout form, use the `layout: :inline` option. To hide labels,
 use the `hide_label: true` option, which keeps your labels accessible to those
 using screen readers.
 
 ```erb
-<%= bootstrap_form_for(@user, style: :inline) do |f| %>
+<%= bootstrap_form_for(@user, layout: :inline) do |f| %>
   <%= f.email_field :email, hide_label: true %>
   <%= f.password_field :password, hide_label: true %>
   <%= f.check_box :remember_me %>
@@ -125,15 +125,15 @@ using screen readers.
 
 ### Horizontal Forms
 
-To use a horizontal-style form with labels to the left of the control, use the
-`style: :horizontal` option. You should specify both `label_col` and
+To use a horizontal-layout form with labels to the left of the control, use the
+`layout: :horizontal` option. You should specify both `label_col` and
 `control_col` css classes as well (they default to `col-sm-2` and `col-sm-10`).
 
 In the example below, the checkbox and submit button have been wrapped in a
 `form_group` to keep them properly aligned.
 
 ```erb
-<%= bootstrap_form_for(@user, style: :horizontal, label_col: "col-sm-2", control_col: "col-sm-10") do |f| %>
+<%= bootstrap_form_for(@user, layout: :horizontal, label_col: "col-sm-2", control_col: "col-sm-10") do |f| %>
   <%= f.email_field :email %>
   <%= f.password_field :password %>
   <%= f.form_group do %>
@@ -148,7 +148,7 @@ In the example below, the checkbox and submit button have been wrapped in a
 The `label_col` and `control_col` css classes can also be changed per control:
 
 ```erb
-<%= bootstrap_form_for(@user, style: :horizontal) do |f| %>
+<%= bootstrap_form_for(@user, layout: :horizontal) do |f| %>
   <%= f.email_field :email %>
   <%= f.text_field :age, control_col: "col-sm-3" %>
   <%= f.form_group do %>

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -2,7 +2,7 @@ module BootstrapForm
   class FormBuilder < ActionView::Helpers::FormBuilder
     include BootstrapForm::BootstrapHelpers
 
-    attr_reader :style, :label_col, :control_col, :has_error, :inline_errors
+    attr_reader :layout, :label_col, :control_col, :has_error, :inline_errors
 
     FIELD_HELPERS = %w{color_field date_field datetime_field datetime_local_field
       email_field month_field number_field password_field phone_field
@@ -14,7 +14,7 @@ module BootstrapForm
     delegate :content_tag, :capture, :concat, to: :@template
 
     def initialize(object_name, object, template, options, proc=nil)
-      @style = options[:style]
+      @layout = options[:layout]
       @label_col = options[:label_col] || default_label_col
       @control_col = options[:control_col] || default_control_col
       @inline_errors = options[:inline_errors] != false
@@ -129,7 +129,7 @@ module BootstrapForm
 
     def fields_for(record_name, record_object = nil, fields_options = {}, &block)
       fields_options, record_object = record_object, nil if record_object.is_a?(Hash) && record_object.extractable_options?
-      fields_options[:style] ||= options[:style]
+      fields_options[:layout] ||= options[:layout]
       fields_options[:label_col] = (fields_options.include?(:label_col)) ? fields_options[:label_col] + " #{label_class}" : options[:label_col]
       fields_options[:control_col] ||= options[:control_col]
       super(record_name, record_object, fields_options, &block)
@@ -138,7 +138,7 @@ module BootstrapForm
     private
 
     def horizontal?
-      style == :horizontal
+      layout == :horizontal
     end
 
     def default_label_col

--- a/lib/bootstrap_form/helper.rb
+++ b/lib/bootstrap_form/helper.rb
@@ -3,16 +3,16 @@ module BootstrapForm
     def bootstrap_form_for(object, options = {}, &block)
       options[:builder] = BootstrapForm::FormBuilder
 
-      style = case options[:style]
+      layout = case options[:layout]
         when :inline
           "form-inline"
         when :horizontal
           "form-horizontal"
       end
 
-      if style
+      if layout
         options[:html] ||= {}
-        options[:html][:class] = [options[:html][:class], style].compact.join(" ")
+        options[:html][:class] = [options[:html][:class], layout].compact.join(" ")
       end
 
       temporarily_disable_field_error_proc do

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -6,7 +6,7 @@ class BootstrapFormTest < ActionView::TestCase
   def setup
     @user = User.new(email: 'steve@example.com', password: 'secret', comments: 'my comment')
     @builder = BootstrapForm::FormBuilder.new(:user, @user, self, {}, nil)
-    @horizontal_builder = BootstrapForm::FormBuilder.new(:user, @user, self, { style: :horizontal, label_col: "col-sm-2", control_col: "col-sm-10" }, nil)
+    @horizontal_builder = BootstrapForm::FormBuilder.new(:user, @user, self, { layout: :horizontal, label_col: "col-sm-2", control_col: "col-sm-10" }, nil)
   end
 
   test "default-style forms" do
@@ -16,17 +16,17 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "inline-style forms" do
     expected = %{<form accept-charset="UTF-8" action="/users" class="form-inline" id="new_user" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div></form>}
-    assert_equal expected, bootstrap_form_for(@user, style: :inline) { |f| nil }
+    assert_equal expected, bootstrap_form_for(@user, layout: :inline) { |f| nil }
   end
 
   test "horizontal-style forms" do
     expected = %{<form accept-charset="UTF-8" action="/users" class="form-horizontal" id="new_user" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div><div class="form-group"><label class="control-label col-sm-2" for="user_email">Email</label><div class="col-sm-10"><input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" /></div></div></form>}
-    assert_equal expected, bootstrap_form_for(@user, style: :horizontal) { |f| f.email_field :email }
+    assert_equal expected, bootstrap_form_for(@user, layout: :horizontal) { |f| f.email_field :email }
   end
 
   test "existing styles aren't clobbered when specifying a form style" do
     expected = %{<form accept-charset="UTF-8" action="/users" class="my-style form-horizontal" id="new_user" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div><div class="form-group"><label class="control-label col-sm-2" for="user_email">Email</label><div class="col-sm-10"><input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" /></div></div></form>}
-    assert_equal expected, bootstrap_form_for(@user, style: :horizontal, html: { class: "my-style" }) { |f| f.email_field :email }
+    assert_equal expected, bootstrap_form_for(@user, layout: :horizontal, html: { class: "my-style" }) { |f| f.email_field :email }
   end
 
   test "alert message is wrapped correctly" do
@@ -356,12 +356,12 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "custom label width for horizontal forms" do
     expected = %{<form accept-charset="UTF-8" action="/users" class="form-horizontal" id="new_user" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div><div class="form-group"><label class="control-label col-sm-1" for="user_email">Email</label><div class="col-sm-10"><input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" /></div></div></form>}
-    assert_equal expected, bootstrap_form_for(@user, style: :horizontal) { |f| f.email_field :email, label_col: 'col-sm-1' }
+    assert_equal expected, bootstrap_form_for(@user, layout: :horizontal) { |f| f.email_field :email, label_col: 'col-sm-1' }
   end
 
   test "custom input width for horizontal forms" do
     expected = %{<form accept-charset="UTF-8" action="/users" class="form-horizontal" id="new_user" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div><div class="form-group"><label class="control-label col-sm-2" for="user_email">Email</label><div class="col-sm-5"><input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" /></div></div></form>}
-    assert_equal expected, bootstrap_form_for(@user, style: :horizontal) { |f| f.email_field :email, control_col: 'col-sm-5' }
+    assert_equal expected, bootstrap_form_for(@user, layout: :horizontal) { |f| f.email_field :email, control_col: 'col-sm-5' }
   end
 
   test "passing options to a form control get passed through" do
@@ -518,7 +518,7 @@ class BootstrapFormTest < ActionView::TestCase
   test "fields_for correctly passes horizontal style from parent builder" do
     @user.address = Address.new(street: '123 Main Street')
 
-    output = bootstrap_form_for(@user, style: :horizontal, label_col: 'col-sm-2', control_col: 'col-sm-10') do |f|
+    output = bootstrap_form_for(@user, layout: :horizontal, label_col: 'col-sm-2', control_col: 'col-sm-10') do |f|
       f.fields_for :address do |af|
         af.text_field(:street)
       end
@@ -531,7 +531,7 @@ class BootstrapFormTest < ActionView::TestCase
   test "fields_for correctly passes inline style from parent builder" do
     @user.address = Address.new(street: '123 Main Street')
 
-    output = bootstrap_form_for(@user, style: :inline) do |f|
+    output = bootstrap_form_for(@user, layout: :inline) do |f|
       f.fields_for :address do |af|
         af.text_field(:street)
       end


### PR DESCRIPTION
This request changes the name of the form layout option from `:style` to `:layout`.
