### PR TITLE
Fixes an offset bug in form_group without a given label in horizontal layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Bugfixes:
   - Fixed an exception raised when form_group block returns nil (#111)
   - Fixed an exception on human_attribute_name when using bootstrap_form_tag (#115)
   - Set offset in form_group without label in horizontal layout (#94, @datWav)
+  - Fixes an offset bug in form_group without a given label in horizontal layout (#130, @datWav)
 
 Features:
 

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -169,7 +169,7 @@ module BootstrapForm
         control.concat(generate_icon(options[:icon])) if options[:icon]
 
         if get_group_layout(options[:layout]) == :horizontal
-          control_class = (options[:control_col] || control_col)
+          control_class = (options[:control_col] || control_col.clone)
 
           unless options[:label]
             control_offset = offset_col(/([0-9]+)$/.match(options[:label_col] || default_label_col))

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -774,4 +774,16 @@ class BootstrapFormTest < ActionView::TestCase
     expected = %{<div class="form-group has-feedback"><label class="control-label" for="user_misc">Misc</label><input class="form-control" id="user_misc" name="user[misc]" type="email" /><span class="glyphicon glyphicon-ok form-control-feedback"></span></div>}
     assert_equal expected, @builder.email_field(:misc, icon: 'ok')
   end
+
+  test "single form_group call in horizontal form should not be smash design" do
+    output = ''
+    output = @horizontal_builder.form_group do
+      "Hallo"
+    end
+
+    output = output + @horizontal_builder.text_field(:email)
+
+    expected = %{<div class="form-group"><div class="col-sm-10 col-sm-offset-2">Hallo</div></div><div class="form-group"><label class="control-label col-sm-2" for="user_email">Email</label><div class="col-sm-10"><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /></div></div>}
+    assert_equal expected, output
+  end
 end


### PR DESCRIPTION
Fixes an offset bug(#130) in form_group without a given label in horizontal layout 
