### PR TITLE
Fix EnvironmentMismatchError when running tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,8 +4,6 @@ require 'nokogiri'
 require 'equivalent-xml'
 require 'mocha/mini_test'
 
-ENV["RAILS_ENV"] = "test"
-
 require_relative "../demo/config/environment.rb"
 require "rails/test_help"
 


### PR DESCRIPTION
Once demo app is used, then subsequent runs of `rake test` would print an `EnvironmentMismatchError`. Removing the `RAILS_ENV=test` assignment fixes this warning.

Fixes #402 