### PR TITLE
Add appropriate input-group-lg or input-group-sm when appending a btn-lg...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Bugfixes:
 
   - Use #underscore, not #downcase for help text scope (#140, @atipugin)
   - Radio button and checkbox labels will now include the disabled class as needed. (#156, @ScottSwezey)
+  - Input groups will now have the appropriate `input-group-lg` or `input-group-sm` added when a `btn-lg` or `btn-sm` is appended. (#181, @raptblue)
 
 Features:
 

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -65,7 +65,7 @@ module BootstrapForm
 
         input = content_tag(:span, options[:prepend], class: input_group_class(options[:prepend])) + input if options[:prepend]
         input << content_tag(:span, options[:append], class: input_group_class(options[:append])) if options[:append]
-        input = content_tag(:div, input, class: "input-group") unless options.empty?
+        input = content_tag(:div, input, class: input_group_wrapper_class([options[:prepend], options[:append]])) unless options.empty?
         input
       end
 
@@ -75,6 +75,21 @@ module BootstrapForm
         else
           'input-group-addon'
         end
+      end
+
+      def input_group_wrapper_class(add_on_content)
+        input_group_class = 'input-group'
+
+        add_on_content.each do |add_on|
+          unless add_on.nil?
+            if add_on.match /btn-lg/
+              input_group_class << ' input-group-lg' unless input_group_class.match /input-group-lg/
+            elsif add_on.match /btn-sm/
+              input_group_class << ' input-group-sm' unless input_group_class.match /input-group-sm/
+            end
+          end
+        end
+        input_group_class
       end
 
       def static_class

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -51,6 +51,34 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equal both_button, @builder.text_field(:email, append: button_src, prepend: button_src)
   end
 
+  test "append and prepend large button" do
+    prefix = %{<div class="form-group"><label class="control-label required" for="user_email">Email</label><div class="input-group input-group-lg">}
+    field = %{<input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />}
+    button = %{<span class="input-group-btn"><a class="btn btn-lg btn-default" href="#">Click</a></span>}
+    suffix = %{</div></div>}
+    after_button = prefix + field + button + suffix
+    before_button = prefix + button + field + suffix
+    both_button = prefix + button + field + button  + suffix
+    button_src = link_to("Click", "#", class: "btn btn-lg btn-default")
+    assert_equal after_button, @builder.text_field(:email, append: button_src)
+    assert_equal before_button, @builder.text_field(:email, prepend: button_src)
+    assert_equal both_button, @builder.text_field(:email, append: button_src, prepend: button_src)
+  end
+
+  test "append and prepend small button" do
+    prefix = %{<div class="form-group"><label class="control-label required" for="user_email">Email</label><div class="input-group input-group-sm">}
+    field = %{<input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />}
+    button = %{<span class="input-group-btn"><a class="btn btn-sm btn-default" href="#">Click</a></span>}
+    suffix = %{</div></div>}
+    after_button = prefix + field + button + suffix
+    before_button = prefix + button + field + suffix
+    both_button = prefix + button + field + button  + suffix
+    button_src = link_to("Click", "#", class: "btn btn-sm btn-default")
+    assert_equal after_button, @builder.text_field(:email, append: button_src)
+    assert_equal before_button, @builder.text_field(:email, prepend: button_src)
+    assert_equal both_button, @builder.text_field(:email, append: button_src, prepend: button_src)
+  end
+
   test "adding both prepend and append text" do
     expected = %{<div class="form-group"><label class="control-label required" for="user_email">Email</label><div class="input-group"><span class="input-group-addon">$</span><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /><span class="input-group-addon">.00</span></div></div>}
     assert_equal expected, @builder.text_field(:email, prepend: '$', append: '.00')


### PR DESCRIPTION
... or btn-sm to an input (closes #181)
