### PR TITLE
Allow for Form Tag Helper Methods in Model-Backed Forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Bugfixes:
 Features:
 
   - Allow primary button classes to be overridden (#183, @tanimichi)
+  - Allow users to mix form tag helper methods into model-backed forms by passing in `tag: true` to form helper methods. (@vincedevendra)
 
 ## 2.3.0 (2015-02-17)
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ This gem wraps the following Rails form helpers:
 These helpers accept the same options as the standard Rails form helpers, with
 a few extra options:
 
+### Form Tag Helpers
+To mix form tag helper methods into model-backed forms, pass in `tag: true`.
+
+```erb
+<%= f.text_field :email, tag: true %>
+```
+
 ### Labels
 
 Use the `label` option if you want to specify the field's label text:
@@ -143,7 +150,7 @@ To add custom classes to the field's label:
 #### Required Fields
 
 A label that is associated with a required field is automatically annotated with
-a `required` CSS class. You are free to add any appropriate CSS to style 
+a `required` CSS class. You are free to add any appropriate CSS to style
 required fields as desired.  One example would be to automatically add an
 asterisk to the end of the label:
 

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -47,6 +47,18 @@ class BootstrapFormTest < ActionView::TestCase
     assert_equal expected, bootstrap_form_tag(url: '/users') { |f| f.check_box :misc }
   end
 
+  test "tag option emulates rails form tag helper methods" do
+    output = ""
+    bootstrap_form_for @user do |f|
+      output += f.text_field(:color, tag: true)
+      output += f.text_field(:status)
+    end
+
+    expected = %{<div class=\"form-group\"><label class=\"control-label\" for=\"color\">Color</label><input class=\"form-control\" id=\"color\" name=\"color\" type=\"text\" /></div><div class=\"form-group\"><label class=\"control-label\" for=\"user_status\">Status</label><input class=\"form-control\" id=\"user_status\" name=\"user[status]\" type=\"text\" /></div>}
+
+    assert_equal expected, output
+  end
+
   test "errors display correctly and inline_errors are turned off by default when label_errors is true" do
     @user.email = nil
     @user.valid?


### PR DESCRIPTION
Hello,

As I was using this excellent gem,  I found myself wanting to be able to mix form tag helpers into my model-backed forms.  In order to accomplish this, I check for the presence of a `tag` option, and if it's present, within `#form_group_options`, I temporarily set `@object` to `nil`, `@object_name` to an empty string, and `@acts_like_form_tag` to `true`.  The original values are passed into `#form_group` and set back to their original values before the next form helper method is called.  

Let me know what you think!

Thanks,
Vince
