### PR TITLE
Pretty-print output of failed tests #399.

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -53,8 +53,8 @@ class ActionView::TestCase
 
   # Expected and actual are wrapped in a root tag to ensure proper XML structure
   def assert_equivalent_xml(expected, actual)
-    expected_xml        = Nokogiri::XML("<test-xml>\n#{expected}\n</test-xml>")
-    actual_xml          = Nokogiri::XML("<test-xml>\n#{actual}\n</test-xml>")
+    expected_xml        = Nokogiri::XML("<test-xml>\n#{expected}\n</test-xml>") { |config| config.default_xml.noblanks }
+    actual_xml          = Nokogiri::XML("<test-xml>\n#{actual}\n</test-xml>") { |config| config.default_xml.noblanks }
     ignored_attributes  = %w(style data-disable-with)
 
     equivalent = EquivalentXml.equivalent?(expected_xml, actual_xml, {
@@ -83,8 +83,8 @@ class ActionView::TestCase
     assert equivalent, lambda {
       # using a lambda because diffing is expensive
       Diffy::Diff.new(
-        sort_attributes(expected_xml.root),
-        sort_attributes(actual_xml.root)
+        sort_attributes(expected_xml.root).to_xml(indent: 2),
+        sort_attributes(actual_xml.root).to_xml(indent: 2)
       ).to_s(:color)
     }
   end


### PR DESCRIPTION
Thanks to @mattbrictson for figuring this out. I just implemented what he suggested. :-)

This PR doesn't affect end users. It simply pretty-prints output from failed tests, so that it's easier to see where the differences are.