### PR TITLE
Allow to skip label rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This gem wraps the following Rails form helpers:
 * time_zone_select
 * url_field
 * week_field
- 
+
 These helpers accept the same options as the standard Rails form helpers, with
 a few extra options:
 
@@ -358,6 +358,12 @@ using screen readers.
   <%= f.check_box :remember_me %>
   <%= f.submit %>
 <% end %>
+```
+
+To skip label rendering at all, use `skip_label: true` option.
+
+```erb
+<%= f.password_field :password, skip_label: true %>
 ```
 
 ### Horizontal Forms

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -272,10 +272,6 @@ module BootstrapForm
       layout = get_group_layout(options.delete(:layout))
       form_group_options = {
         id: options[:id],
-        label: {
-          text: label,
-          class: label_class
-        },
         help: help,
         icon: icon,
         label_col: label_col,
@@ -286,6 +282,13 @@ module BootstrapForm
 
       if wrapper_options.is_a?(Hash)
         form_group_options.reverse_merge!(wrapper_options)
+      end
+
+      unless options.delete(:skip_label)
+        form_group_options.reverse_merge!(label: {
+          text: label,
+          class: label_class
+        })
       end
 
       form_group(method, form_group_options) do

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -17,6 +17,11 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equal expected, @builder.text_field(:email, hide_label: true)
   end
 
+  test "skipping a label" do
+    expected = %{<div class="form-group"><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /></div>}
+    assert_equal expected, @builder.text_field(:email, skip_label: true)
+  end
+
   test "adding prepend text" do
     expected = %{<div class="form-group"><label class="control-label" for="user_email">Email</label><div class="input-group"><span class="input-group-addon">@</span><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /></div></div>}
     assert_equal expected, @builder.text_field(:email, prepend: '@')


### PR DESCRIPTION
Sometimes `hide_label: true` is not enough, as it still renders useless markup.
