### PR TITLE
Keep original methods with _without_bootstrap suffix

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -26,57 +26,77 @@ module BootstrapForm
     end
 
     FIELD_HELPERS.each do |method_name|
-      define_method(method_name) do |name, options = {}|
+      with_method_name = "#{method_name}_with_bootstrap"
+      without_method_name = "#{method_name}_without_bootstrap"
+
+      define_method(with_method_name) do |name, options = {}|
         form_group_builder(name, options) do
           prepend_and_append_input(options) do
-            super(name, options)
+            send(without_method_name, name, options)
           end
         end
       end
+
+      alias_method_chain method_name, :bootstrap
     end
 
     DATE_SELECT_HELPERS.each do |method_name|
-      define_method(method_name) do |name, options = {}, html_options = {}|
+      with_method_name = "#{method_name}_with_bootstrap"
+      without_method_name = "#{method_name}_without_bootstrap"
+
+      define_method(with_method_name) do |name, options = {}, html_options = {}|
         form_group_builder(name, options, html_options) do
-          content_tag(:div, super(name, options, html_options), class: control_specific_class(method_name))
+          content_tag(:div, send(without_method_name, name, options, html_options), class: control_specific_class(method_name))
         end
       end
+
+      alias_method_chain method_name, :bootstrap
     end
 
-    def file_field(name, options = {})
+    def file_field_with_bootstrap(name, options = {})
       form_group_builder(name, options.reverse_merge(control_class: nil)) do
-        super(name, options)
+        file_field_without_bootstrap(name, options)
       end
     end
 
-    def select(method, choices, options = {}, html_options = {})
+    alias_method_chain :file_field, :bootstrap
+
+    def select_with_bootstrap(method, choices, options = {}, html_options = {})
       form_group_builder(method, options, html_options) do
-        super(method, choices, options, html_options)
+        select_without_bootstrap(method, choices, options, html_options)
       end
     end
 
-    def collection_select(method, collection, value_method, text_method, options = {}, html_options = {})
+    alias_method_chain :select, :bootstrap
+
+    def collection_select_with_bootstrap(method, collection, value_method, text_method, options = {}, html_options = {})
       form_group_builder(method, options, html_options) do
-        super(method, collection, value_method, text_method, options, html_options)
+        collection_select_without_bootstrap(method, collection, value_method, text_method, options, html_options)
       end
     end
 
-    def grouped_collection_select(method, collection, group_method, group_label_method, option_key_method, option_value_method, options = {}, html_options = {})
+    alias_method_chain :collection_select, :bootstrap
+
+    def grouped_collection_select_with_bootstrap(method, collection, group_method, group_label_method, option_key_method, option_value_method, options = {}, html_options = {})
       form_group_builder(method, options, html_options) do
-        super(method, collection, group_method, group_label_method, option_key_method, option_value_method, options, html_options)
+        grouped_collection_select_without_bootstrap(method, collection, group_method, group_label_method, option_key_method, option_value_method, options, html_options)
       end
     end
 
-    def time_zone_select(method, priority_zones = nil, options = {}, html_options = {})
+    alias_method_chain :grouped_collection_select, :bootstrap
+
+    def time_zone_select_with_bootstrap(method, priority_zones = nil, options = {}, html_options = {})
       form_group_builder(method, options, html_options) do
-        super(method, priority_zones, options, html_options)
+        time_zone_select_without_bootstrap(method, priority_zones, options, html_options)
       end
     end
 
-    def check_box(name, options = {}, checked_value = "1", unchecked_value = "0", &block)
+    alias_method_chain :time_zone_select, :bootstrap
+
+    def check_box_with_bootstrap(name, options = {}, checked_value = "1", unchecked_value = "0", &block)
       options = options.symbolize_keys!
 
-      html = super(name, options.except(:label, :help, :inline), checked_value, unchecked_value)
+      html = check_box_without_bootstrap(name, options.except(:label, :help, :inline), checked_value, unchecked_value)
       label_content = block_given? ? capture(&block) : options[:label]
       html.concat(" ").concat(label_content || (object && object.class.human_attribute_name(name)) || name.to_s.humanize)
 
@@ -92,11 +112,13 @@ module BootstrapForm
       end
     end
 
-    def radio_button(name, value, *args)
+    alias_method_chain :check_box, :bootstrap
+
+    def radio_button_with_bootstrap(name, value, *args)
       options = args.extract_options!.symbolize_keys!
       args << options.except(:label, :help, :inline)
 
-      html = super(name, value, *args) + " " + options[:label]
+      html = radio_button_without_bootstrap(name, value, *args) + " " + options[:label]
 
       if options[:inline]
         label(name, html, class: "radio-inline", value: value)
@@ -106,6 +128,8 @@ module BootstrapForm
         end
       end
     end
+
+    alias_method_chain :radio_button, :bootstrap
 
     def collection_check_boxes(*args)
       inputs_collection(*args) do |name, value, options|
@@ -157,13 +181,15 @@ module BootstrapForm
       end
     end
 
-    def fields_for(record_name, record_object = nil, fields_options = {}, &block)
+    def fields_for_with_bootstrap(record_name, record_object = nil, fields_options = {}, &block)
       fields_options, record_object = record_object, nil if record_object.is_a?(Hash) && record_object.extractable_options?
       fields_options[:layout] ||= options[:layout]
       fields_options[:label_col] = fields_options[:label_col].present? ? "#{fields_options[:label_col]} #{label_class}" : options[:label_col]
       fields_options[:control_col] ||= options[:control_col]
-      super(record_name, record_object, fields_options, &block)
+      fields_for_without_bootstrap(record_name, record_object, fields_options, &block)
     end
+
+    alias_method_chain :fields_for, :bootstrap
 
     private
 


### PR DESCRIPTION
I've added alias_method_chains to keep original methods with `_without_bootstrap` suffix.
This enables us to build own forms within `bootstrap_form_for`.
