### PR TITLE
fixing label/input pairing for checkbox collections

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -70,11 +70,14 @@ module BootstrapForm
       label_content = block_given? ? capture(&block) : options[:label]
       html.concat(" ").concat(label_content || object.class.human_attribute_name(name) || name.to_s.humanize)
 
+      label_name = name
+      label_name = "#{name}_#{checked_value}" if options[:multiple]
+
       if options[:inline]
-        label(name, html, class: "checkbox-inline")
+        label(label_name, html, class: "checkbox-inline")
       else
         content_tag(:div, class: "checkbox") do
-          label(name, html)
+          label(label_name, html)
         end
       end
     end

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -577,28 +577,28 @@ class BootstrapFormTest < ActionView::TestCase
 
   test 'collection_check_boxes renders the form_group correctly' do
     collection = [Address.new(id: 1, street: 'Foobar')]
-    expected = %{<div class="form-group"><label class="control-label" for="user_misc">This is a checkbox collection</label><div class="checkbox"><label for="user_misc"><input id="user_misc_1" name="user[misc][]" type="checkbox" value="1" /> Foobar</label></div><span class="help-block">With a help!</span></div>}
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">This is a checkbox collection</label><div class="checkbox"><label for="user_misc_1"><input id="user_misc_1" name="user[misc][]" type="checkbox" value="1" /> Foobar</label></div><span class="help-block">With a help!</span></div>}
 
     assert_equal expected, @builder.collection_check_boxes(:misc, collection, :id, :street, label: 'This is a checkbox collection', help: 'With a help!')
   end
 
   test 'collection_check_boxes renders multiple checkboxes correctly' do
     collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
-    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><div class="checkbox"><label for="user_misc"><input id="user_misc_1" name="user[misc][]" type="checkbox" value="1" /> Foo</label></div><div class="checkbox"><label for="user_misc"><input id="user_misc_2" name="user[misc][]" type="checkbox" value="2" /> Bar</label></div></div>}
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><div class="checkbox"><label for="user_misc_1"><input id="user_misc_1" name="user[misc][]" type="checkbox" value="1" /> Foo</label></div><div class="checkbox"><label for="user_misc_2"><input id="user_misc_2" name="user[misc][]" type="checkbox" value="2" /> Bar</label></div></div>}
 
     assert_equal expected, @builder.collection_check_boxes(:misc, collection, :id, :street)
   end
 
   test 'collection_check_boxes renders inline checkboxes correctly' do
     collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
-    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><label class="checkbox-inline" for="user_misc"><input id="user_misc_1" name="user[misc][]" type="checkbox" value="1" /> Foo</label><label class="checkbox-inline" for="user_misc"><input id="user_misc_2" name="user[misc][]" type="checkbox" value="2" /> Bar</label></div>}
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><label class="checkbox-inline" for="user_misc_1"><input id="user_misc_1" name="user[misc][]" type="checkbox" value="1" /> Foo</label><label class="checkbox-inline" for="user_misc_2"><input id="user_misc_2" name="user[misc][]" type="checkbox" value="2" /> Bar</label></div>}
 
     assert_equal expected, @builder.collection_check_boxes(:misc, collection, :id, :street, inline: true)
   end
 
   test 'collection_check_boxes renders with checked option correctly' do
     collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
-    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><div class="checkbox"><label for="user_misc"><input checked="checked" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" /> Foo</label></div><div class="checkbox"><label for="user_misc"><input id="user_misc_2" name="user[misc][]" type="checkbox" value="2" /> Bar</label></div></div>}
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><div class="checkbox"><label for="user_misc_1"><input checked="checked" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" /> Foo</label></div><div class="checkbox"><label for="user_misc_2"><input id="user_misc_2" name="user[misc][]" type="checkbox" value="2" /> Bar</label></div></div>}
 
     assert_equal expected, @builder.collection_check_boxes(:misc, collection, :id, :street, checked: 1)
   end


### PR DESCRIPTION
When creating a collection of checkboxes, the 'for' attribute on an individual checkbox's label wasn't matching the input's id.  This can create a situation where clicking on the matching label won't toggle the checkbox.  I think this change should fix the issue without affecting anything else collaterally, but let me know if anything looks fishy!
