### PR TITLE
Allow setting the wrapper id

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -181,7 +181,7 @@ module BootstrapForm
       options[:class] << " #{error_class}" if has_error?(name)
       options[:class] << " #{feedback_class}" if options[:icon]
 
-      content_tag(:div, options.except(:id, :label, :help, :icon, :label_col, :control_col, :layout)) do
+      content_tag(:div, options.except(:label, :help, :icon, :label_col, :control_col, :layout)) do
         label = generate_label(options[:id], name, options[:label], options[:label_col], options[:layout]) if options[:label]
         control = capture(&block).to_s
         control.concat(generate_help(name, options[:help]).to_s)

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -181,8 +181,11 @@ module BootstrapForm
       options[:class] << " #{error_class}" if has_error?(name)
       options[:class] << " #{feedback_class}" if options[:icon]
 
+      id = options[:id]
+      options[:id] = options.delete(:wrapper_id)
+
       content_tag(:div, options.except(:label, :help, :icon, :label_col, :control_col, :layout)) do
-        label = generate_label(options[:id], name, options[:label], options[:label_col], options[:layout]) if options[:label]
+        label = generate_label(id, name, options[:label], options[:label_col], options[:layout]) if options[:label]
         control = capture(&block).to_s
         control.concat(generate_help(name, options[:help]).to_s)
         control.concat(generate_icon(options[:icon])) if options[:icon]
@@ -314,6 +317,7 @@ module BootstrapForm
       }
 
       if wrapper_options.is_a?(Hash)
+        wrapper_options[:wrapper_id] = wrapper_options[:id] if wrapper_options.has_key?(:id)
         form_group_options.merge!(wrapper_options)
       end
 

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -98,6 +98,11 @@ class BootstrapFieldsTest < ActionView::TestCase
     assert_equal expected, @builder.week_field(:misc)
   end
 
+  test "text fields with wrapper params are wrapped correctly" do
+    expected = %{<div class="form-group email_class" id="email_wrapper"><label class="control-label required" for="user_email">Email</label><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /></div>}
+    assert_equal expected, @builder.text_field(:email, wrapper: { id: "email_wrapper", class: "email_class" } )
+  end
+
   test "bootstrap_form_for helper works for associations" do
     @user.address = Address.new(street: '123 Main Street')
 


### PR DESCRIPTION
This is so that when someone puts f.text_field :some_field, wrapper: {id: "something"} it works as one would expect. 
