### PR TITLE
Don't throw undefined method when form_group content block returns nil

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -138,11 +138,15 @@ module BootstrapForm
       options[:class] << " #{error_class}" if has_error?(name)
 
       content_tag(:div, options.except(:id, :label, :help, :label_col, :control_col, :layout)) do
-        label = generate_label(options[:id], name, options[:label], options[:label_col], options[:layout])
-        control_and_help = capture(&block).concat(generate_help(name, options[:help]))
+        label   = generate_label(options[:id], name, options[:label], options[:label_col], options[:layout])
+        control = capture(&block).to_s
+        help    = generate_help(name, options[:help]).to_s
+        control_and_help = control.concat(help)
+
         if get_group_layout(options[:layout]) == :horizontal
           control_and_help = content_tag(:div, control_and_help, class: (options[:control_col] || control_col))
         end
+
         concat(label).concat(control_and_help)
       end
     end

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -671,4 +671,14 @@ class BootstrapFormTest < ActionView::TestCase
 
     assert_equal expected, @builder.errors_on(:email, hide_attribute_name: true)
   end
+
+  test "doesn't throw undefined method error when the content block returns nil" do
+    output = @builder.form_group :nil, label: { text: 'Foo' } do
+      nil
+    end
+
+    expected = %{<div class="form-group"><label class="control-label" for="user_nil">Foo</label></div>}
+    assert_equal expected, output
+  end
+
 end


### PR DESCRIPTION
Fixes #111
