### PR TITLE
[v4] Submit button

### DIFF
--- a/demo/app/views/bootstrap/form.html.erb
+++ b/demo/app/views/bootstrap/form.html.erb
@@ -13,6 +13,9 @@
     <%= form.datetime_select :misc, include_blank: true %>
 
     <%= form.submit %>
+    <%= form.primary do %>
+      <%= link_to "Cancel", "/", class: "btn-link ml-2" %>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -207,6 +207,7 @@ module BootstrapForm
 
     bootstrap_method_alias :collection_radio_buttons
 
+    # TODO: Needs documention
     def form_group(*args, &block)
       options = args.extract_options!
       name = args.first
@@ -245,11 +246,10 @@ module BootstrapForm
 
     bootstrap_method_alias :fields_for
 
-    # Add bootstrap formatted submit button. It's a primary button by default.
-    # If you need to change its type or add another css class, you need to
-    # override all css classes like so:
+    # Add bootstrap formatted submit button. If you need to change its type or
+    # add another css class, you need to override all css classes like so:
     #
-    #   <%= form.submit class: "btn btn-secondary custom-class" %>
+    #   <%= form.submit class: "btn btn-info custom-class" %>
     #
     # You may add additional content that directly follows the button. Here's
     # an example of a cancel link:
@@ -259,10 +259,17 @@ module BootstrapForm
     #   <% end %>
     #
     def submit(value = nil, options = {}, &block)
-      options.reverse_merge!(class: "btn btn-primary")
-      out = super(value, options)
+      out = super(value, options.reverse_merge(class: "btn"))
       out += capture(&block) if block_given?
-      out
+
+      form_group do
+        out
+      end
+    end
+
+    # Same as submit button, only with btn-primary class added
+    def primary(value = nil, options = {}, &block)
+      submit(value, options.reverse_merge(class: "btn btn-primary"), &block)
     end
 
     private
@@ -280,7 +287,7 @@ module BootstrapForm
     end
 
     def offset_col(label_col)
-      label_col.sub(/^col-(\w+)-(\d)$/, 'col-\1-offset-\2')
+      label_col.sub(/^col-(\w+)-(\d)$/, 'offset-\1-\2')
     end
 
     def default_control_col

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -245,6 +245,26 @@ module BootstrapForm
 
     bootstrap_method_alias :fields_for
 
+    # Add bootstrap formatted submit button. It's a primary button by default.
+    # If you need to change its type or add another css class, you need to
+    # override all css classes like so:
+    #
+    #   <%= form.submit class: "btn btn-secondary custom-class" %>
+    #
+    # You may add additional content that directly follows the button. Here's
+    # an example of a cancel link:
+    #
+    #   <%= form.submit do %>
+    #     <%= link_to "Cancel", "/", class: "btn btn-link" %>
+    #   <% end %>
+    #
+    def submit(value = nil, options = {}, &block)
+      options.reverse_merge!(class: "btn btn-primary")
+      out = super(value, options)
+      out += capture(&block) if block_given?
+      out
+    end
+
     private
 
     def horizontal?

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -1,15 +1,6 @@
 module BootstrapForm
   module Helpers
     module Bootstrap
-      def submit(name = nil, options = {})
-        options.reverse_merge! class: 'btn btn-secondary'
-        super(name, options)
-      end
-
-      def primary(name = nil, options = {})
-        options.reverse_merge! class: 'btn btn-primary'
-        submit(name, options)
-      end
 
       def alert_message(title, options = {})
         css = options[:class] || 'alert alert-danger'

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -121,14 +121,12 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="form-group">
-        <label class="form-control-label" for="user_misc">This is a checkbox collection</label>
+        <label for="user_misc">This is a checkbox collection</label>
         <div class="form-check">
           <label class="form-check-label" for="user_misc_1">
-            <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-            Foobar
-          </label>
+            <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" /> Foobar</label>
         </div>
-        <span class="form-text text-muted">With a help!</span>
+        <small class="form-text text-muted">With a help!</small>
       </div>
     HTML
 
@@ -140,7 +138,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="form-group">
-        <label class="form-control-label" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <div class="form-check">
           <label class="form-check-label" for="user_misc_1">
             <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
@@ -164,7 +162,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="form-group">
-        <label class="form-control-label" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <label class="form-check-inline" for="user_misc_1">
           <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
           Foo
@@ -184,7 +182,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="form-group">
-        <label class="form-control-label" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <div class="form-check">
           <label class="form-check-label" for="user_misc_1">
             <input checked="checked" class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
@@ -209,18 +207,14 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="form-group">
-        <label class="form-control-label" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <div class="form-check">
           <label class="form-check-label" for="user_misc_1">
-            <input checked="checked" class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-            Foo
-          </label>
+            <input checked="checked" class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" /> Foo</label>
         </div>
         <div class="form-check">
           <label class="form-check-label" for="user_misc_2">
-            <input checked="checked" class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
-            Bar
-          </label>
+            <input checked="checked" class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" /> Bar</label>
         </div>
       </div>
     HTML
@@ -234,7 +228,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="form-group">
-        <label class="form-control-label" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <div class="form-check">
           <label class="form-check-label" for="user_misc_foo_st">
             <input class="form-check-input" id="user_misc_foo_st" name="user[misc][]" type="checkbox" value="Foo St" />
@@ -251,7 +245,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="form-group">
-        <label class="form-control-label" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <div class="form-check">
           <label class="form-check-label" for="user_misc_1">
             <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
@@ -275,7 +269,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="form-group">
-        <label class="form-control-label" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <div class="form-check">
           <label class="form-check-label" for="user_misc_address_1">
             <input class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
@@ -298,7 +292,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="form-group">
-        <label class="form-control-label" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <div class="form-check">
           <label class="form-check-label" for="user_misc_1">
             <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
@@ -322,7 +316,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="form-group">
-        <label class="form-control-label" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <div class="form-check">
           <label class="form-check-label" for="user_misc_address_1">
             <input class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
@@ -346,7 +340,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="form-group">
-        <label class="form-control-label" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <div class="form-check">
           <label class="form-check-label" for="user_misc_address_1">
             <input checked="checked" class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
@@ -371,7 +365,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="form-group">
-        <label class="form-control-label" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <div class="form-check">
           <label class="form-check-label" for="user_misc_address_1">
             <input checked="checked" class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -399,8 +399,8 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equivalent_xml expected, output
   end
 
+  # TODO: Translate test name to english
   test "single form_group call in horizontal form should not be smash design" do
-    output = ''
     output = @horizontal_builder.form_group do
       "Hallo"
     end
@@ -412,7 +412,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <div class="col-sm-10 col-sm-offset-2">Hallo</div>
       </div>
       <div class="form-group row">
-        <label class=" col-sm-2 required" for="user_email">Email</label>
+        <label class="col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
           <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
         </div>

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -233,7 +233,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group row">
-        <div class="col-sm-10 col-sm-offset-2">
+        <div class="col-sm-10 offset-sm-2">
           <p class="form-control-static">Bar</p>
         </div>
       </div>
@@ -264,7 +264,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group foo row">
-        <div class="col-sm-10 col-sm-offset-2">
+        <div class="col-sm-10 offset-sm-2">
           <p class="form-control-static">Bar</p>
         </div>
       </div>
@@ -272,14 +272,14 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equivalent_xml expected, output
   end
 
-  test "form_group accepts class thorugh options hash without needing a name" do
+  test "form_group accepts class through options hash without needing a name" do
     output = @horizontal_builder.form_group class: "foo" do
       %{<p class="form-control-static">Bar</p>}.html_safe
     end
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group foo row">
-        <div class="col-sm-10 col-sm-offset-2">
+        <div class="col-sm-10 offset-sm-2">
           <p class="form-control-static">Bar</p>
         </div>
       </div>
@@ -371,14 +371,12 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "adds offset for form_group without label" do
     output = @horizontal_builder.form_group do
-      @horizontal_builder.submit
+      "test"
     end
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group row">
-        <div class="col-sm-10 col-sm-offset-2">
-          <input class="btn btn-secondary" name="commit" type="submit" value="Create User" />
-        </div>
+        <div class="col-sm-10 offset-sm-2">test</div>
       </div>
     HTML
     assert_equivalent_xml expected, output
@@ -386,36 +384,12 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "adds offset for form_group without label but specific label_col" do
     output = @horizontal_builder.form_group label_col: 'col-sm-5', control_col: 'col-sm-8' do
-      @horizontal_builder.submit
+      "test"
     end
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group row">
-        <div class="col-sm-8 col-sm-offset-5">
-          <input class="btn btn-secondary" name="commit" type="submit" value="Create User" />
-        </div>
-      </div>
-    HTML
-    assert_equivalent_xml expected, output
-  end
-
-  # TODO: Translate test name to english
-  test "single form_group call in horizontal form should not be smash design" do
-    output = @horizontal_builder.form_group do
-      "Hallo"
-    end
-
-    output = output + @horizontal_builder.text_field(:email)
-
-    expected = <<-HTML.strip_heredoc
-      <div class="form-group row">
-        <div class="col-sm-10 col-sm-offset-2">Hallo</div>
-      </div>
-      <div class="form-group row">
-        <label class="col-sm-2 required" for="user_email">Email</label>
-        <div class="col-sm-10">
-          <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
-        </div>
+        <div class="col-sm-8 offset-sm-5">test</div>
       </div>
     HTML
     assert_equivalent_xml expected, output
@@ -468,14 +442,19 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "non-default column span on form is reflected in form_group" do
-    non_default_horizontal_builder = BootstrapForm::FormBuilder.new(:user, @user, self, { layout: :horizontal, label_col: "col-sm-3", control_col: "col-sm-9" })
+    non_default_horizontal_builder = BootstrapForm::FormBuilder.new(:user, @user, self,
+      layout:       :horizontal,
+      label_col:    "col-sm-3",
+      control_col:  "col-sm-9"
+    )
+
     output = non_default_horizontal_builder.form_group do
       %{<p class="form-control-static">Bar</p>}.html_safe
     end
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group row">
-        <div class="col-sm-9 col-sm-offset-3">
+        <div class="col-sm-9 offset-sm-3">
           <p class="form-control-static">Bar</p>
         </div>
       </div>
@@ -484,10 +463,18 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "non-default column span on form isn't mutated" do
-    frozen_horizontal_builder = BootstrapForm::FormBuilder.new(:user, @user, self, { layout: :horizontal, label_col: "col-sm-3".freeze, control_col: "col-sm-9".freeze })
+    frozen_horizontal_builder = BootstrapForm::FormBuilder.new(:user, @user, self,
+      layout: :horizontal,
+      label_col: "col-sm-3".freeze,
+      control_col: "col-sm-9".freeze
+    )
     output = frozen_horizontal_builder.form_group { 'test' }
 
-    expected = %{<div class="form-group row"><div class="col-sm-9 col-sm-offset-3">test</div></div>}
+    expected = <<-HTML.strip_heredoc
+      <div class="form-group row">
+        <div class="col-sm-9 offset-sm-3">test</div>
+      </div>
+    HTML
     assert_equivalent_xml expected, output
   end
 
@@ -498,11 +485,14 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <div class="input-group input-group-lg">
           <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
           <div class="input-group-append">
-            <input class="btn btn-primary" name="commit" type="submit" value="Subscribe" />
+            <button class="btn">Subscribe</button>
           </div>
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.email_field(:email, append: @builder.primary('Subscribe'), input_group_class: 'input-group-lg')
+    assert_equivalent_xml expected, @builder.email_field(:email,
+      append: %{<button class="btn">Subscribe</button>}.html_safe,
+      input_group_class: 'input-group-lg'
+    )
   end
 end

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -299,13 +299,14 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         <input name="utf8" type="hidden" value="&#x2713;" />
         <div class="form-group row">
-          <div class="col-md-10 col-md-offset-2">
-            <input class="btn btn-secondary" name="commit" type="submit" value="Create User" />
+          <div class="col-md-10 offset-md-2">
+            <input class="btn" name="commit" type="submit" value="Create User" />
           </div>
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, bootstrap_form_for(@user, layout: :horizontal, label_col: 'col-md-2', control_col: 'col-md-10') { |f| f.form_group { f.submit } }
+    options = {layout: :horizontal, label_col: 'col-md-2', control_col: 'col-md-10'}
+    assert_equivalent_xml expected, bootstrap_form_for(@user, options){|f| f.submit}
   end
 
   test "custom input width for horizontal forms" do

--- a/test/bootstrap_other_components_test.rb
+++ b/test/bootstrap_other_components_test.rb
@@ -94,24 +94,47 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
   end
 
   test "submit button" do
-    expected = %{<input class="btn btn-primary" name="commit" type="submit" value="Create User" />}
+    expected = <<-HTML.strip_heredoc
+      <div class="form-group">
+        <input class="btn" name="commit" type="submit" value="Create User" />
+      </div>
+    HTML
     assert_equivalent_xml expected, @builder.submit
   end
 
+  test "submit button as primary" do
+    expected = <<-HTML.strip_heredoc
+      <div class="form-group">
+        <input class="btn btn-primary" name="commit" type="submit" value="Create User" />
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.primary
+  end
+
   test "submit button with defined name" do
-    expected = %{<input class="btn btn-primary" name="commit" type="submit" value="Test" />}
+    expected = <<-HTML.strip_heredoc
+      <div class="form-group">
+        <input class="btn" name="commit" type="submit" value="Test" />
+      </div>
+    HTML
     assert_equivalent_xml expected, @builder.submit("Test")
   end
 
   test "submit button with custom class" do
-    expected = %{<input class="test" name="commit" type="submit" value="Create User" />}
+    expected = <<-HTML.strip_heredoc
+      <div class="form-group">
+        <input class="test" name="commit" type="submit" value="Create User" />
+      </div>
+    HTML
     assert_equivalent_xml expected, @builder.submit(class: "test")
   end
 
   test "submit button with block" do
     expected = <<-HTML.strip_heredoc
-      <input class="btn btn-primary" name="commit" type="submit" value="Create User"/>
-      <a href="/" class="btn btn-link">Cancel</a>
+      <div class="form-group">
+        <input class="btn" name="commit" type="submit" value="Create User"/>
+        <a href="/" class="btn btn-link">Cancel</a>
+      </div>
     HTML
 
     result = @builder.submit do
@@ -124,8 +147,8 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
   test "submit button for horizontal form" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group row">
-        <div class="col-sm-10 offset-md-2">
-          <input class="btn btn-primary" name="commit" type="submit" value="Create User"/>
+        <div class="col-sm-10 offset-sm-2">
+          <input class="btn" name="commit" type="submit" value="Create User"/>
         </div>
       </div>
     HTML

--- a/test/bootstrap_other_components_test.rb
+++ b/test/bootstrap_other_components_test.rb
@@ -93,28 +93,43 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
     assert_equivalent_xml expected, output
   end
 
-  test "submit button defaults to rails action name" do
-    expected = %{<input class="btn btn-secondary" name="commit" type="submit" value="Create User" />}
+  test "submit button" do
+    expected = %{<input class="btn btn-primary" name="commit" type="submit" value="Create User" />}
     assert_equivalent_xml expected, @builder.submit
   end
 
-  test "submit button uses default button classes" do
-    expected = %{<input class="btn btn-secondary" name="commit" type="submit" value="Submit Form" />}
-    assert_equivalent_xml expected, @builder.submit("Submit Form")
+  test "submit button with defined name" do
+    expected = %{<input class="btn btn-primary" name="commit" type="submit" value="Test" />}
+    assert_equivalent_xml expected, @builder.submit("Test")
   end
 
-  test "override submit button classes" do
-    expected = %{<input class="btn btn-primary" name="commit" type="submit" value="Submit Form" />}
-    assert_equivalent_xml expected, @builder.submit("Submit Form", class: "btn btn-primary")
+  test "submit button with custom class" do
+    expected = %{<input class="test" name="commit" type="submit" value="Create User" />}
+    assert_equivalent_xml expected, @builder.submit(class: "test")
   end
 
-  test "primary button uses proper css classes" do
-    expected = %{<input class="btn btn-primary" name="commit" type="submit" value="Submit Form" />}
-    assert_equivalent_xml expected, @builder.primary("Submit Form")
+  test "submit button with block" do
+    expected = <<-HTML.strip_heredoc
+      <input class="btn btn-primary" name="commit" type="submit" value="Create User"/>
+      <a href="/" class="btn btn-link">Cancel</a>
+    HTML
+
+    result = @builder.submit do
+      %{<a href="/" class="btn btn-link">Cancel</a>}.html_safe
+    end
+
+    assert_equivalent_xml expected, result
   end
 
-  test "override primary button classes" do
-    expected = %{<input class="btn btn-primary disabled" name="commit" type="submit" value="Submit Form" />}
-    assert_equivalent_xml expected, @builder.primary("Submit Form", class: "btn btn-primary disabled")
+  test "submit button for horizontal form" do
+    expected = <<-HTML.strip_heredoc
+      <div class="form-group row">
+        <div class="col-sm-10 offset-md-2">
+          <input class="btn btn-primary" name="commit" type="submit" value="Create User"/>
+        </div>
+      </div>
+    HTML
+    assert_equivalent_xml expected, @horizontal_builder.submit
   end
+
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,19 +38,6 @@ class ActionView::TestCase
     })
   end
 
-  def sort_attributes doc
-    doc.dup.traverse do |node|
-      if node.is_a?(Nokogiri::XML::Element)
-        attributes = node.attribute_nodes.sort_by(&:name)
-        attributes.each do |attribute|
-          node.delete(attribute.name)
-          node[attribute.name] = attribute.value
-        end
-      end
-      node
-    end
-  end
-
   # Expected and actual are wrapped in a root tag to ensure proper XML structure
   def assert_equivalent_xml(expected, actual)
     expected_xml        = Nokogiri::XML("<test-xml>\n#{expected}\n</test-xml>")
@@ -87,6 +74,22 @@ class ActionView::TestCase
         sort_attributes(actual_xml.root)
       ).to_s(:color)
     }
+  end
+
+private
+
+  def sort_attributes(doc)
+    return if doc.blank?
+    doc.dup.traverse do |node|
+      if node.is_a?(Nokogiri::XML::Element)
+        attributes = node.attribute_nodes.sort_by(&:name)
+        attributes.each do |attribute|
+          node.delete(attribute.name)
+          node[attribute.name] = attribute.value
+        end
+      end
+      node
+    end
   end
 
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,9 +51,10 @@ class ActionView::TestCase
     end
   end
 
+  # Expected and actual are wrapped in a root tag to ensure proper XML structure
   def assert_equivalent_xml(expected, actual)
-    expected_xml        = Nokogiri::XML("<test-xml>#{expected}</test-xml>")
-    actual_xml          = Nokogiri::XML("<test-xml>#{actual}</test-xml>")
+    expected_xml        = Nokogiri::XML("<test-xml>\n#{expected}\n</test-xml>")
+    actual_xml          = Nokogiri::XML("<test-xml>\n#{actual}\n</test-xml>")
     ignored_attributes  = %w(style data-disable-with)
 
     equivalent = EquivalentXml.equivalent?(expected_xml, actual_xml, {


### PR DESCRIPTION
- defaulting to `btn` class. Anything else is changed via `class:` option. 
- allowing block content for additional html like cancel links
- automatically is put in column if used in a `layout: horizontal` form
- fixed offset class generation (closes #338)