### PR TITLE
Builder option 'force_help_block' to forcefully render help-block of inline-errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ test/dummy/tmp/
 *.gem
 .rbenv-gemsets
 *.swp
-.project

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test/dummy/tmp/
 *.gem
 .rbenv-gemsets
 *.swp
+.project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Features:
   - Use humanized attribute name in label errors (#146, @atipugin)
   - Allow to skip label rendering (#145, @atipugin)
   - Added a `required` CSS class for labels with required attributes (#150, @krsyoung)
+  - Allow users to forcefully render the help-block used for inline-errors, so it could be populated after a remote form submit
 
 ## 2.2.0 (2014-09-16)
 

--- a/README.md
+++ b/README.md
@@ -456,6 +456,27 @@ You can turn off inline errors for the entire form like this:
 <% end %>
 ```
 
+#### Forcefully render help-block of inline-errors
+
+If you intend to populate the help-block upon submit of a remote form (AJAX submit of a form) you could use the option `force_help_block`
+
+```erb
+<%= bootstrap_form_for(@user, force_help_block: true) do |f| %>
+  ...
+<% end %>
+```
+
+This will force the builder to render the help-block regardless if there is a help text or not for that input :
+
+```html
+<div class="form-group has-error">
+  <label class="control-label" for="user_email">Email</label>
+  <input class="form-control" id="user_email" name="user[email]" type="email" value="">
+  <span class="help-block"></span>
+</div>
+```
+Thus you can populate the help-block upon feedback on the form submit.
+
 ### Label Errors (Master-branch only)
 
 You can also display validation errors in the field's label; just turn

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -4,7 +4,7 @@ module BootstrapForm
   class FormBuilder < ActionView::Helpers::FormBuilder
     include BootstrapForm::Helpers::Bootstrap
 
-    attr_reader :layout, :label_col, :control_col, :has_error, :inline_errors, :label_errors, :acts_like_form_tag
+    attr_reader :layout, :label_col, :control_col, :has_error, :inline_errors, :label_errors, :force_help_block, :acts_like_form_tag
 
     FIELD_HELPERS = %w{color_field date_field datetime_field datetime_local_field
       email_field month_field number_field password_field phone_field
@@ -25,6 +25,7 @@ module BootstrapForm
       else
         options[:inline_errors] != false
       end
+      @force_help_block = options[:force_help_block] || false
       @acts_like_form_tag = options[:acts_like_form_tag]
 
       super
@@ -198,6 +199,7 @@ module BootstrapForm
       fields_options[:control_col] ||= options[:control_col]
       fields_options[:inline_errors] ||= options[:inline_errors]
       fields_options[:label_errors] ||= options[:label_errors]
+      fields_options[:force_help_block] ||= options[:force_help_block]
       fields_for_without_bootstrap(record_name, record_object, fields_options, &block)
     end
 
@@ -337,11 +339,13 @@ module BootstrapForm
 
     def generate_help(name, help_text)
       help_text = object.errors[name].join(", ") if has_error?(name) && inline_errors
-      return if help_text === false
-
-      help_text ||= get_help_text_by_i18n_key(name)
-
-      content_tag(:span, help_text, class: 'help-block') if help_text.present?
+      if help_text === false
+        return unless force_help_block
+        content_tag(:span, '', class: 'help-block')
+      else
+        help_text ||= get_help_text_by_i18n_key(name)
+        content_tag(:span, help_text, class: 'help-block') if help_text.present? || force_help_block
+      end
     end
 
     def generate_icon(icon)

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -89,6 +89,16 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equal expected, @builder.text_field(:password, help: false)
   end
 
+  test "help-block rendered empty although no help to be shown with a builder that has the force_help_block option" do
+    expected = %{<div class="form-group"><label class="control-label required" for="user_email">Email</label><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /><span class="help-block"></span></div>}
+    assert_equal expected, @force_help_builder.text_field(:email)
+  end
+
+  test "help-block rendered normal when help present and force_help_block option of builder is true" do
+    expected = %{<div class="form-group"><label class="control-label required" for="user_email">Email</label><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /><span class="help-block">This is required</span></div>}
+    assert_equal expected, @force_help_builder.text_field(:email, help: 'This is required')
+  end
+
   test "form_group creates a valid structure and allows arbitrary html to be added via a block" do
     output = @horizontal_builder.form_group :nil, label: { text: 'Foo' } do
       %{<p class="form-control-static">Bar</p>}.html_safe

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -90,11 +90,13 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "help-block rendered empty although no help to be shown with a builder that has the force_help_block option" do
+    setup_force_help_builder
     expected = %{<div class="form-group"><label class="control-label required" for="user_email">Email</label><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /><span class="help-block"></span></div>}
     assert_equal expected, @force_help_builder.text_field(:email)
   end
 
   test "help-block rendered normal when help present and force_help_block option of builder is true" do
+    setup_force_help_builder
     expected = %{<div class="form-group"><label class="control-label required" for="user_email">Email</label><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /><span class="help-block">This is required</span></div>}
     assert_equal expected, @force_help_builder.text_field(:email, help: 'This is required')
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,6 +16,9 @@ def setup_test_fixture
   @user = User.new(email: 'steve@example.com', password: 'secret', comments: 'my comment')
   @builder = BootstrapForm::FormBuilder.new(:user, @user, self, {})
   @horizontal_builder = BootstrapForm::FormBuilder.new(:user, @user, self, { layout: :horizontal, label_col: "col-sm-2", control_col: "col-sm-10" })
-  @force_help_builder = BootstrapForm::FormBuilder.new(:user, @user, self, { force_help_block: true })
   I18n.backend.store_translations(:en, {activerecord: {help: {user: {password: "A good password should be at least six characters long"}}}})
+end
+
+def setup_force_help_builder
+  @force_help_builder = BootstrapForm::FormBuilder.new(:user, @user, self, { force_help_block: true })
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,5 +16,6 @@ def setup_test_fixture
   @user = User.new(email: 'steve@example.com', password: 'secret', comments: 'my comment')
   @builder = BootstrapForm::FormBuilder.new(:user, @user, self, {})
   @horizontal_builder = BootstrapForm::FormBuilder.new(:user, @user, self, { layout: :horizontal, label_col: "col-sm-2", control_col: "col-sm-10" })
+  @force_help_builder = BootstrapForm::FormBuilder.new(:user, @user, self, { force_help_block: true })
   I18n.backend.store_translations(:en, {activerecord: {help: {user: {password: "A good password should be at least six characters long"}}}})
 end


### PR DESCRIPTION
Hi maintainers,

I did a small addition to your gem.
As I am using it to generate a remote form I needed the help-block spans be forcefully rendered (not just upon precence of help messages) so I could populate them upon AJAX feedback on the submit.
-> I added a builder option to take care of this.

I did not create an issue for this as I was just playing around a little at first (to see if I could manage that)

Let me know if this of interest for you or if you would require some additions/changes before you could accept the pull request.

Greetz,
Florian
