### PR TITLE
Add default lookup in 'help' scope for help text I18n

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -413,7 +413,7 @@ module BootstrapForm
       downcased_scope = "activerecord.help.#{object.class.name.downcase}"
       help_text = underscored_scope_chain.map { |underscored_scope| I18n.t(name, scope: underscored_scope, default: '').presence }.compact.first
       help_text ||= if text = I18n.t(name, scope: downcased_scope, default: '').presence
-        warn "I18n key '#{downcased_scope}.#{name}' is deprecated, use '#{underscored_scope}.#{name}' instead"
+        warn "I18n key '#{downcased_scope}.#{name}' is deprecated, use '#{underscored_scope_chain.first}.#{name}' instead"
         text
       end
 

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -406,9 +406,12 @@ module BootstrapForm
     end
 
     def get_help_text_by_i18n_key(name)
-      underscored_scope = "activerecord.help.#{object.class.name.underscore}"
+      underscored_scope_chain = [
+        "activerecord.help.#{object.class.name.underscore}",
+        "help"
+      ]
       downcased_scope = "activerecord.help.#{object.class.name.downcase}"
-      help_text = I18n.t(name, scope: underscored_scope, default: '').presence
+      help_text = underscored_scope_chain.map { |underscored_scope| I18n.t(name, scope: underscored_scope, default: '').presence }.compact.first
       help_text ||= if text = I18n.t(name, scope: downcased_scope, default: '').presence
         warn "I18n key '#{downcased_scope}.#{name}' is deprecated, use '#{underscored_scope}.#{name}' instead"
         text

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -86,6 +86,11 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equal expected, @builder.text_field(:password)
   end
 
+  test "help messages to look up I18n automatically in the default scope" do
+    expected = %{<div class="form-group"><label class="control-label" for="user_common">Common</label><input class="form-control" id="user_common" name="user[common]" type="text" /><span class="help-block">Common has a common help text</span></div>}
+    assert_equal expected, @builder.text_field(:common)
+  end
+
   test "help messages to warn about deprecated I18n key" do
     super_user = SuperUser.new(@user.attributes)
     builder = BootstrapForm::FormBuilder.new(:super_user, super_user, self, {})

--- a/test/dummy/db/migrate/20151118013433_add_common_to_users.rb
+++ b/test/dummy/db/migrate/20151118013433_add_common_to_users.rb
@@ -1,0 +1,5 @@
+class AddCommonToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :common, :string
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140922133133) do
+ActiveRecord::Schema.define(version: 20151118013433) do
 
   create_table "addresses", force: true do |t|
     t.integer  "user_id"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20140922133133) do
     t.text     "preferences"
     t.boolean  "terms",       default: false
     t.string   "type"
+    t.string   "common"
   end
 
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,5 +16,8 @@ def setup_test_fixture
   @user = User.new(email: 'steve@example.com', password: 'secret', comments: 'my comment')
   @builder = BootstrapForm::FormBuilder.new(:user, @user, self, {})
   @horizontal_builder = BootstrapForm::FormBuilder.new(:user, @user, self, { layout: :horizontal, label_col: "col-sm-2", control_col: "col-sm-10" })
-  I18n.backend.store_translations(:en, {activerecord: {help: {user: {password: "A good password should be at least six characters long"}}}})
+  I18n.backend.store_translations(:en, {
+    activerecord: {help: {user: {password: "A good password should be at least six characters long"}}},
+    help: {common: "Common has a common help text"}
+  })
 end


### PR DESCRIPTION
Hello,
this PR adds a default lookup for help texts in the top level `:help` scope as Rails I18n also does for `human_attribute_name`, at least in version 4.
I find this helpful for things like address components which is the particular reason why I decided to implement this and see what you think of it.

One remark: It prefers the new default lookup over the deprecated lookup using the downcased scope.
