### PR TITLE
Bootstrap v4 file field

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -62,13 +62,16 @@ module BootstrapForm
 
     def file_field_with_bootstrap(name, options = {})
       options = options.symbolize_keys!
-      file_field_options = options.except(:label, :label_class, :help, :inline)
+      file_field_options = options.except(:label, :label_class, :help, :span)
       file_field_options[:class] = ["custom-file-input", file_field_options[:class]].compact.join(' ')
 
       label_content = block_given? ? capture(&block) : options[:label]
       label_content = (label_content || (object && object.class.human_attribute_name(name)) || name.to_s.humanize)
       html = label_content.concat(file_field_without_bootstrap(name, file_field_options))
-      html = html.concat(content_tag(:span, nil, class: "custom-file-control"))
+
+      span_options = options[:span] || {}
+      span_class = ["custom-file-control", span_options[:class]].compact.join(' ')
+      html = html.concat(content_tag(:span, nil, span_options.merge(class: span_class)))
 
       label_class    = ["custom-file", options[:label_class]].compact.join(' ')
       content_tag(:div, class: "form-group") do

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -61,8 +61,18 @@ module BootstrapForm
     end
 
     def file_field_with_bootstrap(name, options = {})
-      form_group_builder(name, options.reverse_merge(control_class: nil)) do
-        file_field_without_bootstrap(name, options)
+      options = options.symbolize_keys!
+      file_field_options = options.except(:label, :label_class, :help, :inline)
+      file_field_options[:class] = ["custom-file-input", file_field_options[:class]].compact.join(' ')
+
+      label_content = block_given? ? capture(&block) : options[:label]
+      label_content = (label_content || (object && object.class.human_attribute_name(name)) || name.to_s.humanize)
+      html = label_content.concat(file_field_without_bootstrap(name, file_field_options))
+      html = html.concat(content_tag(:span, nil, class: "custom-file-control"))
+
+      label_class    = ["custom-file", options[:label_class]].compact.join(' ')
+      content_tag(:div, class: "form-group") do
+        label(name, html.html_safe, class: label_class)
       end
     end
 

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -33,7 +33,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "file fields are wrapped correctly" do
-    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><input id="user_misc" name="user[misc]" type="file" /></div>}
+    expected = %{<div class="form-group"><label class="custom-file" for="user_misc">Misc<input class="custom-file-input" id="user_misc" name="user[misc]" type="file" /><span class="custom-file-control"></span></label></div>}
     assert_equal expected, @builder.file_field(:misc)
   end
 

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -37,6 +37,11 @@ class BootstrapFieldsTest < ActionView::TestCase
     assert_equal expected, @builder.file_field(:misc)
   end
 
+  test "file fields can have span attributes set correctly" do
+    expected = %{<div class="form-group"><label class="custom-file" for="user_misc">Misc<input class="custom-file-input" id="user_misc" name="user[misc]" type="file" /><span attribute="value" class="custom-file-control"></span></label></div>}
+    assert_equal expected, @builder.file_field(:misc, span: {attribute: 'value'})
+  end
+
   test "hidden fields are supported" do
     expected = %{<input id="user_misc" name="user[misc]" type="hidden" />}
     assert_equal expected, @builder.hidden_field(:misc)


### PR DESCRIPTION
Changed the file input helper to match Bootstrap v4's new expected HTML as described http://v4-alpha.getbootstrap.com/components/forms/#file-browser

Also, added support for passing attributes to the span section, so JS can be used to update the prompt text into a filename, as described https://github.com/twbs/bootstrap/issues/19661
