### PR TITLE
Render Bootstrap 4 Radio Buttons and Check Boxes

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -115,14 +115,8 @@ module BootstrapForm
       end
 
       checkbox_html = check_box_without_bootstrap(name, check_box_options, checked_value, unchecked_value)
-      checkbox_html_without_bootstrap = checkbox_html.clone
       label_content = block_given? ? capture(&block) : options[:label]
       label_description = label_content || (object && object.class.human_attribute_name(name)) || name.to_s.humanize
-      if options[:custom]
-        html = label_description
-      else
-        html = checkbox_html.concat(" ").concat(label_description)
-      end
 
       label_name = name
       # label's `for` attribute needs to match checkbox tag's id,
@@ -139,16 +133,17 @@ module BootstrapForm
         div_class = ["custom-control", "custom-checkbox"]
         div_class.append("custom-control-inline") if options[:inline]
         content_tag(:div, class: div_class.compact.join(" ")) do
-          checkbox_html.concat(label(label_name, html, class: ["custom-control-label", label_class].compact.join(" ")))
+          checkbox_html.concat(label(label_name, label_description, class: ["custom-control-label", label_class].compact.join(" ")))
         end
       else
         disabled_class = " disabled" if options[:disabled]
         if options[:inline]
           label_class = " #{label_class}" if label_class
-          label(label_name, html, { class: "form-check-inline#{disabled_class}#{label_class}" }.merge(options[:id].present? ? { for: options[:id] } : {}))
+          checkbox_html
+            .concat(label(label_name, label_description, { class: "form-check-inline#{disabled_class}#{label_class}" }.merge(options[:id].present? ? { for: options[:id] } : {})))
         else
           content_tag(:div, class: "form-check#{disabled_class}") do
-            checkbox_html_without_bootstrap
+            checkbox_html
               .concat(label(label_name, label_description, { class: ["form-check-label", label_class].compact.join(" ") }.merge(options[:id].present? ? { for: options[:id] } : {})))
           end
         end

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -161,13 +161,6 @@ module BootstrapForm
       radio_options[:class] = ["custom-control-input", options[:class]].compact.join(' ') if options[:custom]
       args << radio_options
       radio_html = radio_button_without_bootstrap(name, value, *args)
-      radio_html_without_bootstrap = radio_html.clone
-
-      if options[:custom]
-        html = options[:label]
-      else
-        html = radio_html.concat(" ").concat(options[:label])
-      end
 
       disabled_class = " disabled" if options[:disabled]
       label_class    = options[:label_class]
@@ -176,16 +169,16 @@ module BootstrapForm
         div_class = ["custom-control", "custom-radio"]
         div_class.append("custom-control-inline") if options[:inline]
         content_tag(:div, class: div_class.compact.join(" ")) do
-          radio_html.concat(label(name, html, value: value, class: ["custom-control-label", label_class].compact.join(" ")))
+          radio_html.concat(label(name, options[:label], value: value, class: ["custom-control-label", label_class].compact.join(" ")))
         end
       else
         if options[:inline]
           label_class = " #{label_class}" if label_class
-          radio_html_without_bootstrap
+          radio_html
             .concat(label(name, options[:label], { class: "radio-inline#{disabled_class}#{label_class}", value: value }.merge(options[:id].present? ? { for: options[:id] } : {})))
         else
           content_tag(:div, class: "radio#{disabled_class}") do
-            radio_html_without_bootstrap
+            radio_html
               .concat(label(name, options[:label], { value: value, class: label_class }.merge(options[:id].present? ? { for: options[:id] } : {})))
           end
         end

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -174,7 +174,7 @@ module BootstrapForm
           radio_html
             .concat(label(name, options[:label], { class: "radio-inline#{disabled_class}#{label_class}", value: value }.merge(options[:id].present? ? { for: options[:id] } : {})))
         else
-          content_tag(:div, class: "radio#{disabled_class}") do
+          content_tag(:div, class: "form-check#{disabled_class}") do
             radio_html
               .concat(label(name, options[:label], { value: value, class: label_class }.merge(options[:id].present? ? { for: options[:id] } : {})))
           end

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -115,6 +115,7 @@ module BootstrapForm
       end
 
       checkbox_html = check_box_without_bootstrap(name, check_box_options, checked_value, unchecked_value)
+      checkbox_html_without_bootstrap = checkbox_html.clone
       label_content = block_given? ? capture(&block) : options[:label]
       label_description = label_content || (object && object.class.human_attribute_name(name)) || name.to_s.humanize
       if options[:custom]
@@ -147,7 +148,8 @@ module BootstrapForm
           label(label_name, html, { class: "form-check-inline#{disabled_class}#{label_class}" }.merge(options[:id].present? ? { for: options[:id] } : {}))
         else
           content_tag(:div, class: "form-check#{disabled_class}") do
-            label(label_name, html, { class: ["form-check-label", label_class].compact.join(" ") }.merge(options[:id].present? ? { for: options[:id] } : {}))
+            checkbox_html_without_bootstrap
+              .concat(label(label_name, label_description, { class: ["form-check-label", label_class].compact.join(" ") }.merge(options[:id].present? ? { for: options[:id] } : {})))
           end
         end
       end

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -181,7 +181,8 @@ module BootstrapForm
       else
         if options[:inline]
           label_class = " #{label_class}" if label_class
-          label(name, html, { class: "radio-inline#{disabled_class}#{label_class}", value: value }.merge(options[:id].present? ? { for: options[:id] } : {}))
+          radio_html_without_bootstrap
+            .concat(label(name, options[:label], { class: "radio-inline#{disabled_class}#{label_class}", value: value }.merge(options[:id].present? ? { for: options[:id] } : {})))
         else
           content_tag(:div, class: "radio#{disabled_class}") do
             radio_html_without_bootstrap

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -136,15 +136,18 @@ module BootstrapForm
           checkbox_html.concat(label(label_name, label_description, class: ["custom-control-label", label_class].compact.join(" ")))
         end
       else
-        disabled_class = " disabled" if options[:disabled]
         if options[:inline]
           label_class = " #{label_class}" if label_class
           checkbox_html
-            .concat(label(label_name, label_description, { class: "form-check-inline#{disabled_class}#{label_class}" }.merge(options[:id].present? ? { for: options[:id] } : {})))
+            .concat(label(label_name,
+                          label_description,
+                          { class: "form-check-inline#{label_class}" }.merge(options[:id].present? ? { for: options[:id] } : {})))
         else
-          content_tag(:div, class: "form-check#{disabled_class}") do
+          content_tag(:div, class: "form-check") do
             checkbox_html
-              .concat(label(label_name, label_description, { class: ["form-check-label", label_class].compact.join(" ") }.merge(options[:id].present? ? { for: options[:id] } : {})))
+              .concat(label(label_name,
+                            label_description,
+                            { class: ["form-check-label", label_class].compact.join(" ") }.merge(options[:id].present? ? { for: options[:id] } : {})))
           end
         end
       end

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -161,6 +161,8 @@ module BootstrapForm
       radio_options[:class] = ["custom-control-input", options[:class]].compact.join(' ') if options[:custom]
       args << radio_options
       radio_html = radio_button_without_bootstrap(name, value, *args)
+      radio_html_without_bootstrap = radio_html.clone
+
       if options[:custom]
         html = options[:label]
       else
@@ -182,7 +184,8 @@ module BootstrapForm
           label(name, html, { class: "radio-inline#{disabled_class}#{label_class}", value: value }.merge(options[:id].present? ? { for: options[:id] } : {}))
         else
           content_tag(:div, class: "radio#{disabled_class}") do
-            label(name, html, { value: value, class: label_class }.merge(options[:id].present? ? { for: options[:id] } : {}))
+            radio_html_without_bootstrap
+              .concat(label(name, options[:label], { value: value, class: label_class }.merge(options[:id].present? ? { for: options[:id] } : {})))
           end
         end
       end

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -20,9 +20,9 @@ class BootstrapCheckboxTest < ActionView::TestCase
 
   test "disabled check_box has proper wrapper classes" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-check disabled">
-        <input disabled="disabled" name="user[terms]" type="hidden" value="0" />
-        <input class="form-check-input" disabled="disabled" id="user_terms" name="user[terms]" type="checkbox" value="1" />
+      <div class="form-check">
+        <input name="user[terms]" type="hidden" value="0" disabled="disabled" />
+        <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" disabled="disabled" />
         <label class="form-check-label" for="user_terms">
           I agree to the terms
         </label>
@@ -109,9 +109,9 @@ class BootstrapCheckboxTest < ActionView::TestCase
 
   test "disabled inline check_box" do
     expected = <<-HTML.strip_heredoc
-    <input disabled="disabled" name="user[terms]" type="hidden" value="0" />
-    <input class="form-check-input" disabled="disabled" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-      <label class="form-check-inline disabled" for="user_terms">
+    <input name="user[terms]" type="hidden" value="0" disabled="disabled" />
+    <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" disabled="disabled" />
+      <label class="form-check-inline" for="user_terms">
         I agree to the terms
       </label>
     HTML
@@ -424,7 +424,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="custom-control custom-checkbox">
         <input name="user[terms]" type="hidden" value="0" disabled="disabled" />
-        <input class="custom-control-input" id="user_terms" name="user[terms]" type="checkbox" disabled="disabled" value="1" />
+        <input class="custom-control-input" id="user_terms" name="user[terms]" type="checkbox" value="1" disabled="disabled" />
         <label class="custom-control-label" for="user_terms">I agree to the terms</label>
       </div>
     HTML

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -98,9 +98,9 @@ class BootstrapCheckboxTest < ActionView::TestCase
 
   test "inline checkboxes" do
     expected = <<-HTML.strip_heredoc
+    <input name="user[terms]" type="hidden" value="0" />
+    <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
       <label class="form-check-inline" for="user_terms">
-        <input name="user[terms]" type="hidden" value="0" />
-        <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
         I agree to the terms
       </label>
     HTML
@@ -109,9 +109,9 @@ class BootstrapCheckboxTest < ActionView::TestCase
 
   test "disabled inline check_box" do
     expected = <<-HTML.strip_heredoc
+    <input disabled="disabled" name="user[terms]" type="hidden" value="0" />
+    <input class="form-check-input" disabled="disabled" id="user_terms" name="user[terms]" type="checkbox" value="1" />
       <label class="form-check-inline disabled" for="user_terms">
-        <input disabled="disabled" name="user[terms]" type="hidden" value="0" />
-        <input class="form-check-input" disabled="disabled" id="user_terms" name="user[terms]" type="checkbox" value="1" />
         I agree to the terms
       </label>
     HTML
@@ -120,9 +120,9 @@ class BootstrapCheckboxTest < ActionView::TestCase
 
   test "inline checkboxes with custom label class" do
     expected = <<-HTML.strip_heredoc
+    <input name="user[terms]" type="hidden" value="0" />
+    <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
       <label class="form-check-inline btn" for="user_terms">
-        <input name="user[terms]" type="hidden" value="0" />
-        <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
         Terms
       </label>
     HTML
@@ -176,12 +176,12 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="form-group">
         <label for="user_misc">Misc</label>
+        <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
         <label class="form-check-inline" for="user_misc_1">
-          <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
           Foo
         </label>
+        <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
         <label class="form-check-inline" for="user_misc_2">
-          <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
           Bar
         </label>
       </div>

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -8,9 +8,9 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "check_box is wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
+        <input name="user[terms]" type="hidden" value="0" />
+        <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
         <label class="form-check-label" for="user_terms">
-          <input name="user[terms]" type="hidden" value="0" />
-          <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
           I agree to the terms
         </label>
       </div>
@@ -21,9 +21,9 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "disabled check_box has proper wrapper classes" do
     expected = <<-HTML.strip_heredoc
       <div class="form-check disabled">
+        <input disabled="disabled" name="user[terms]" type="hidden" value="0" />
+        <input class="form-check-input" disabled="disabled" id="user_terms" name="user[terms]" type="checkbox" value="1" />
         <label class="form-check-label" for="user_terms">
-          <input disabled="disabled" name="user[terms]" type="hidden" value="0" />
-          <input class="form-check-input" disabled="disabled" id="user_terms" name="user[terms]" type="checkbox" value="1" />
           I agree to the terms
         </label>
       </div>
@@ -34,9 +34,9 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "check_box label allows html" do
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
+        <input name="user[terms]" type="hidden" value="0" />
+        <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
         <label class="form-check-label" for="user_terms">
-          <input name="user[terms]" type="hidden" value="0" />
-          <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
           I agree to the <a href="#">terms</a>
         </label>
       </div>
@@ -47,9 +47,9 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "check_box accepts a block to define the label" do
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
+        <input name="user[terms]" type="hidden" value="0" />
+        <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
         <label class="form-check-label" for="user_terms">
-          <input name="user[terms]" type="hidden" value="0" />
-          <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
           I agree to the terms
         </label>
       </div>
@@ -60,9 +60,9 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "check_box accepts a custom label class" do
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
+        <input name="user[terms]" type="hidden" value="0" />
+        <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
         <label class="form-check-label btn" for="user_terms">
-          <input name="user[terms]" type="hidden" value="0" />
-          <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
           Terms
         </label>
       </div>
@@ -73,9 +73,9 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "check_box 'id' attribute is used to specify label 'for' attribute" do
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
+        <input name="user[terms]" type="hidden" value="0" />
+        <input class="form-check-input" id="custom_id" name="user[terms]" type="checkbox" value="1" />
         <label class="form-check-label" for="custom_id">
-          <input name="user[terms]" type="hidden" value="0" />
-          <input class="form-check-input" id="custom_id" name="user[terms]" type="checkbox" value="1" />
           Terms
         </label>
       </div>
@@ -86,9 +86,9 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "check_box responds to checked_value and unchecked_value arguments" do
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
+        <input name="user[terms]" type="hidden" value="no" />
+        <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="yes" />
         <label class="form-check-label" for="user_terms">
-          <input name="user[terms]" type="hidden" value="no" />
-          <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="yes" />
           I agree to the terms
         </label>
       </div>
@@ -136,8 +136,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-group">
         <label for="user_misc">This is a checkbox collection</label>
         <div class="form-check">
-          <label class="form-check-label" for="user_misc_1">
-            <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" /> Foobar</label>
+          <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
+          <label class="form-check-label" for="user_misc_1"> Foobar</label>
         </div>
         <small class="form-text text-muted">With a help!</small>
       </div>
@@ -153,14 +153,14 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-group">
         <label for="user_misc">Misc</label>
         <div class="form-check">
+          <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_misc_1">
-            <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
             Foo
           </label>
         </div>
         <div class="form-check">
+          <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
           <label class="form-check-label" for="user_misc_2">
-            <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
             Bar
           </label>
         </div>
@@ -197,14 +197,14 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-group">
         <label for="user_misc">Misc</label>
         <div class="form-check">
+          <input checked="checked" class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_misc_1">
-            <input checked="checked" class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
             Foo
           </label>
         </div>
         <div class="form-check">
+          <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
           <label class="form-check-label" for="user_misc_2">
-            <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
             Bar
           </label>
         </div>
@@ -222,12 +222,12 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-group">
         <label for="user_misc">Misc</label>
         <div class="form-check">
-          <label class="form-check-label" for="user_misc_1">
-            <input checked="checked" class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" /> Foo</label>
+          <input checked="checked" class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
+          <label class="form-check-label" for="user_misc_1"> Foo</label>
         </div>
         <div class="form-check">
-          <label class="form-check-label" for="user_misc_2">
-            <input checked="checked" class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" /> Bar</label>
+          <input checked="checked" class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
+          <label class="form-check-label" for="user_misc_2"> Bar</label>
         </div>
       </div>
     HTML
@@ -243,8 +243,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-group">
         <label for="user_misc">Misc</label>
         <div class="form-check">
+          <input class="form-check-input" id="user_misc_foo_st" name="user[misc][]" type="checkbox" value="Foo St" />
           <label class="form-check-label" for="user_misc_foo_st">
-            <input class="form-check-input" id="user_misc_foo_st" name="user[misc][]" type="checkbox" value="Foo St" />
             Foo St
           </label>
         </div>
@@ -260,14 +260,14 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-group">
         <label for="user_misc">Misc</label>
         <div class="form-check">
+          <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_misc_1">
-            <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
             ooF
           </label>
         </div>
         <div class="form-check">
+          <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
           <label class="form-check-label" for="user_misc_2">
-            <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
             raB
           </label>
         </div>
@@ -284,14 +284,14 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-group">
         <label for="user_misc">Misc</label>
         <div class="form-check">
+          <input class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
           <label class="form-check-label" for="user_misc_address_1">
-            <input class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
             Foo
           </label>
         </div>
         <div class="form-check">
+          <input class="form-check-input" id="user_misc_address_2" name="user[misc][]" type="checkbox" value="address_2" />
           <label class="form-check-label" for="user_misc_address_2">
-            <input class="form-check-input" id="user_misc_address_2" name="user[misc][]" type="checkbox" value="address_2" />
             Bar
           </label>
         </div>
@@ -307,14 +307,14 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-group">
         <label for="user_misc">Misc</label>
         <div class="form-check">
+          <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_misc_1">
-            <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
             ooF
           </label>
         </div>
         <div class="form-check">
+          <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
           <label class="form-check-label" for="user_misc_2">
-            <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
             raB
           </label>
         </div>
@@ -331,14 +331,14 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-group">
         <label for="user_misc">Misc</label>
         <div class="form-check">
+          <input class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
           <label class="form-check-label" for="user_misc_address_1">
-            <input class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
             Foo
           </label>
         </div>
         <div class="form-check">
+          <input class="form-check-input" id="user_misc_address_2" name="user[misc][]" type="checkbox" value="address_2" />
           <label class="form-check-label" for="user_misc_address_2">
-            <input class="form-check-input" id="user_misc_address_2" name="user[misc][]" type="checkbox" value="address_2" />
             Bar
           </label>
         </div>
@@ -355,14 +355,14 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-group">
         <label for="user_misc">Misc</label>
         <div class="form-check">
+          <input checked="checked" class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
           <label class="form-check-label" for="user_misc_address_1">
-            <input checked="checked" class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
             Foo
           </label>
         </div>
         <div class="form-check">
+          <input class="form-check-input" id="user_misc_address_2" name="user[misc][]" type="checkbox" value="address_2" />
           <label class="form-check-label" for="user_misc_address_2">
-            <input class="form-check-input" id="user_misc_address_2" name="user[misc][]" type="checkbox" value="address_2" />
             Bar
           </label>
         </div>
@@ -380,14 +380,14 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-group">
         <label for="user_misc">Misc</label>
         <div class="form-check">
+          <input checked="checked" class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
           <label class="form-check-label" for="user_misc_address_1">
-            <input checked="checked" class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
             Foo
           </label>
         </div>
         <div class="form-check">
+          <input checked="checked" class="form-check-input" id="user_misc_address_2" name="user[misc][]" type="checkbox" value="address_2" />
           <label class="form-check-label" for="user_misc_address_2">
-            <input checked="checked" class="form-check-input" id="user_misc_address_2" name="user[misc][]" type="checkbox" value="address_2" />
             Bar
           </label>
         </div>

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -101,7 +101,6 @@ class BootstrapFormTest < ActionView::TestCase
     assert_equivalent_xml expected, bootstrap_form_tag(url: '/users') { |f| f.text_field :email, name: 'NAME', id: "ID" }
   end
 
-  # TODO: difference in rendering between 5.0 and 5.1?
   test "bootstrap_form_tag allows an empty name for checkboxes" do
     if ::Rails::VERSION::STRING >= '5.1'
       id = 'misc'
@@ -114,9 +113,9 @@ class BootstrapFormTest < ActionView::TestCase
     <form accept-charset="UTF-8" action="/users" method="post" role="form">
       <input name="utf8" type="hidden" value="&#x2713;" />
       <div class="form-check">
-        <label class="form-check-label" for="#{id}"><input name="#{name}" type="hidden" value="0" />
-          <input class="form-check-input" id="#{id}" name="#{name}" type="checkbox" value="1" /> Misc
-        </label>
+        <input class="form-check-input" id="#{id}" name="#{name}" type="checkbox" value="1" />
+        <input name="#{name}" type="hidden" value="0" />
+        <label class="form-check-label" for="#{id}"> Misc</label>
       </div>
     </form>
     HTML

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -7,7 +7,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "radio_button is wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="radio">
+      <div class="form-check">
         <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
         <label for="user_misc_1">
           This is a radio button
@@ -19,7 +19,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "radio_button disabled label is set correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="radio disabled">
+      <div class="form-check disabled">
         <input disabled="disabled" id="user_misc_1" name="user[misc]" type="radio" value="1" />
         <label for="user_misc_1">
           This is a radio button
@@ -31,7 +31,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "radio_button label class is set correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="radio">
+      <div class="form-check">
         <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
         <label class="btn" for="user_misc_1">
           This is a radio button
@@ -43,7 +43,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "radio_button 'id' attribute is used to specify label 'for' attribute" do
     expected = <<-HTML.strip_heredoc
-      <div class="radio">
+      <div class="form-check">
         <input id="custom_id" name="user[misc]" type="radio" value="1" />
         <label for="custom_id">
           This is a radio button
@@ -88,7 +88,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
         <label for="user_misc">This is a radio button collection</label>
-        <div class="radio">
+        <div class="form-check">
           <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
           <label for="user_misc_1">
             Foobar
@@ -106,11 +106,11 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
         <label for="user_misc">Misc</label>
-        <div class="radio">
+        <div class="form-check">
           <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
           <label for="user_misc_1"> Foo</label>
         </div>
-        <div class="radio">
+        <div class="form-check">
           <input id="user_misc_2" name="user[misc]" type="radio" value="2" />
           <label for="user_misc_2"> Bar</label>
         </div>
@@ -140,11 +140,11 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
         <label for="user_misc">Misc</label>
-        <div class="radio">
+        <div class="form-check">
           <input checked="checked" id="user_misc_1" name="user[misc]" type="radio" value="1" />
           <label for="user_misc_1"> Foo</label>
         </div>
-        <div class="radio">
+        <div class="form-check">
           <input id="user_misc_2" name="user[misc]" type="radio" value="2" />
           <label for="user_misc_2"> Bar</label>
         </div>
@@ -159,7 +159,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
         <label for="user_misc">This is a radio button collection</label>
-        <div class="radio">
+        <div class="form-check">
           <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
           <label for="user_misc_1"> rabooF</label>
         </div>
@@ -175,7 +175,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
         <label for="user_misc">This is a radio button collection</label>
-        <div class="radio">
+        <div class="form-check">
           <input id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
           <label for="user_misc_address_1"> Foobar</label>
         </div>
@@ -191,11 +191,11 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
         <label for="user_misc">Misc</label>
-        <div class="radio">
+        <div class="form-check">
           <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
           <label for="user_misc_1"> ooF</label>
         </div>
-        <div class="radio">
+        <div class="form-check">
           <input id="user_misc_2" name="user[misc]" type="radio" value="2" />
           <label for="user_misc_2"> raB</label>
         </div>
@@ -210,11 +210,11 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
         <label for="user_misc">Misc</label>
-        <div class="radio">
+        <div class="form-check">
           <input id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
           <label for="user_misc_address_1"> Foo</label>
         </div>
-        <div class="radio">
+        <div class="form-check">
           <input id="user_misc_address_2" name="user[misc]" type="radio" value="address_2" />
           <label for="user_misc_address_2"> Bar</label>
         </div>
@@ -229,7 +229,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
         <label for="user_misc">This is a radio button collection</label>
-        <div class="radio">
+        <div class="form-check">
           <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
           <label for="user_misc_1"> rabooF</label>
         </div>
@@ -245,7 +245,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
         <label for="user_misc">This is a radio button collection</label>
-        <div class="radio">
+        <div class="form-check">
           <input id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
           <label for="user_misc_address_1"> Foobar</label>
         </div>
@@ -261,11 +261,11 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
         <label for="user_misc">Misc</label>
-        <div class="radio">
+        <div class="form-check">
           <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
           <label for="user_misc_1"> ooF</label>
         </div>
-        <div class="radio">
+        <div class="form-check">
           <input id="user_misc_2" name="user[misc]" type="radio" value="2" />
           <label for="user_misc_2"> raB</label>
         </div>
@@ -280,11 +280,11 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
         <label for="user_misc">Misc</label>
-        <div class="radio">
+        <div class="form-check">
           <input id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
           <label for="user_misc_address_1"> Foo</label>
         </div>
-        <div class="radio">
+        <div class="form-check">
           <input id="user_misc_address_2" name="user[misc]" type="radio" value="address_2" />
           <label for="user_misc_address_2"> Bar</label>
         </div>

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -55,8 +55,8 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "radio_button inline label is set correctly" do
     expected = <<-HTML.strip_heredoc
+      <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
       <label class="radio-inline" for="user_misc_1">
-        <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
         This is a radio button
       </label>
     HTML
@@ -65,8 +65,8 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "radio_button disabled inline label is set correctly" do
     expected = <<-HTML.strip_heredoc
+      <input disabled="disabled" id="user_misc_1" name="user[misc]" type="radio" value="1" />
       <label class="radio-inline disabled" for="user_misc_1">
-        <input disabled="disabled" id="user_misc_1" name="user[misc]" type="radio" value="1" />
         This is a radio button
       </label>
     HTML
@@ -75,8 +75,8 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "radio_button inline label class is set correctly" do
     expected = <<-HTML.strip_heredoc
+      <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
       <label class="radio-inline btn" for="user_misc_1">
-        <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
         This is a radio button
       </label>
     HTML
@@ -125,12 +125,10 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
         <label for="user_misc">Misc</label>
-        <label class="radio-inline" for="user_misc_1">
-          <input id="user_misc_1" name="user[misc]" type="radio" value="1" /> Foo
-        </label>
-        <label class="radio-inline" for="user_misc_2">
-          <input id="user_misc_2" name="user[misc]" type="radio" value="2" /> Bar
-        </label>
+        <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
+        <label class="radio-inline" for="user_misc_1"> Foo</label>
+        <input id="user_misc_2" name="user[misc]" type="radio" value="2" />
+        <label class="radio-inline" for="user_misc_2"> Bar</label>
       </div>
     HTML
 

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -8,8 +8,8 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "radio_button is wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="radio">
+        <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
         <label for="user_misc_1">
-          <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
           This is a radio button
         </label>
       </div>
@@ -20,8 +20,8 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "radio_button disabled label is set correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="radio disabled">
+        <input disabled="disabled" id="user_misc_1" name="user[misc]" type="radio" value="1" />
         <label for="user_misc_1">
-          <input disabled="disabled" id="user_misc_1" name="user[misc]" type="radio" value="1" />
           This is a radio button
         </label>
       </div>
@@ -32,8 +32,8 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "radio_button label class is set correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="radio">
+        <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
         <label class="btn" for="user_misc_1">
-          <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
           This is a radio button
         </label>
       </div>
@@ -44,8 +44,8 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "radio_button 'id' attribute is used to specify label 'for' attribute" do
     expected = <<-HTML.strip_heredoc
       <div class="radio">
+        <input id="custom_id" name="user[misc]" type="radio" value="1" />
         <label for="custom_id">
-          <input id="custom_id" name="user[misc]" type="radio" value="1" />
           This is a radio button
         </label>
       </div>
@@ -89,8 +89,8 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       <div class="form-group">
         <label for="user_misc">This is a radio button collection</label>
         <div class="radio">
+          <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
           <label for="user_misc_1">
-            <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
             Foobar
           </label>
         </div>
@@ -107,14 +107,12 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       <div class="form-group">
         <label for="user_misc">Misc</label>
         <div class="radio">
-          <label for="user_misc_1">
-            <input id="user_misc_1" name="user[misc]" type="radio" value="1" /> Foo
-          </label>
+          <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
+          <label for="user_misc_1"> Foo</label>
         </div>
         <div class="radio">
-          <label for="user_misc_2">
-            <input id="user_misc_2" name="user[misc]" type="radio" value="2" /> Bar
-          </label>
+          <input id="user_misc_2" name="user[misc]" type="radio" value="2" />
+          <label for="user_misc_2"> Bar</label>
         </div>
       </div>
     HTML
@@ -145,14 +143,12 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       <div class="form-group">
         <label for="user_misc">Misc</label>
         <div class="radio">
-          <label for="user_misc_1">
-            <input checked="checked" id="user_misc_1" name="user[misc]" type="radio" value="1" /> Foo
-          </label>
+          <input checked="checked" id="user_misc_1" name="user[misc]" type="radio" value="1" />
+          <label for="user_misc_1"> Foo</label>
         </div>
         <div class="radio">
-          <label for="user_misc_2">
-            <input id="user_misc_2" name="user[misc]" type="radio" value="2" /> Bar
-          </label>
+          <input id="user_misc_2" name="user[misc]" type="radio" value="2" />
+          <label for="user_misc_2"> Bar</label>
         </div>
       </div>
     HTML
@@ -166,9 +162,8 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       <div class="form-group">
         <label for="user_misc">This is a radio button collection</label>
         <div class="radio">
-          <label for="user_misc_1">
-            <input id="user_misc_1" name="user[misc]" type="radio" value="1" /> rabooF
-          </label>
+          <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
+          <label for="user_misc_1"> rabooF</label>
         </div>
         <small class="form-text text-muted">With a help!</small>
       </div>
@@ -183,9 +178,8 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       <div class="form-group">
         <label for="user_misc">This is a radio button collection</label>
         <div class="radio">
-          <label for="user_misc_address_1">
-            <input id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" /> Foobar
-          </label>
+          <input id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
+          <label for="user_misc_address_1"> Foobar</label>
         </div>
         <small class="form-text text-muted">With a help!</small>
       </div>
@@ -200,14 +194,12 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       <div class="form-group">
         <label for="user_misc">Misc</label>
         <div class="radio">
-          <label for="user_misc_1">
-            <input id="user_misc_1" name="user[misc]" type="radio" value="1" /> ooF
-          </label>
+          <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
+          <label for="user_misc_1"> ooF</label>
         </div>
         <div class="radio">
-          <label for="user_misc_2">
-            <input id="user_misc_2" name="user[misc]" type="radio" value="2" /> raB
-          </label>
+          <input id="user_misc_2" name="user[misc]" type="radio" value="2" />
+          <label for="user_misc_2"> raB</label>
         </div>
       </div>
     HTML
@@ -221,14 +213,12 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       <div class="form-group">
         <label for="user_misc">Misc</label>
         <div class="radio">
-          <label for="user_misc_address_1">
-            <input id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" /> Foo
-          </label>
+          <input id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
+          <label for="user_misc_address_1"> Foo</label>
         </div>
         <div class="radio">
-          <label for="user_misc_address_2">
-            <input id="user_misc_address_2" name="user[misc]" type="radio" value="address_2" /> Bar
-          </label>
+          <input id="user_misc_address_2" name="user[misc]" type="radio" value="address_2" />
+          <label for="user_misc_address_2"> Bar</label>
         </div>
       </div>
     HTML
@@ -242,9 +232,8 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       <div class="form-group">
         <label for="user_misc">This is a radio button collection</label>
         <div class="radio">
-          <label for="user_misc_1">
-            <input id="user_misc_1" name="user[misc]" type="radio" value="1" /> rabooF
-          </label>
+          <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
+          <label for="user_misc_1"> rabooF</label>
         </div>
         <small class="form-text text-muted">With a help!</small>
       </div>
@@ -259,9 +248,8 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       <div class="form-group">
         <label for="user_misc">This is a radio button collection</label>
         <div class="radio">
-          <label for="user_misc_address_1">
-            <input id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" /> Foobar
-          </label>
+          <input id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
+          <label for="user_misc_address_1"> Foobar</label>
         </div>
         <small class="form-text text-muted">With a help!</small>
       </div>
@@ -276,14 +264,12 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       <div class="form-group">
         <label for="user_misc">Misc</label>
         <div class="radio">
-          <label for="user_misc_1">
-            <input id="user_misc_1" name="user[misc]" type="radio" value="1" /> ooF
-          </label>
+          <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
+          <label for="user_misc_1"> ooF</label>
         </div>
         <div class="radio">
-          <label for="user_misc_2">
-            <input id="user_misc_2" name="user[misc]" type="radio" value="2" /> raB
-          </label>
+          <input id="user_misc_2" name="user[misc]" type="radio" value="2" />
+          <label for="user_misc_2"> raB</label>
         </div>
       </div>
     HTML
@@ -297,14 +283,12 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       <div class="form-group">
         <label for="user_misc">Misc</label>
         <div class="radio">
-          <label for="user_misc_address_1">
-            <input id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" /> Foo
-          </label>
+          <input id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
+          <label for="user_misc_address_1"> Foo</label>
         </div>
         <div class="radio">
-          <label for="user_misc_address_2">
-            <input id="user_misc_address_2" name="user[misc]" type="radio" value="address_2" /> Bar
-          </label>
+          <input id="user_misc_address_2" name="user[misc]" type="radio" value="address_2" />
+          <label for="user_misc_address_2"> Bar</label>
         </div>
       </div>
     HTML


### PR DESCRIPTION
Bootstrap 4 no longer wraps radio buttons and check boxes inside the label. Previously it was:
```
<div class="form-check">
  <label class="form-check-label" for="user_misc_1">
    <input class="form-check-input" type="checkbox" value="1" name="user[misc][]" id="user_misc_1" />
    Foo
  </label>
</div>

<div class="radio">
  <label for="user_misc_1">
    <input type="radio" value="1" name="user[misc]" id="user_misc_1" />
    Foo
  </label>
</div>
```
Where it should be:
```
<div class="form-check">
  <input class="form-check-input" type="checkbox" value="" id="defaultCheck1">
  <label class="form-check-label" for="defaultCheck1">
    Default checkbox
  </label>
</div>

<div class="form-check">
  <input class="form-check-input" type="radio" name="exampleRadios" id="exampleRadios1" value="option1" checked>
  <label class="form-check-label" for="exampleRadios1">
    Default radio
  </label>
</div>
```

I really couldn't see any sensible way to change the rendering without doing a little bit of simplifying of the code in the `radio_button_with_bootstrap` and `check_box_with_bootstrap` helpers. I suspect more refactoring/simplification could be done in those methods, but I thought now is not the time to do that.

I would appreciate it if someone who's a little more knowledgeable about Bootstrap 4, makes sure that I changed the test cases correctly.
