### PR TITLE
Miscellaneous cleanup; rewrite CHANGELOG for 4.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ demo/tmp/
 .rbenv-gemsets
 *.swp
 Gemfile.lock
+test/gemfiles/*.lock
 .ruby-version

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ demo/tmp/
 Gemfile.lock
 test/gemfiles/*.lock
 .ruby-version
+Vagrantfile
+.vagrant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,29 @@
 ## [Pending Release][]
 
-Bugfixes:
-  - Your contribution here!
-  - form-control-danger is replaced with is-invalid for bootstrap 4.0.0.beta3
-  - form-control-feedback is replaced with invalid-feedback for bootstrap 4.0.0.beta3
-  - help texts are rendered with <small> tag instead of <span> tag, i.e. like in bootstrap 4.0.0.beta3
-  - removing support for `nested_form` gem
-  - `icon` option is no longer available
-  - completely removing deprecated methods: `check_boxes_collection` and `radio_buttons_collection`
+🚨 **This release adds support for Bootstrap v4 and drops support for Bootstrap v3.** 🚨
 
-Features:
-  - Your contribution here!
-  - new `custom: true` option for radio buttons and check boxes according to bootstrap 4.0.0.beta3
-  - Allow HTML in help translations by using the '_html' suffix on the key - [@unikitty37](https://github.com/unikitty37)
-  * [#325](https://github.com/bootstrap-ruby/rails-bootstrap-forms/pull/325): Support :prepend and :append for the `select` helper - [@donv](https://github.com/donv).
+If your app uses Bootstrap v3, you should continue using bootstrap_form 2.7.x instead.
+
+Bootstrap v3 and v4 are very different, and thus bootstrap_form now produces different markup in order to target v4. The changes are too many to list here; you can refer to Bootstrap's [Migrating to v4](https://getbootstrap.com/docs/4.0/migration/) page for a detailed explanation.
+
+In addition to these necessary markup changes, the bootstrap_form API itself has the following important changes in this release.
+
+### Breaking changes
+
+* Built-in support for the `nested_form` gem has been completely removed
+* The `icon` option is no longer supported (Bootstrap v4 does not include icons)
+* The deprecated Rails methods `check_boxes_collection` and `radio_buttons_collection` have been removed
+* Your contribution here!
+
+### New features
+
+* Support Bootstrap v4's [Custom Checkboxes and Radios](https://getbootstrap.com/docs/4.0/components/forms/#checkboxes-and-radios-1) with a new `custom: true` option
+* Allow HTML in help translations by using the `_html` suffix on the key - [@unikitty37](https://github.com/unikitty37)
+* Your contribution here!
+
+### Bugfixes
+
+* Your contribution here!
 
 ## [2.7.0][] (2017-04-21)
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -45,7 +45,7 @@ end
 # Did you remove the CHANGELOG's "Your contribution here!" line?
 # ------------------------------------------------------------------------------
 if has_changelog_changes
-  if IO.read("CHANGELOG.md").scan(/^\s*- Your contribution here/i).count < 2
+  if IO.read("CHANGELOG.md").scan(/^\s*[-\*] Your contribution here/i).count < 3
     fail(
       "Please put the `- Your contribution here!` line back into CHANGELOG.md.",
       :sticky => false

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Bootstrap v4-style forms into your Rails application.
 
 ## Requirements
 
-* Ruby 2.3+
+* Ruby 2.2.2+
 * Rails 5.0+
 * Bootstrap 4.0.0+
 

--- a/bootstrap_form.gemspec
+++ b/bootstrap_form.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version     = BootstrapForm::VERSION
   s.authors     = ["Stephen Potenza", "Carlos Lopes"]
   s.email       = ["potenza@gmail.com", "carlos.el.lopes@gmail.com"]
-  s.homepage    = "https://github.com/bootstrap-ruby/rails-bootstrap-forms"
+  s.homepage    = "https://github.com/bootstrap-ruby/bootstrap_form"
   s.summary     = "Rails form builder that makes it easy to style forms using "\
                   "Bootstrap 4"
   s.description = "bootstrap_form is a rails form builder that makes it super "\

--- a/test/gemfiles/5.1.gemfile
+++ b/test/gemfiles/5.1.gemfile
@@ -5,7 +5,9 @@ gemspec path: "../../"
 gem "rails", "~> 5.1.0"
 
 group :test do
+  # TODO: remove once Rails 5.1.5 is released
   gem "minitest", "~> 5.10.3"
+
   gem "diffy"
   gem "equivalent-xml"
   gem "mocha"

--- a/test/gemfiles/5.2.gemfile
+++ b/test/gemfiles/5.2.gemfile
@@ -5,7 +5,7 @@ gemspec path: "../../"
 gem "rails", "~> 5.2.0.beta2"
 
 group :test do
-  # can relax version requirement for Rails 5.2.beta3+
+  # TODO: remove once Rails > 5.2.0.beta2 is released
   gem "minitest", "~> 5.10.3"
 
   gem "diffy"


### PR DESCRIPTION
This PR includes a handful of tweaks:

1. Fix a mistake in Ruby version requirement listed in the README: we support 2.2.2+, not 2.3+.
2. Using the various gemfiles in `test/gemfiles` causes `.lock` files to be created. These should never be committed, so add them to the `.gitignore`.
3. The repo URL has recently changed; update the homepage in the gemspec to match.
4. The minitest fix in Rails has been backported to the 5.1 branch; add a comment as a reminder to remove our workaround once 5.1.5 has been released.
5. The CHANGELOG did not explain the magnitude of the changes since the last bootstrap_form release (2.7.0) and there are too many markup changes to reasonably list. Rewrite the CHANGELOG to explain what has changed at a high-level and direct people to the Bootstrap v4 docs for a more complete explanation of the markup changes.