### PR TITLE
`//= require rails_bootstrap_forms` is not needed if using bootstrap via CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Then require the CSS on your `application.css` file:
 
 `//= require rails_bootstrap_forms`
 
+**NOTICE** : This line is needed if you are using bootstrap via gem `twitter-bootstrap-rails`. Please do not add this line if using CDN or local copied bootstrap package.
+
 ## Usage
 
 To get started, just use the **Rails Bootstrap Forms** form helper. Here's an example:


### PR DESCRIPTION
I have got a file not found error while adding that line to css file, and I got the answer from [this post][http://stackoverflow.com/questions/22001680/trouble-using-bootstrap-form-gem-couldnt-find-file-rails-bootstrap-forms-er]. I think pointing this out can save some time for others.
