### PR TITLE
Fix `hide_label` option for `collection_check_boxes`

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -334,13 +334,13 @@ module BootstrapForm
       end
 
       unless options.delete(:skip_label)
+        label_class = hide_class if options.delete(:hide_label)
         if options[:label].is_a?(Hash)
-          label_text  = options[:label].delete(:text)
-          label_class = options[:label].delete(:class)
+          label_text = options[:label].delete(:text)
+          label_class ||= options[:label].delete(:class)
           options.delete(:label)
         end
         label_class ||= options.delete(:label_class)
-        label_class = hide_class if options.delete(:hide_label)
 
         if options[:label].is_a?(String)
           label_text ||= options.delete(:label)

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -140,5 +140,11 @@ class BootstrapCheckboxTest < ActionView::TestCase
     assert_equal expected, @builder.collection_check_boxes(:misc, collection, lambda { |a| "address_#{a.id}" }, :street, checked: collection)
   end
 
+  test 'collection_check_boxes renders :label_class with :hide_label option' do
+    collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
+    expected = %{<input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" /><div class="form-group"><label class="sr-only control-label" for="user_misc">Misc</label><div class="checkbox"><label class="my-label" for="user_misc_1"><input id="user_misc_1" name="user[misc][]" type="checkbox" value="1" /> Foo</label></div><div class="checkbox"><label class="my-label" for="user_misc_2"><input id="user_misc_2" name="user[misc][]" type="checkbox" value="2" /> Bar</label></div></div>}
+
+    assert_equal expected, @builder.collection_check_boxes(:misc, collection, :id, :street, hide_label: true, label_class: 'my-label')
+  end
 
 end


### PR DESCRIPTION
When `hide_label` and `label_class` options are given to `collection_check_boxes`, `label_class` should be rendered to label of each checkbox.

This fixes an unexpected change that caused by 9a846c98.
