### PR TITLE
It's possible to hide the attribute name in the errors_on field with the option 'hide_attribute_name: true'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,3 +59,4 @@ Features:
   - Added errors_on helper (@baldwindavid)
   - Added per field layout option (@baldwindavid)
   - Added support for bootstrap_form_tag (@baldwindavid)
+  - Added support for hidding attribute name in errors_on helper (@datWav)

--- a/README.md
+++ b/README.md
@@ -387,6 +387,18 @@ classes.
 <div class="alert alert-danger">Tasks must be added (at least one).</div>
 ```
 
+Sometimes you need only the error message and you want to hide the attribute name.
+
+```erb
+<%= f.errors_on :check_point, hide_attribute_name: true %>
+```
+
+This will be produce the following output.
+
+```html
+<div class="alert alert-danger">Error message</div>
+```
+
 ### Internationalization
 
 bootstrap_form follows standard rails conventions so it's i18n-ready. See more

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -30,10 +30,16 @@ module BootstrapForm
         end
       end
 
-      def errors_on(name)
+      def errors_on(name, options = {})
         if has_error?(name)
+          hide_attribute_name = options[:hide_attribute_name] || false
+
           content_tag :div, class: "alert alert-danger" do
-            object.errors.full_messages_for(name).join(", ")
+            if hide_attribute_name
+              object.errors[name].join(", ")
+            else
+              object.errors.full_messages_for(name).join(", ")
+            end
           end
         end
       end

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -663,4 +663,12 @@ class BootstrapFormTest < ActionView::TestCase
     assert_equal expected, @builder.collection_check_boxes(:misc, collection, :id, :street, checked: 1)
   end
 
+  test 'errors_on hide attribute name in message' do
+    @user.email = nil
+    @user.valid?
+
+    expected = %{<div class="alert alert-danger">can&#39;t be blank, is too short (minimum is 5 characters)</div>}
+
+    assert_equal expected, @builder.errors_on(:email, hide_attribute_name: true)
+  end
 end


### PR DESCRIPTION
It's possible to hide the attribute name in the errors_on field with the option 'hide_attribute: true'
