### PR TITLE
fixed generated radio_button html

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -92,9 +92,13 @@ module BootstrapForm
 
       html = super(name, value, *args) + " " + options[:label]
 
-      css = "radio"
-      css << "-inline" if options[:inline]
-      label(name, html, class: css, for: nil)
+      if options[:inline]
+        label(name, html, class: "radio-inline", value: value)
+      else
+        content_tag(:div, class: "radio") do
+          label(name, html, value: value)
+        end
+      end
     end
 
     def collection_check_boxes(*args)

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -328,12 +328,12 @@ class BootstrapFormTest < ActionView::TestCase
   end
 
   test "radio_button is wrapped correctly" do
-    expected = %{<label class="radio"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> This is a radio button</label>}
+    expected = %{<div class="radio"><label for="user_misc_1"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> This is a radio button</label></div>}
     assert_equal expected, @builder.radio_button(:misc, '1', label: 'This is a radio button')
   end
 
   test "radio_button inline label is set correctly" do
-    expected = %{<label class="radio-inline"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> This is a radio button</label>}
+    expected = %{<label class="radio-inline" for="user_misc_1"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> This is a radio button</label>}
     assert_equal expected, @builder.radio_button(:misc, '1', label: 'This is a radio button', inline: true)
   end
 
@@ -427,7 +427,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = %{<div class="form-group foo"><label class="control-label col-sm-2"></label><div class="col-sm-10"><p class="form-control-static">Bar</p></div></div>}
     assert_equal expected, output
   end
-  
+
   test "form_group accepts class thorugh options hash without needing a name" do
     output = @horizontal_builder.form_group class: "foo" do
       %{<p class="form-control-static">Bar</p>}.html_safe
@@ -590,28 +590,28 @@ class BootstrapFormTest < ActionView::TestCase
 
   test 'collection_radio_buttons renders the form_group correctly' do
     collection = [Address.new(id: 1, street: 'Foobar')]
-    expected = %{<div class="form-group"><label class="control-label" for="user_misc">This is a radio button collection</label><label class="radio"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> Foobar</label><span class="help-block">With a help!</span></div>}
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">This is a radio button collection</label><div class="radio"><label for="user_misc_1"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> Foobar</label></div><span class="help-block">With a help!</span></div>}
 
     assert_equal expected, @builder.collection_radio_buttons(:misc, collection, :id, :street, label: 'This is a radio button collection', help: 'With a help!')
   end
 
   test 'collection_radio_buttons renders multiple radios correctly' do
     collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
-    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><label class="radio"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> Foo</label><label class="radio"><input id="user_misc_2" name="user[misc]" type="radio" value="2" /> Bar</label></div>}
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><div class="radio"><label for="user_misc_1"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> Foo</label></div><div class="radio"><label for="user_misc_2"><input id="user_misc_2" name="user[misc]" type="radio" value="2" /> Bar</label></div></div>}
 
     assert_equal expected, @builder.collection_radio_buttons(:misc, collection, :id, :street)
   end
 
   test 'collection_radio_buttons renders inline radios correctly' do
     collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
-    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><label class="radio-inline"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> Foo</label><label class="radio-inline"><input id="user_misc_2" name="user[misc]" type="radio" value="2" /> Bar</label></div>}
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><label class="radio-inline" for="user_misc_1"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> Foo</label><label class="radio-inline" for="user_misc_2"><input id="user_misc_2" name="user[misc]" type="radio" value="2" /> Bar</label></div>}
 
     assert_equal expected, @builder.collection_radio_buttons(:misc, collection, :id, :street, inline: true)
   end
 
   test 'collection_radio_buttons renders with checked option correctly' do
     collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
-    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><label class="radio"><input checked="checked" id="user_misc_1" name="user[misc]" type="radio" value="1" /> Foo</label><label class="radio"><input id="user_misc_2" name="user[misc]" type="radio" value="2" /> Bar</label></div>}
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><div class="radio"><label for="user_misc_1"><input checked="checked" id="user_misc_1" name="user[misc]" type="radio" value="1" /> Foo</label></div><div class="radio"><label for="user_misc_2"><input id="user_misc_2" name="user[misc]" type="radio" value="2" /> Bar</label></div></div>}
 
     assert_equal expected, @builder.collection_radio_buttons(:misc, collection, :id, :street, checked: 1)
   end


### PR DESCRIPTION
Hello guys,

Currently wrong markup is generated when using the radio_button helper.

This is the fix for https://github.com/bootstrap-ruby/rails-bootstrap-forms/issues/88

I ran into the same problem so I just quickly fixed it myself.
