### PR TITLE
Support showing error summaries when inline_errors is enabled

### DIFF
--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -17,7 +17,7 @@ module BootstrapForm
         if object.respond_to?(:errors) && object.errors.full_messages.any?
           content_tag :div, class: css do
             concat content_tag :p, title
-            concat error_summary unless inline_errors || options[:error_summary] == false
+            concat error_summary unless options[:error_summary] == false
           end
         end
       end

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -47,14 +47,14 @@ class BootstrapFormTest < ActionView::TestCase
   test "alert message is wrapped correctly" do
     @user.email = nil
     @user.valid?
-    expected = %{<div class="alert alert-danger"><p>Please fix the following errors:</p></div>}
+    expected = %{<div class="alert alert-danger"><p>Please fix the following errors:</p><ul class="rails-bootstrap-forms-error-summary"><li>Email can&#39;t be blank</li><li>Email is too short (minimum is 5 characters)</li><li>Terms must be accepted</li></ul></div>}
     assert_equal expected, @builder.alert_message('Please fix the following errors:')
   end
 
   test "changing the class name for the alert message" do
     @user.email = nil
     @user.valid?
-    expected = %{<div class="my-css-class"><p>Please fix the following errors:</p></div>}
+    expected = %{<div class="my-css-class"><p>Please fix the following errors:</p><ul class="rails-bootstrap-forms-error-summary"><li>Email can&#39;t be blank</li><li>Email is too short (minimum is 5 characters)</li><li>Terms must be accepted</li></ul></div>}
     assert_equal expected, @builder.alert_message('Please fix the following errors:', class: 'my-css-class')
   end
 
@@ -79,6 +79,18 @@ class BootstrapFormTest < ActionView::TestCase
     end
 
     expected = %{<form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div><div class="alert alert-danger"><p>Please fix the following errors:</p></div></form>}
+    assert_equal expected, output
+  end
+
+  test "alert_message allows the error_summary to be turned on with inline_errors also turned on" do
+    @user.email = nil
+    @user.valid?
+
+    output = bootstrap_form_for(@user, inline_errors: true) do |f|
+      f.alert_message('Please fix the following errors:', error_summary: true)
+    end
+
+    expected = %{<form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div><div class="alert alert-danger"><p>Please fix the following errors:</p><ul class="rails-bootstrap-forms-error-summary"><li>Email can&#39;t be blank</li><li>Email is too short (minimum is 5 characters)</li><li>Terms must be accepted</li></ul></div></form>}
     assert_equal expected, output
   end
 


### PR DESCRIPTION
Is there a reason why we can't display an alert_message error summary when also using inline_errors?

This commit is backwards compatible, but means if error_summary is explicitly set to true, then the error summary will display, regardless of inline_errors also being enabled.
