### PR TITLE
Rendering input with bootstrap but without wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Features:
 
   - Allow primary button classes to be overridden (#183, @tanimichi)
   - Allow to pass a block to select helper in Rails >= 4.1.0 (#229, @doits)
+  - Allow to render input without wrapper (#259, @yevhene)
 
 ## 2.3.0 (2015-02-17)
 

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -357,8 +357,12 @@ module BootstrapForm
         })
       end
 
-      form_group(method, form_group_options) do
+      if wrapper_options == false
         yield
+      else
+        form_group(method, form_group_options) do
+          yield
+        end
       end
     end
 

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -245,6 +245,11 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.search_field(:misc, wrapper: { data: { foo: 'bar' } })
   end
 
+  test "rendering without wrapper" do
+    expected = %{<input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />}
+    assert_equivalent_xml expected, @builder.text_field(:email, wrapper: false)
+  end
+
   test "passing options to a form control get passed through" do
     expected = %{<div class="form-group"><label class="control-label required" for="user_email">Email</label><input autofocus="autofocus" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /></div>}
     assert_equivalent_xml expected, @builder.text_field(:email, autofocus: true)


### PR DESCRIPTION
Useful when real field value specified indirectly:

``` ruby
f.form_group :user do
  f.email_field :email, wrapper: false
end
```
