### PR TITLE
fix using check_box with bootstrap_form_tag

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -78,7 +78,7 @@ module BootstrapForm
 
       html = super(name, options.except(:label, :help, :inline), checked_value, unchecked_value)
       label_content = block_given? ? capture(&block) : options[:label]
-      html.concat(" ").concat(label_content || object.class.human_attribute_name(name) || name.to_s.humanize)
+      html.concat(" ").concat(label_content || (object && object.class.human_attribute_name(name)) || name.to_s.humanize)
 
       label_name = name
       label_name = "#{name}_#{checked_value}" if options[:multiple]


### PR DESCRIPTION
check_box and bootstrap_form_tag do not work together. this will fix it so it doesn't try to make the label object.class.human_attribute_name(name) where object.class is NilClass since there is no object in bootstrap_form_tag. Instead it will use name.to_s.humanize
