### PR TITLE
#generate_help for I18n convention support

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -252,10 +252,10 @@ module BootstrapForm
 
     def generate_help(name, help_text)
       help_text = object.errors[name].join(", ") if has_error?(name) && inline_errors
-      if help_text
-        help_text = I18n.t(name, scope: "activerecord.help.#{object.class.to_s.downcase}") if help_text === true
-        content_tag(:span, help_text, class: "help-block")
-      end
+      return if help_text === false
+
+      help_text ||= I18n.t(name, scope: "activerecord.help.#{object.class.to_s.downcase}", default: '')
+      content_tag(:span, help_text, class: 'help-block') if help_text.present?
     end
 
     def inputs_collection(name, collection, value, text, options = {}, &block)

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -7,6 +7,7 @@ class BootstrapFormTest < ActionView::TestCase
     @user = User.new(email: 'steve@example.com', password: 'secret', comments: 'my comment')
     @builder = BootstrapForm::FormBuilder.new(:user, @user, self, {})
     @horizontal_builder = BootstrapForm::FormBuilder.new(:user, @user, self, { layout: :horizontal, label_col: "col-sm-2", control_col: "col-sm-10" })
+    I18n.backend.store_translations(:en, {activerecord: {help: {user: {password: "A good password should have at least six characters long"}}}})
   end
 
   test "default-style forms" do
@@ -156,7 +157,7 @@ class BootstrapFormTest < ActionView::TestCase
   end
 
   test "password fields are wrapped correctly" do
-    expected = %{<div class="form-group"><label class="control-label" for="user_password">Password</label><input class="form-control" id="user_password" name="user[password]" type="password" /></div>}
+    expected = %{<div class="form-group"><label class="control-label" for="user_password">Password</label><input class="form-control" id="user_password" name="user[password]" type="password" /><span class="help-block">A good password should have at least six characters long</span></div>}
     assert_equal expected, @builder.password_field(:password)
   end
 
@@ -408,10 +409,14 @@ class BootstrapFormTest < ActionView::TestCase
     assert_equal expected, @horizontal_builder.text_field(:email, help: "This is required")
   end
 
-  test "help messges for form when help is true" do
-    I18n.backend.store_translations(:en, {activerecord: {help: {user: {email: "An awesome hint"}}}})
-    expected = %{<div class="form-group"><label class="control-label" for="user_email">Email</label><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /><span class="help-block">An awesome hint</span></div>}
-    assert_equal expected, @builder.text_field(:email, help: true)
+  test "help messages to look up I18n automatically" do
+    expected = %{<div class="form-group"><label class="control-label" for="user_password">Password</label><input class="form-control" id="user_password" name="user[password]" type="text" value="secret" /><span class="help-block">A good password should have at least six characters long</span></div>}
+    assert_equal expected, @builder.text_field(:password)
+  end
+
+  test "help messages to ignore translation when user disables help" do
+    expected = %{<div class="form-group"><label class="control-label" for="user_password">Password</label><input class="form-control" id="user_password" name="user[password]" type="text" value="secret" /></div>}
+    assert_equal expected, @builder.text_field(:password, help: false)
   end
 
   test "custom label width for horizontal forms" do


### PR DESCRIPTION
Hi, thanks for this awesome gem. I have added the `generate_help` I18n translation support when user pass in `help: true` :coffee: 
