### PR TITLE
Update `hide_label` and `skip_label` for check boxes and radio buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ In addition to these necessary markup changes, the bootstrap_form API itself has
 * Built-in support for the `nested_form` gem has been completely removed
 * The `icon` option is no longer supported (Bootstrap v4 does not include icons)
 * The deprecated Rails methods `check_boxes_collection` and `radio_buttons_collection` have been removed
+* `hide_label: true` and `skip_label: true` on individual check boxes and radio buttons apply Bootstrap 4 markup. This means the appearance of a page may change if you're upgrading from the Bootstrap 3 version of `bootstrap_form`, and you used `check_box` or `radio_button` with either of those options
 * Your contribution here!
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -64,10 +64,9 @@ This generates the following HTML:
     <input class="form-control" id="user_password" name="user[password]" type="password">
   </div>
   <div class="form-check">
-    <label for="user_remember_me">
-      <input name="user[remember_me]" type="hidden" value="0">
-      <input id="user_remember_me" name="user[remember_me]" type="checkbox" value="1"> Remember me
-    </label>
+    <input name="user[remember_me]" type="hidden" value="0">
+    <input class="form-check-input" id="user_remember_me" name="user[remember_me]" type="checkbox" value="1">
+    <label class="form-check-label" for="user_remember_me">Remember me</label>
   </div>
   <input class="btn btn-secondary" name="commit" type="submit" value="Log In">
 </form>
@@ -114,9 +113,9 @@ This generates:
     <small class="form-text text-muted">A good password should be at least six characters long</small>
   </div>
   <div class="form-check">
-    <label class="form-check-label" for="user_remember_me">
-    <input name="user[remember_me]" type="hidden" value="0" />
-    <input class="form-check-input" type="checkbox" value="1" name="user[remember_me]" /> Remember me</label>
+    <input name="user[remember_me]" type="hidden" value="0">
+    <input class="form-check-input" id="user_remember_me" name="user[remember_me]" type="checkbox" value="1">
+    <label class="form-check-label" for="user_remember_me">Remember me</label>
   </div>
   <input type="submit" name="commit" value="Log In" class="btn btn-secondary" data-disable-with="Log In" />
 </form>

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -155,7 +155,7 @@ module BootstrapForm
 
     def radio_button_with_bootstrap(name, value, *args)
       options = args.extract_options!.symbolize_keys!
-      radio_options = options.except(:label, :label_class, :help, :inline, :custom, :skip_label)
+      radio_options = options.except(:label, :label_class, :help, :inline, :custom, :hide_label, :skip_label)
       if options[:custom]
         radio_options[:class] = ["custom-control-input", options[:class]].compact.join(' ')
       else
@@ -165,22 +165,25 @@ module BootstrapForm
       radio_html = radio_button_without_bootstrap(name, value, *args)
 
       disabled_class = " disabled" if options[:disabled]
-      label_class    = options[:label_class]
+      label_classes  = [options[:label_class]]
+      label_classes << "sr-only" if options[:hide_label]
 
       if options[:custom]
         div_class = ["custom-control", "custom-radio"]
         div_class.append("custom-control-inline") if options[:inline]
+        label_class = label_classes.prepend("custom-control-label").compact.join(" ")
         content_tag(:div, class: div_class.compact.join(" ")) do
           if options[:skip_label]
             radio_html
           else
-            radio_html.concat(label(name, options[:label], value: value, class: ["custom-control-label", label_class].compact.join(" ")))
+            # TODO: Notice we don't seem to pass the ID into the custom control.
+            radio_html.concat(label(name, options[:label], value: value, class: label_class))
           end
         end
       else
         wrapper_class = "form-check"
         wrapper_class += " form-check-inline" if options[:inline]
-        label_class = ["form-check-label", label_class].compact.join(" ")
+        label_class = label_classes.prepend("form-check-label").compact.join(" ")
         content_tag(:div, class: "#{wrapper_class}#{disabled_class}") do
           if options[:skip_label]
             radio_html

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -130,7 +130,7 @@ module BootstrapForm
       end
 
       label_classes = [options[:label_class]]
-      label_classes << "sr-only" if options[:hide_label]
+      label_classes << hide_class if options[:hide_label]
 
       if options[:custom]
         div_class = ["custom-control", "custom-checkbox"]
@@ -178,7 +178,7 @@ module BootstrapForm
 
       disabled_class = " disabled" if options[:disabled]
       label_classes  = [options[:label_class]]
-      label_classes << "sr-only" if options[:hide_label]
+      label_classes << hide_class if options[:hide_label]
 
       if options[:custom]
         div_class = ["custom-control", "custom-radio"]

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -106,12 +106,14 @@ module BootstrapForm
     def check_box_with_bootstrap(name, options = {}, checked_value = "1", unchecked_value = "0", &block)
       options = options.symbolize_keys!
       check_box_options = options.except(:label, :label_class, :help, :inline, :custom, :hide_label, :skip_label)
+      check_box_classes = [check_box_options[:class]]
+      check_box_classes << "position-static" if options[:skip_label]
       if options[:custom]
         validation = nil
         validation = "is-invalid" if has_error?(name)
-        check_box_options[:class] = ["custom-control-input", validation, check_box_options[:class]].compact.join(' ')
+        check_box_options[:class] = (["custom-control-input", validation] + check_box_classes).compact.join(' ')
       else
-        check_box_options[:class] = ["form-check-input", check_box_options[:class]].compact.join(' ')
+        check_box_options[:class] = (["form-check-input"] + check_box_classes).compact.join(' ')
       end
 
       checkbox_html = check_box_without_bootstrap(name, check_box_options, checked_value, unchecked_value)
@@ -164,10 +166,12 @@ module BootstrapForm
     def radio_button_with_bootstrap(name, value, *args)
       options = args.extract_options!.symbolize_keys!
       radio_options = options.except(:label, :label_class, :help, :inline, :custom, :hide_label, :skip_label)
+      radio_classes = [options[:class]]
+      radio_classes << "position-static" if options[:skip_label]
       if options[:custom]
-        radio_options[:class] = ["custom-control-input", options[:class]].compact.join(' ')
+        radio_options[:class] = radio_classes.prepend("custom-control-input").compact.join(' ')
       else
-        radio_options[:class] = ["form-check-input", options[:class]].compact.join(' ')
+        radio_options[:class] = radio_classes.prepend("form-check-input").compact.join(' ')
       end
       args << radio_options
       radio_html = radio_button_without_bootstrap(name, value, *args)

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -105,7 +105,7 @@ module BootstrapForm
 
     def check_box_with_bootstrap(name, options = {}, checked_value = "1", unchecked_value = "0", &block)
       options = options.symbolize_keys!
-      check_box_options = options.except(:label, :label_class, :help, :inline, :custom, :skip_label)
+      check_box_options = options.except(:label, :label_class, :help, :inline, :custom, :hide_label, :skip_label)
       if options[:custom]
         validation = nil
         validation = "is-invalid" if has_error?(name)
@@ -127,26 +127,34 @@ module BootstrapForm
           "#{name}_#{checked_value.to_s.gsub(/\s/, "_").gsub(/[^-\w]/, "").downcase}"
       end
 
-      label_class = options[:label_class]
+      label_classes = [options[:label_class]]
+      label_classes << "sr-only" if options[:hide_label]
 
       if options[:custom]
         div_class = ["custom-control", "custom-checkbox"]
         div_class.append("custom-control-inline") if options[:inline]
+        label_class = label_classes.prepend("custom-control-label").compact.join(" ")
         content_tag(:div, class: div_class.compact.join(" ")) do
-          checkbox_html.concat(label(label_name, label_description, class: ["custom-control-label", label_class].compact.join(" ")))
+          if options[:skip_label]
+            checkbox_html
+          else
+            # TODO: Notice we don't seem to pass the ID into the custom control.
+            checkbox_html.concat(label(label_name, label_description, class: label_class))
+          end
         end
       else
         wrapper_class = "form-check"
         wrapper_class += " form-check-inline" if options[:inline]
+        label_class = label_classes.prepend("form-check-label").compact.join(" ")
         content_tag(:div, class: wrapper_class) do
-          # if options[:skip_label]
-          #   checkbox_html
-          # else
+          if options[:skip_label]
+            checkbox_html
+          else
             checkbox_html
               .concat(label(label_name,
                             label_description,
-                            { class: ["form-check-label", label_class].compact.join(" ") }.merge(options[:id].present? ? { for: options[:id] } : {})))
-          # end
+                            { class: label_class }.merge(options[:id].present? ? { for: options[:id] } : {})))
+          end
         end
       end
     end

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -107,7 +107,7 @@ module BootstrapForm
       options = options.symbolize_keys!
       check_box_options = options.except(:label, :label_class, :help, :inline, :custom, :hide_label, :skip_label)
       check_box_classes = [check_box_options[:class]]
-      check_box_classes << "position-static" if options[:skip_label]
+      check_box_classes << "position-static" if options[:skip_label] || options[:hide_label]
       if options[:custom]
         validation = nil
         validation = "is-invalid" if has_error?(name)
@@ -167,7 +167,7 @@ module BootstrapForm
       options = args.extract_options!.symbolize_keys!
       radio_options = options.except(:label, :label_class, :help, :inline, :custom, :hide_label, :skip_label)
       radio_classes = [options[:class]]
-      radio_classes << "position-static" if options[:skip_label]
+      radio_classes << "position-static" if options[:skip_label] || options[:hide_label]
       if options[:custom]
         radio_options[:class] = radio_classes.prepend("custom-control-input").compact.join(' ')
       else

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -105,7 +105,7 @@ module BootstrapForm
 
     def check_box_with_bootstrap(name, options = {}, checked_value = "1", unchecked_value = "0", &block)
       options = options.symbolize_keys!
-      check_box_options = options.except(:label, :label_class, :help, :inline, :custom)
+      check_box_options = options.except(:label, :label_class, :help, :inline, :custom, :skip_label)
       if options[:custom]
         validation = nil
         validation = "is-invalid" if has_error?(name)
@@ -139,10 +139,14 @@ module BootstrapForm
         wrapper_class = "form-check"
         wrapper_class += " form-check-inline" if options[:inline]
         content_tag(:div, class: wrapper_class) do
-          checkbox_html
-            .concat(label(label_name,
-                          label_description,
-                          { class: ["form-check-label", label_class].compact.join(" ") }.merge(options[:id].present? ? { for: options[:id] } : {})))
+          # if options[:skip_label]
+          #   checkbox_html
+          # else
+            checkbox_html
+              .concat(label(label_name,
+                            label_description,
+                            { class: ["form-check-label", label_class].compact.join(" ") }.merge(options[:id].present? ? { for: options[:id] } : {})))
+          # end
         end
       end
     end
@@ -151,7 +155,7 @@ module BootstrapForm
 
     def radio_button_with_bootstrap(name, value, *args)
       options = args.extract_options!.symbolize_keys!
-      radio_options = options.except(:label, :label_class, :help, :inline, :custom)
+      radio_options = options.except(:label, :label_class, :help, :inline, :custom, :skip_label)
       if options[:custom]
         radio_options[:class] = ["custom-control-input", options[:class]].compact.join(' ')
       else
@@ -174,8 +178,12 @@ module BootstrapForm
         wrapper_class += " form-check-inline" if options[:inline]
         label_class = ["form-check-label", label_class].compact.join(" ")
         content_tag(:div, class: "#{wrapper_class}#{disabled_class}") do
-          radio_html
-            .concat(label(name, options[:label], { value: value, class: label_class }.merge(options[:id].present? ? { for: options[:id] } : {})))
+          if options[:skip_label]
+            radio_html
+          else
+            radio_html
+              .concat(label(name, options[:label], { value: value, class: label_class }.merge(options[:id].present? ? { for: options[:id] } : {})))
+          end
         end
       end
     end

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -171,7 +171,11 @@ module BootstrapForm
         div_class = ["custom-control", "custom-radio"]
         div_class.append("custom-control-inline") if options[:inline]
         content_tag(:div, class: div_class.compact.join(" ")) do
-          radio_html.concat(label(name, options[:label], value: value, class: ["custom-control-label", label_class].compact.join(" ")))
+          if options[:skip_label]
+            radio_html
+          else
+            radio_html.concat(label(name, options[:label], value: value, class: ["custom-control-label", label_class].compact.join(" ")))
+          end
         end
       else
         wrapper_class = "form-check"

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -18,6 +18,29 @@ class BootstrapCheckboxTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.check_box(:terms, label: 'I agree to the terms')
   end
 
+  test "check_box is wrapped correctly for hide_label" do
+    expected = <<-HTML.strip_heredoc
+      <div class="form-check">
+        <input name="user[terms]" type="hidden" value="0" />
+        <input class="form-check-input position-static" id="user_terms" name="user[terms]" type="checkbox" value="1" />
+        <label class="form-check-label sr-only" for="user_terms">
+          I agree to the terms
+        </label>
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.check_box(:terms, label: 'I agree to the terms', hide_label: true)
+  end
+
+  test "check_box is wrapped correctly for skip_label" do
+    expected = <<-HTML.strip_heredoc
+      <div class="form-check">
+        <input name="user[terms]" type="hidden" value="0" />
+        <input class="form-check-input position-static" id="user_terms" name="user[terms]" type="checkbox" value="1" />
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.check_box(:terms, label: 'I agree to the terms', skip_label: true)
+  end
+
   test "disabled check_box has proper wrapper classes" do
     expected = <<-HTML.strip_heredoc
       <div class="form-check">

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -18,29 +18,6 @@ class BootstrapCheckboxTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.check_box(:terms, label: 'I agree to the terms')
   end
 
-  test "check_box is wrapped correctly for hide_label" do
-    expected = <<-HTML.strip_heredoc
-      <div class="form-check">
-        <input name="user[terms]" type="hidden" value="0" />
-        <input class="form-check-input position-static" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-check-label sr-only" for="user_terms">
-          I agree to the terms
-        </label>
-      </div>
-    HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: 'I agree to the terms', hide_label: true)
-  end
-
-  test "check_box is wrapped correctly for skip_label" do
-    expected = <<-HTML.strip_heredoc
-      <div class="form-check">
-        <input name="user[terms]" type="hidden" value="0" />
-        <input class="form-check-input position-static" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-      </div>
-    HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: 'I agree to the terms', skip_label: true)
-  end
-
   test "disabled check_box has proper wrapper classes" do
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
@@ -489,7 +466,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
-        <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
+        <input class="form-check-input position-static" id="user_terms" name="user[terms]" type="checkbox" value="1" />
         <label class="form-check-label sr-only" for="user_terms">I agree to the terms</label>
       </div>
     HTML
@@ -510,7 +487,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="custom-control custom-checkbox">
         <input name="user[terms]" type="hidden" value="0" />
-        <input class="custom-control-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
+        <input class="custom-control-input position-static" id="user_terms" name="user[terms]" type="checkbox" value="1" />
         <label class="custom-control-label sr-only" for="user_terms">I agree to the terms</label>
       </div>
     HTML

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -451,4 +451,46 @@ class BootstrapCheckboxTest < ActionView::TestCase
     HTML
     assert_equivalent_xml expected, @builder.check_box(:terms, {label: 'I agree to the terms', inline: true, disabled: true, custom: true})
   end
+
+  test "check_box skip label" do
+    expected = <<-HTML.strip_heredoc
+      <div class="form-check">
+        <input name="user[terms]" type="hidden" value="0" />
+        <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.check_box(:terms, label: 'I agree to the terms', skip_label: true)
+  end
+
+  test "check_box hide label" do
+    expected = <<-HTML.strip_heredoc
+      <div class="form-check">
+        <input name="user[terms]" type="hidden" value="0" />
+        <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
+        <label class="form-check-label sr-only" for="user_terms">I agree to the terms</label>
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.check_box(:terms, label: 'I agree to the terms', hide_label: true)
+  end
+
+  test "check_box skip label with custom option set" do
+    expected = <<-HTML.strip_heredoc
+      <div class="custom-control custom-checkbox">
+        <input name="user[terms]" type="hidden" value="0" />
+        <input class="custom-control-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.check_box(:terms, {label: 'I agree to the terms', custom: true, skip_label: true})
+  end
+
+  test "check_box hide label with custom option set" do
+    expected = <<-HTML.strip_heredoc
+      <div class="custom-control custom-checkbox">
+        <input name="user[terms]" type="hidden" value="0" />
+        <input class="custom-control-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
+        <label class="custom-control-label sr-only" for="user_terms">I agree to the terms</label>
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.check_box(:terms, {label: 'I agree to the terms', custom: true, hide_label: true})
+  end
 end

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -456,7 +456,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
-        <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
+        <input class="form-check-input position-static" id="user_terms" name="user[terms]" type="checkbox" value="1" />
       </div>
     HTML
     assert_equivalent_xml expected, @builder.check_box(:terms, label: 'I agree to the terms', skip_label: true)
@@ -477,7 +477,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="custom-control custom-checkbox">
         <input name="user[terms]" type="hidden" value="0" />
-        <input class="custom-control-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
+        <input class="custom-control-input position-static" id="user_terms" name="user[terms]" type="checkbox" value="1" />
       </div>
     HTML
     assert_equivalent_xml expected, @builder.check_box(:terms, {label: 'I agree to the terms', custom: true, skip_label: true})

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -360,4 +360,24 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     HTML
     assert_equivalent_xml expected, @builder.radio_button(:misc, '1', {label: 'This is a radio button', custom: true, skip_label: true})
   end
+
+  test "radio button hide label" do
+    expected = <<-HTML.strip_heredoc
+      <div class="form-check">
+        <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
+        <label class="form-check-label sr-only" for="user_misc_1">This is a radio button</label>
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.radio_button(:misc, '1', label: 'This is a radio button', hide_label: true)
+  end
+
+  test "radio button hide label with custom option set" do
+    expected = <<-HTML.strip_heredoc
+      <div class="custom-control custom-radio">
+        <input class="custom-control-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
+        <label class="custom-control-label sr-only" for="user_misc_1">This is a radio button</label>
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.radio_button(:misc, '1', {label: 'This is a radio button', custom: true, hide_label: true})
+  end
 end

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -343,12 +343,21 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.radio_button(:misc, '1', {label: 'This is a radio button', inline: true, disabled: true, custom: true})
   end
 
-  test "skip label" do
+  test "radio button skip label" do
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
         <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
       </div>
     HTML
     assert_equivalent_xml expected, @builder.radio_button(:misc, '1', label: 'This is a radio button', skip_label: true)
+  end
+
+  test "radio button skip label with custom option set" do
+    expected = <<-HTML.strip_heredoc
+      <div class="custom-control custom-radio">
+        <input class="custom-control-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.radio_button(:misc, '1', {label: 'This is a radio button', custom: true, skip_label: true})
   end
 end

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -17,6 +17,27 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.radio_button(:misc, '1', label: 'This is a radio button')
   end
 
+  test "radio_button is wrapped correctly for hide_label" do
+    expected = <<-HTML.strip_heredoc
+      <div class="form-check">
+        <input class="form-check-input position-static" id="user_misc_1" name="user[misc]" type="radio" value="1" />
+        <label class="form-check-label sr-only" for="user_misc_1">
+          This is a radio button
+        </label>
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.radio_button(:misc, '1', label: 'This is a radio button')
+  end
+
+  test "radio_button is wrapped correctly for skip_label" do
+    expected = <<-HTML.strip_heredoc
+      <div class="form-check">
+        <input class="form-check-input position-static" id="user_misc_1" name="user[misc]" type="radio" value="1" />
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.radio_button(:misc, '1', label: 'This is a radio button')
+  end
+
   test "radio_button disabled label is set correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-check disabled">

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -343,4 +343,12 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.radio_button(:misc, '1', {label: 'This is a radio button', inline: true, disabled: true, custom: true})
   end
 
+  test "skip label" do
+    expected = <<-HTML.strip_heredoc
+      <div class="form-check">
+        <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.radio_button(:misc, '1', label: 'This is a radio button', skip_label: true)
+  end
 end

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -26,7 +26,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.radio_button(:misc, '1', label: 'This is a radio button')
+    assert_equivalent_xml expected, @builder.radio_button(:misc, '1', label: 'This is a radio button', hide_label: true)
   end
 
   test "radio_button is wrapped correctly for skip_label" do
@@ -35,7 +35,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         <input class="form-check-input position-static" id="user_misc_1" name="user[misc]" type="radio" value="1" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.radio_button(:misc, '1', label: 'This is a radio button')
+    assert_equivalent_xml expected, @builder.radio_button(:misc, '1', label: 'This is a radio button', skip_label: true)
   end
 
   test "radio_button disabled label is set correctly" do

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -346,21 +346,11 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "radio button skip label" do
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
-        <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
+        <input class="form-check-input position-static" id="user_misc_1" name="user[misc]" type="radio" value="1" />
       </div>
     HTML
     assert_equivalent_xml expected, @builder.radio_button(:misc, '1', label: 'This is a radio button', skip_label: true)
   end
-
-  test "radio button skip label with custom option set" do
-    expected = <<-HTML.strip_heredoc
-      <div class="custom-control custom-radio">
-        <input class="custom-control-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-      </div>
-    HTML
-    assert_equivalent_xml expected, @builder.radio_button(:misc, '1', {label: 'This is a radio button', custom: true, skip_label: true})
-  end
-
   test "radio button hide label" do
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
@@ -369,6 +359,16 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       </div>
     HTML
     assert_equivalent_xml expected, @builder.radio_button(:misc, '1', label: 'This is a radio button', hide_label: true)
+  end
+
+
+  test "radio button skip label with custom option set" do
+    expected = <<-HTML.strip_heredoc
+    <div class="custom-control custom-radio">
+      <input class="custom-control-input position-static" id="user_misc_1" name="user[misc]" type="radio" value="1" />
+    </div>
+    HTML
+    assert_equivalent_xml expected, @builder.radio_button(:misc, '1', {label: 'This is a radio button', custom: true, skip_label: true})
   end
 
   test "radio button hide label with custom option set" do

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -17,27 +17,6 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.radio_button(:misc, '1', label: 'This is a radio button')
   end
 
-  test "radio_button is wrapped correctly for hide_label" do
-    expected = <<-HTML.strip_heredoc
-      <div class="form-check">
-        <input class="form-check-input position-static" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-check-label sr-only" for="user_misc_1">
-          This is a radio button
-        </label>
-      </div>
-    HTML
-    assert_equivalent_xml expected, @builder.radio_button(:misc, '1', label: 'This is a radio button', hide_label: true)
-  end
-
-  test "radio_button is wrapped correctly for skip_label" do
-    expected = <<-HTML.strip_heredoc
-      <div class="form-check">
-        <input class="form-check-input position-static" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-      </div>
-    HTML
-    assert_equivalent_xml expected, @builder.radio_button(:misc, '1', label: 'This is a radio button', skip_label: true)
-  end
-
   test "radio_button disabled label is set correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-check disabled">
@@ -375,7 +354,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "radio button hide label" do
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
-        <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
+        <input class="form-check-input position-static" id="user_misc_1" name="user[misc]" type="radio" value="1" />
         <label class="form-check-label sr-only" for="user_misc_1">This is a radio button</label>
       </div>
     HTML
@@ -395,7 +374,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "radio button hide label with custom option set" do
     expected = <<-HTML.strip_heredoc
       <div class="custom-control custom-radio">
-        <input class="custom-control-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
+        <input class="custom-control-input position-static" id="user_misc_1" name="user[misc]" type="radio" value="1" />
         <label class="custom-control-label sr-only" for="user_misc_1">This is a radio button</label>
       </div>
     HTML


### PR DESCRIPTION
This PR updates markup for check boxes and radio buttons to Bootstrap 4. It applies to the `radio` and `check_box` helpers only, not the `collection_radio_buttons` and `collection_check_boxes`. The collection versions should probably be discussed under #412.

Further clean-up of this code is possible, but an attempt was made to minimize changes (not always successful, mind you).

This is part of the response to #395.
