### PR TITLE
Removed "for" attribute on the label surrounding a radio button

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -90,7 +90,7 @@ module BootstrapForm
 
       css = "radio"
       css << "-inline" if options[:inline]
-      label("#{name}_#{value}", html, class: css)
+      label(name, html, class: css, for: nil)
     end
 
     def collection_check_boxes(*args)

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -318,12 +318,12 @@ class BootstrapFormTest < ActionView::TestCase
   end
 
   test "radio_button is wrapped correctly" do
-    expected = %{<label class="radio" for="user_misc_1"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> This is a radio button</label>}
+    expected = %{<label class="radio"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> This is a radio button</label>}
     assert_equal expected, @builder.radio_button(:misc, '1', label: 'This is a radio button')
   end
 
   test "radio_button inline label is set correctly" do
-    expected = %{<label class="radio-inline" for="user_misc_1"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> This is a radio button</label>}
+    expected = %{<label class="radio-inline"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> This is a radio button</label>}
     assert_equal expected, @builder.radio_button(:misc, '1', label: 'This is a radio button', inline: true)
   end
 
@@ -562,28 +562,28 @@ class BootstrapFormTest < ActionView::TestCase
 
   test 'collection_radio_buttons renders the form_group correctly' do
     collection = [Address.new(id: 1, street: 'Foobar')]
-    expected = %{<div class="form-group"><label class="control-label" for="user_misc">This is a radio button collection</label><label class="radio" for="user_misc_1"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> Foobar</label><span class="help-block">With a help!</span></div>}
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">This is a radio button collection</label><label class="radio"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> Foobar</label><span class="help-block">With a help!</span></div>}
 
     assert_equal expected, @builder.collection_radio_buttons(:misc, collection, :id, :street, label: 'This is a radio button collection', help: 'With a help!')
   end
 
   test 'collection_radio_buttons renders multiple radios correctly' do
     collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
-    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><label class="radio" for="user_misc_1"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> Foo</label><label class="radio" for="user_misc_2"><input id="user_misc_2" name="user[misc]" type="radio" value="2" /> Bar</label></div>}
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><label class="radio"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> Foo</label><label class="radio"><input id="user_misc_2" name="user[misc]" type="radio" value="2" /> Bar</label></div>}
 
     assert_equal expected, @builder.collection_radio_buttons(:misc, collection, :id, :street)
   end
 
   test 'collection_radio_buttons renders inline radios correctly' do
     collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
-    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><label class="radio-inline" for="user_misc_1"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> Foo</label><label class="radio-inline" for="user_misc_2"><input id="user_misc_2" name="user[misc]" type="radio" value="2" /> Bar</label></div>}
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><label class="radio-inline"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> Foo</label><label class="radio-inline"><input id="user_misc_2" name="user[misc]" type="radio" value="2" /> Bar</label></div>}
 
     assert_equal expected, @builder.collection_radio_buttons(:misc, collection, :id, :street, inline: true)
   end
 
   test 'collection_radio_buttons renders with checked option correctly' do
     collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
-    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><label class="radio" for="user_misc_1"><input checked="checked" id="user_misc_1" name="user[misc]" type="radio" value="1" /> Foo</label><label class="radio" for="user_misc_2"><input id="user_misc_2" name="user[misc]" type="radio" value="2" /> Bar</label></div>}
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><label class="radio"><input checked="checked" id="user_misc_1" name="user[misc]" type="radio" value="1" /> Foo</label><label class="radio"><input id="user_misc_2" name="user[misc]" type="radio" value="2" /> Bar</label></div>}
 
     assert_equal expected, @builder.collection_radio_buttons(:misc, collection, :id, :street, checked: 1)
   end


### PR DESCRIPTION
The "for" attribute is invalid when the value is for example "0.1". This attribute is actually not needed because the label surrounds the input. So I removed it.

It should probably be done on check boxes too.
