### PR TITLE
Only wrap inputs in input-group when prepend or append is specified

### DIFF
--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -65,7 +65,7 @@ module BootstrapForm
 
         input = content_tag(:span, options[:prepend], class: input_group_class(options[:prepend])) + input if options[:prepend]
         input << content_tag(:span, options[:append], class: input_group_class(options[:append])) if options[:append]
-        input = content_tag(:div, input, class: "input-group") unless options.empty?
+        input = content_tag(:div, input, class: "input-group") if options[:append] || options[:prepend]
         input
       end
 


### PR DESCRIPTION
Options hash will always contain the prepend and append keys after extract! so will never be empty?

Without prepend and append the form input control has incorrect width (not 100% of container)
