### PR TITLE
Move errors inside input-group and form-group.

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -38,7 +38,7 @@ module BootstrapForm
 
       define_method(with_method_name) do |name, options = {}|
         form_group_builder(name, options) do
-          prepend_and_append_and_error_input(name, options) do
+          prepend_and_append_input(name, options) do
             send(without_method_name, name, options)
           end
         end
@@ -71,7 +71,7 @@ module BootstrapForm
 
     def select_with_bootstrap(method, choices = nil, options = {}, html_options = {}, &block)
       form_group_builder(method, options, html_options) do
-        prepend_and_append_and_error_input(method, options) do
+        prepend_and_append_input(method, options) do
           select_without_bootstrap(method, choices, options, html_options, &block)
         end
       end

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -53,7 +53,9 @@ module BootstrapForm
 
       define_method(with_method_name) do |name, options = {}, html_options = {}|
         form_group_builder(name, options, html_options) do
-          content_tag(:div, send(without_method_name, name, options, html_options), class: control_specific_class(method_name))
+          control_error_help(name, options) do
+            content_tag(:div, send(without_method_name, name, options, html_options), class: control_specific_class(method_name))
+          end
         end
       end
 

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -38,7 +38,7 @@ module BootstrapForm
 
       define_method(with_method_name) do |name, options = {}|
         form_group_builder(name, options) do
-          prepend_and_append_input(name, options) do
+          prepend_and_append_and_error_input(name, options) do
             send(without_method_name, name, options)
           end
         end
@@ -71,7 +71,7 @@ module BootstrapForm
 
     def select_with_bootstrap(method, choices = nil, options = {}, html_options = {}, &block)
       form_group_builder(method, options, html_options) do
-        prepend_and_append_input(method, options) do
+        prepend_and_append_and_error_input(method, options) do
           select_without_bootstrap(method, choices, options, html_options, &block)
         end
       end
@@ -128,12 +128,15 @@ module BootstrapForm
       end
 
       label_class = options[:label_class]
+      error_text = generate_help(name, options.delete(:help)).to_s
 
       if options[:custom]
         div_class = ["custom-control", "custom-checkbox"]
         div_class.append("custom-control-inline") if options[:inline]
         content_tag(:div, class: div_class.compact.join(" ")) do
-          checkbox_html.concat(label(label_name, label_description, class: ["custom-control-label", label_class].compact.join(" ")))
+          checkbox_html
+            .concat(label(label_name, label_description, class: ["custom-control-label", label_class].compact.join(" ")))
+            .concat(error_text)
         end
       else
         wrapper_class = "form-check"
@@ -143,6 +146,7 @@ module BootstrapForm
             .concat(label(label_name,
                           label_description,
                           { class: ["form-check-label", label_class].compact.join(" ") }.merge(options[:id].present? ? { for: options[:id] } : {})))
+            .concat(error_text)
         end
       end
     end
@@ -162,12 +166,15 @@ module BootstrapForm
 
       disabled_class = " disabled" if options[:disabled]
       label_class    = options[:label_class]
+      error_text = generate_help(name, options.delete(:help)).to_s
 
       if options[:custom]
         div_class = ["custom-control", "custom-radio"]
         div_class.append("custom-control-inline") if options[:inline]
         content_tag(:div, class: div_class.compact.join(" ")) do
-          radio_html.concat(label(name, options[:label], value: value, class: ["custom-control-label", label_class].compact.join(" ")))
+          radio_html
+            .concat(label(name, options[:label], value: value, class: ["custom-control-label", label_class].compact.join(" ")))
+            .concat(error_text)
         end
       else
         wrapper_class = "form-check"
@@ -176,6 +183,7 @@ module BootstrapForm
         content_tag(:div, class: "#{wrapper_class}#{disabled_class}") do
           radio_html
             .concat(label(name, options[:label], { value: value, class: label_class }.merge(options[:id].present? ? { for: options[:id] } : {})))
+            .concat(error_text)
         end
       end
     end
@@ -211,7 +219,6 @@ module BootstrapForm
       content_tag(:div, options.except(:id, :label, :help, :icon, :label_col, :control_col, :layout)) do
         label = generate_label(options[:id], name, options[:label], options[:label_col], options[:layout]) if options[:label]
         control = capture(&block).to_s
-        control.concat(generate_help(name, options[:help]).to_s)
 
         if get_group_layout(options[:layout]) == :horizontal
           control_class = options[:control_col] || control_col
@@ -324,7 +331,7 @@ module BootstrapForm
 
       wrapper_class = css_options.delete(:wrapper_class)
       wrapper_options = css_options.delete(:wrapper)
-      help = options.delete(:help)
+      help = options[:help]
       icon = options.delete(:icon)
       label_col = options.delete(:label_col)
       control_col = options.delete(:control_col)

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -65,7 +65,9 @@ module BootstrapForm
     def file_field_with_bootstrap(name, options = {})
       options = options.reverse_merge(control_class: 'form-control-file')
       form_group_builder(name, options) do
-        file_field_without_bootstrap(name, options)
+        control_error_help(name, options) do
+          file_field_without_bootstrap(name, options)
+        end
       end
     end
 
@@ -83,7 +85,9 @@ module BootstrapForm
 
     def collection_select_with_bootstrap(method, collection, value_method, text_method, options = {}, html_options = {})
       form_group_builder(method, options, html_options) do
-        collection_select_without_bootstrap(method, collection, value_method, text_method, options, html_options)
+        control_error_help(method, options) do
+          collection_select_without_bootstrap(method, collection, value_method, text_method, options, html_options)
+        end
       end
     end
 
@@ -91,7 +95,9 @@ module BootstrapForm
 
     def grouped_collection_select_with_bootstrap(method, collection, group_method, group_label_method, option_key_method, option_value_method, options = {}, html_options = {})
       form_group_builder(method, options, html_options) do
-        grouped_collection_select_without_bootstrap(method, collection, group_method, group_label_method, option_key_method, option_value_method, options, html_options)
+        control_error_help(method, options) do
+          grouped_collection_select_without_bootstrap(method, collection, group_method, group_label_method, option_key_method, option_value_method, options, html_options)
+        end
       end
     end
 

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -136,19 +136,13 @@ module BootstrapForm
           checkbox_html.concat(label(label_name, label_description, class: ["custom-control-label", label_class].compact.join(" ")))
         end
       else
-        if options[:inline]
-          label_class = " #{label_class}" if label_class
+        wrapper_class = "form-check"
+        wrapper_class += " form-check-inline" if options[:inline]
+        content_tag(:div, class: wrapper_class) do
           checkbox_html
             .concat(label(label_name,
                           label_description,
-                          { class: "form-check-inline#{label_class}" }.merge(options[:id].present? ? { for: options[:id] } : {})))
-        else
-          content_tag(:div, class: "form-check") do
-            checkbox_html
-              .concat(label(label_name,
-                            label_description,
-                            { class: ["form-check-label", label_class].compact.join(" ") }.merge(options[:id].present? ? { for: options[:id] } : {})))
-          end
+                          { class: ["form-check-label", label_class].compact.join(" ") }.merge(options[:id].present? ? { for: options[:id] } : {})))
         end
       end
     end
@@ -176,15 +170,12 @@ module BootstrapForm
           radio_html.concat(label(name, options[:label], value: value, class: ["custom-control-label", label_class].compact.join(" ")))
         end
       else
-        label_class = " #{label_class}" if label_class
-        if options[:inline]
+        wrapper_class = "form-check"
+        wrapper_class += " form-check-inline" if options[:inline]
+        label_class = ["form-check-label", label_class].compact.join(" ")
+        content_tag(:div, class: "#{wrapper_class}#{disabled_class}") do
           radio_html
-            .concat(label(name, options[:label], { class: "form-check-label#{label_class}", value: value }.merge(options[:id].present? ? { for: options[:id] } : {})))
-        else
-          content_tag(:div, class: "form-check#{disabled_class}") do
-            radio_html
-              .concat(label(name, options[:label], { class: "form-check-label#{label_class}", value: value }.merge(options[:id].present? ? { for: options[:id] } : {})))
-          end
+            .concat(label(name, options[:label], { value: value, class: label_class }.merge(options[:id].present? ? { for: options[:id] } : {})))
         end
       end
     end

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -97,7 +97,9 @@ module BootstrapForm
 
     def time_zone_select_with_bootstrap(method, priority_zones = nil, options = {}, html_options = {})
       form_group_builder(method, options, html_options) do
-        time_zone_select_without_bootstrap(method, priority_zones, options, html_options)
+        control_error_help(method, options) do
+          time_zone_select_without_bootstrap(method, priority_zones, options, html_options)
+        end
       end
     end
 

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -38,7 +38,7 @@ module BootstrapForm
 
       define_method(with_method_name) do |name, options = {}|
         form_group_builder(name, options) do
-          prepend_and_append_input(options) do
+          prepend_and_append_input(name, options) do
             send(without_method_name, name, options)
           end
         end
@@ -71,7 +71,7 @@ module BootstrapForm
 
     def select_with_bootstrap(method, choices = nil, options = {}, html_options = {}, &block)
       form_group_builder(method, options, html_options) do
-        prepend_and_append_input(options) do
+        prepend_and_append_input(method, options) do
           select_without_bootstrap(method, choices, options, html_options, &block)
         end
       end

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -77,16 +77,28 @@ module BootstrapForm
       end
 
       def prepend_and_append_input(name, options, error_text: nil, &block)
-        options = options.extract!(:prepend, :append, :input_group_class)
+        control_error_help(name,
+                           options,
+                           prepend: options.delete(:prepend),
+                           append: options.delete(:append),
+                           error_text: error_text,
+                           &block)
+      end
+
+      ##
+      # Render a block, and add its error or help.
+      # Add prepend and append if provided.
+      def control_error_help(name, options, prepend: nil, append: nil, error_text: nil, &block)
+        options = options.extract!(:input_group_class)
         input_group_class = ["input-group", options[:input_group_class]].compact.join(' ')
 
         input = capture(&block)
 
-        input = content_tag(:div, input_group_content(options[:prepend]), class: 'input-group-prepend') + input if options[:prepend]
-        input << content_tag(:div, input_group_content(options[:append]), class: 'input-group-append') if options[:append]
+        input = content_tag(:div, input_group_content(prepend), class: 'input-group-prepend') + input if prepend
+        input << content_tag(:div, input_group_content(append), class: 'input-group-append') if append
         input << error_text
         # FIXME: TBC The following isn't right yet. Wrap if there were errors. Maybe???
-        input = content_tag(:div, input, class: input_group_class) unless options.empty?
+        input = content_tag(:div, input, class: input_group_class) unless options.empty? && prepend.nil? && append.nil?
         input
       end
 

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -69,9 +69,11 @@ module BootstrapForm
       ##
       # Add prepend and append, if any, and error if any.
       # If anything is added, the whole thing is wrapped in an input-group.
+      # FIXME: I think this has to be the other way around, i.e. we need to be
+      # able to render fields with error or help, but only sometimes with
+      # prepend and append.
       def prepend_and_append_and_error_input(name, options, &block)
-        puts "options[:help]: #{options[:help]}"
-        prepend_and_append_input(name, options, error_text: generate_help(name, options[:help]).to_s, &block)
+        prepend_and_append_input(name, options, error_text: generate_help(name, options.delete(:help)).to_s, &block)
       end
 
       def prepend_and_append_input(name, options, error_text: nil, &block)

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -66,7 +66,15 @@ module BootstrapForm
         form_group_builder(name, options, &block)
       end
 
-      def prepend_and_append_input(options, &block)
+      ##
+      # Add prepend and append, if any, and error if any.
+      # If anything is added, the whole thing is wrapped in an input-group.
+      def prepend_and_append_and_error_input(name, options, &block)
+        puts "options[:help]: #{options[:help]}"
+        prepend_and_append_input(name, options, error_text: generate_help(name, options[:help]).to_s, &block)
+      end
+
+      def prepend_and_append_input(name, options, error_text: nil, &block)
         options = options.extract!(:prepend, :append, :input_group_class)
         input_group_class = ["input-group", options[:input_group_class]].compact.join(' ')
 
@@ -74,6 +82,8 @@ module BootstrapForm
 
         input = content_tag(:div, input_group_content(options[:prepend]), class: 'input-group-prepend') + input if options[:prepend]
         input << content_tag(:div, input_group_content(options[:append]), class: 'input-group-append') if options[:append]
+        input << error_text
+        # FIXME: TBC The following isn't right yet. Wrap if there were errors. Maybe???
         input = content_tag(:div, input, class: input_group_class) unless options.empty?
         input
       end

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -69,26 +69,20 @@ module BootstrapForm
       ##
       # Add prepend and append, if any, and error if any.
       # If anything is added, the whole thing is wrapped in an input-group.
-      # FIXME: I think this has to be the other way around, i.e. we need to be
-      # able to render fields with error or help, but only sometimes with
-      # prepend and append.
-      def prepend_and_append_and_error_input(name, options, &block)
-        prepend_and_append_input(name, options, error_text: generate_help(name, options.delete(:help)).to_s, &block)
-      end
-
-      def prepend_and_append_input(name, options, error_text: nil, &block)
+      def prepend_and_append_input(name, options, &block)
         control_error_help(name,
                            options,
                            prepend: options.delete(:prepend),
                            append: options.delete(:append),
-                           error_text: error_text,
                            &block)
       end
 
       ##
       # Render a block, and add its error or help.
-      # Add prepend and append if provided.
-      def control_error_help(name, options, prepend: nil, append: nil, error_text: nil, &block)
+      # Add prepend and append if provided, and wrap if they were, or if
+      # an input_group_class was provided.
+      def control_error_help(name, options, prepend: nil, append: nil, &block)
+        error_text = generate_help(name, options.delete(:help)).to_s
         options = options.extract!(:input_group_class)
         input_group_class = ["input-group", options[:input_group_class]].compact.join(' ')
 

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -144,8 +144,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_misc_1"> Foobar</label>
+          <small class="form-text text-muted">With a help!</small>
         </div>
-        <small class="form-text text-muted">With a help!</small>
       </div>
     HTML
 
@@ -450,5 +450,35 @@ class BootstrapCheckboxTest < ActionView::TestCase
       </div>
     HTML
     assert_equivalent_xml expected, @builder.check_box(:terms, {label: 'I agree to the terms', inline: true, disabled: true, custom: true})
+  end
+
+  test 'collection_check_boxes renders error after last check box' do
+    collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
+    @user.errors.add(:misc, "a box must be checked")
+
+    expected = <<-HTML.strip_heredoc
+    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <input name="utf8" type="hidden" value="&#x2713;"/>
+      <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <div class="form-group">
+        <label for="user_misc">Misc</label>
+        <div class="form-check">
+          <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
+          <label class="form-check-label" for="user_misc_1">Foo</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
+          <label class="form-check-label" for="user_misc_2">Bar</label>
+          <div class="invalid-feedback">a box must be checked</div>
+        </div>
+      </div>
+    </form>
+    HTML
+
+    actual = bootstrap_form_for(@user) do |f|
+      f.collection_check_boxes(:misc, collection, :id, :street)
+    end
+
+    assert_equivalent_xml expected, actual
   end
 end

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -451,34 +451,4 @@ class BootstrapCheckboxTest < ActionView::TestCase
     HTML
     assert_equivalent_xml expected, @builder.check_box(:terms, {label: 'I agree to the terms', inline: true, disabled: true, custom: true})
   end
-
-  test 'collection_check_boxes renders error after last check box' do
-    collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
-    @user.errors.add(:misc, "a box must be checked")
-
-    expected = <<-HTML.strip_heredoc
-    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
-      <input name="utf8" type="hidden" value="&#x2713;"/>
-      <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
-      <div class="form-group">
-        <label for="user_misc">Misc</label>
-        <div class="form-check">
-          <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-          <label class="form-check-label" for="user_misc_1">Foo</label>
-        </div>
-        <div class="form-check">
-          <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
-          <label class="form-check-label" for="user_misc_2">Bar</label>
-          <div class="invalid-feedback">a box must be checked</div>
-        </div>
-      </div>
-    </form>
-    HTML
-
-    actual = bootstrap_form_for(@user) do |f|
-      f.collection_check_boxes(:misc, collection, :id, :street)
-    end
-
-    assert_equivalent_xml expected, actual
-  end
 end

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -98,33 +98,39 @@ class BootstrapCheckboxTest < ActionView::TestCase
 
   test "inline checkboxes" do
     expected = <<-HTML.strip_heredoc
-    <input name="user[terms]" type="hidden" value="0" />
-    <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-      <label class="form-check-inline" for="user_terms">
-        I agree to the terms
-      </label>
+      <div class="form-check form-check-inline">
+        <input name="user[terms]" type="hidden" value="0" />
+        <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
+        <label class="form-check-label" for="user_terms">
+          I agree to the terms
+        </label>
+      </div>
     HTML
     assert_equivalent_xml expected, @builder.check_box(:terms, label: 'I agree to the terms', inline: true)
   end
 
   test "disabled inline check_box" do
     expected = <<-HTML.strip_heredoc
-    <input name="user[terms]" type="hidden" value="0" disabled="disabled" />
-    <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" disabled="disabled" />
-      <label class="form-check-inline" for="user_terms">
-        I agree to the terms
-      </label>
+      <div class="form-check form-check-inline">
+        <input name="user[terms]" type="hidden" value="0" disabled="disabled" />
+        <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" disabled="disabled" />
+        <label class="form-check-label" for="user_terms">
+          I agree to the terms
+        </label>
+      </div>
     HTML
     assert_equivalent_xml expected, @builder.check_box(:terms, label: 'I agree to the terms', inline: true, disabled: true)
   end
 
   test "inline checkboxes with custom label class" do
     expected = <<-HTML.strip_heredoc
-    <input name="user[terms]" type="hidden" value="0" />
-    <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-      <label class="form-check-inline btn" for="user_terms">
+    <div class="form-check form-check-inline">
+      <input name="user[terms]" type="hidden" value="0" />
+      <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
+      <label class="form-check-label btn" for="user_terms">
         Terms
       </label>
+    </div>
     HTML
     assert_equivalent_xml expected, @builder.check_box(:terms, inline: true, label_class: 'btn')
   end
@@ -176,14 +182,18 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="form-group">
         <label for="user_misc">Misc</label>
-        <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-        <label class="form-check-inline" for="user_misc_1">
-          Foo
-        </label>
-        <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
-        <label class="form-check-inline" for="user_misc_2">
-          Bar
-        </label>
+        <div class="form-check form-check-inline">
+          <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
+          <label class="form-check-label" for="user_misc_1">
+            Foo
+          </label>
+        </div>
+        <div class="form-check form-check-inline">
+          <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
+          <label class="form-check-label" for="user_misc_2">
+            Bar
+          </label>
+        </div>
       </div>
     HTML
 

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -329,22 +329,26 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equivalent_xml expected, output
   end
 
-  test 'form_group renders the "error" class and message corrrectly when object is invalid' do
-    @user.email = nil
-    assert @user.invalid?
-
-    output = @builder.form_group :email do
-      %{<p class="form-control-static">Bar</p>}.html_safe
-    end
-
-    expected = <<-HTML.strip_heredoc
-      <div class="form-group">
-        <p class="form-control-static">Bar</p>
-        <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
-      </div>
-    HTML
-    assert_equivalent_xml expected, output
-  end
+  # test 'form_group renders the "error" class and message corrrectly when object is invalid' do
+  #   # It could be said that the meaning of "form-group" has changed in Bootstrap 4,
+  #   # and that's why it shouldn't be outputting the error message anymore. Which
+  #   # would make this test case no longer valid.
+  #   # THIS TEST WAS REMOVED FROM v2.7.
+  #   @user.email = nil
+  #   assert @user.invalid?
+  #
+  #   output = @builder.form_group :email do
+  #     %{<p class="form-control-static">Bar</p>}.html_safe
+  #   end
+  #
+  #   expected = <<-HTML.strip_heredoc
+  #     <div class="form-group">
+  #       <p class="form-control-static">Bar</p>
+  #       <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
+  #     </div>
+  #   HTML
+  #   assert_equivalent_xml expected, output
+  # end
 
   test "adds class to wrapped form_group by a field" do
     expected = <<-HTML.strip_heredoc

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -147,6 +147,32 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.text_field(:email, prepend: '$', append: '.00')
   end
 
+  test "adding both prepend and append text with validation error" do
+    @user.email = nil
+    assert @user.invalid?
+
+    expected = <<-HTML.strip_heredoc
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+        <input name="utf8" type="hidden" value="&#x2713;"/>
+        <div class="form-group">
+          <label class="required" for="user_email">Email</label>
+          <div class="input-group">
+            <div class="input-group-prepend">
+              <span class="input-group-text">$</div>
+            </div>
+            <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
+            <div class="input-group-append">
+              <span class="input-group-text">.00</span>
+            </div>
+            <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</span>
+          </div>
+        </div>
+      </form>
+    HTML
+    # TODO: We should build the @builder properly from `bootstrap_form_for`, so it's easier to test errors.
+    assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.text_field :email, prepend: '$', append: '.00' }
+  end
+
   test "help messages for default forms" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -55,30 +55,36 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "radio_button inline label is set correctly" do
     expected = <<-HTML.strip_heredoc
-      <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-      <label class="form-check-label" for="user_misc_1">
-        This is a radio button
-      </label>
+      <div class="form-check form-check-inline">
+        <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
+        <label class="form-check-label" for="user_misc_1">
+          This is a radio button
+        </label>
+      </div>
     HTML
     assert_equivalent_xml expected, @builder.radio_button(:misc, '1', label: 'This is a radio button', inline: true)
   end
 
   test "radio_button disabled inline label is set correctly" do
     expected = <<-HTML.strip_heredoc
-      <input class="form-check-input" disabled="disabled" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-      <label class="form-check-label" for="user_misc_1">
-        This is a radio button
-      </label>
+      <div class="form-check form-check-inline disabled">
+        <input class="form-check-input" disabled="disabled" id="user_misc_1" name="user[misc]" type="radio" value="1" />
+        <label class="form-check-label" for="user_misc_1">
+          This is a radio button
+        </label>
+      </div>
     HTML
     assert_equivalent_xml expected, @builder.radio_button(:misc, '1', label: 'This is a radio button', inline: true, disabled: true)
   end
 
   test "radio_button inline label class is set correctly" do
     expected = <<-HTML.strip_heredoc
-      <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-      <label class="form-check-label btn" for="user_misc_1">
-        This is a radio button
-      </label>
+      <div class="form-check form-check-inline">
+        <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
+        <label class="form-check-label btn" for="user_misc_1">
+          This is a radio button
+        </label>
+      </div>
     HTML
     assert_equivalent_xml expected, @builder.radio_button(:misc, '1', label: 'This is a radio button', inline: true, label_class: 'btn')
   end
@@ -125,10 +131,14 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
         <label for="user_misc">Misc</label>
-        <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-check-label" for="user_misc_1"> Foo</label>
-        <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-        <label class="form-check-label" for="user_misc_2"> Bar</label>
+        <div class="form-check form-check-inline">
+          <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
+          <label class="form-check-label" for="user_misc_1"> Foo</label>
+        </div>
+        <div class="form-check form-check-inline">
+          <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
+          <label class="form-check-label" for="user_misc_2"> Bar</label>
+        </div>
       </div>
     HTML
 

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -99,8 +99,8 @@ class BootstrapRadioButtonTest < ActionView::TestCase
           <label class="form-check-label" for="user_misc_1">
             Foobar
           </label>
+          <small class="form-text text-muted">With a help!</small>
         </div>
-        <small class="form-text text-muted">With a help!</small>
       </div>
     HTML
 
@@ -172,8 +172,8 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
           <label class="form-check-label" for="user_misc_1"> rabooF</label>
+          <small class="form-text text-muted">With a help!</small>
         </div>
-        <small class="form-text text-muted">With a help!</small>
       </div>
     HTML
 
@@ -188,8 +188,8 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
           <label class="form-check-label" for="user_misc_address_1"> Foobar</label>
+          <small class="form-text text-muted">With a help!</small>
         </div>
-        <small class="form-text text-muted">With a help!</small>
       </div>
     HTML
 
@@ -242,8 +242,8 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
           <label class="form-check-label" for="user_misc_1"> rabooF</label>
+          <small class="form-text text-muted">With a help!</small>
         </div>
-        <small class="form-text text-muted">With a help!</small>
       </div>
     HTML
 
@@ -258,8 +258,8 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
           <label class="form-check-label" for="user_misc_address_1"> Foobar</label>
+          <small class="form-text text-muted">With a help!</small>
         </div>
-        <small class="form-text text-muted">With a help!</small>
       </div>
     HTML
 

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -24,6 +24,21 @@ class BootstrapSelectsTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.time_zone_select(:misc)
   end
 
+  test "time zone selects are wrapped correctly with error" do
+    @user.errors.add(:misc, "error for test")
+    expected = <<-HTML.strip_heredoc
+    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <input name="utf8" type="hidden" value="&#x2713;"/>
+      <div class="form-group">
+        <label for="user_misc">Misc</label>
+        <select class="form-control is-invalid" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
+        <div class="invalid-feedback">error for test</div>
+      </div>
+    </form>
+    HTML
+    assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.time_zone_select(:misc) }
+  end
+
   test "selects are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -245,6 +245,33 @@ class BootstrapSelectsTest < ActionView::TestCase
     end
   end
 
+  test "date selects are wrapped correctly with error" do
+    @user.errors.add(:misc, "error for test")
+    Timecop.freeze(Time.utc(2012, 2, 3)) do
+      expected = <<-HTML.strip_heredoc
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+        <input name="utf8" type="hidden" value="&#x2713;"/>
+        <div class="form-group">
+          <label for="user_misc">Misc</label>
+          <div class="rails-bootstrap-forms-date-select is-invalid">
+            <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
+              #{options_range(start: 2007, stop: 2017, selected: 2012)}
+            </select>
+            <select class="form-control" id="user_misc_2i" name="user[misc(2i)]">
+              #{options_range(start: 1, stop: 12, selected: 2, months: true)}
+            </select>
+            <select class="form-control" id="user_misc_3i" name="user[misc(3i)]">
+              #{options_range(start: 1, stop: 31, selected: 3)}
+            </select>
+          </div>
+          <div class="invalid-feedback">error for test</div>
+        </div>
+      </form>
+      HTML
+      assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.date_select(:misc) }
+    end
+  end
+
   test "date selects with options are wrapped correctly" do
     Timecop.freeze(Time.utc(2012, 2, 3)) do
       expected = <<-HTML.strip_heredoc
@@ -316,6 +343,34 @@ class BootstrapSelectsTest < ActionView::TestCase
         </div>
       HTML
       assert_equivalent_xml expected, @builder.time_select(:misc)
+    end
+  end
+
+  test "time selects are wrapped correctly with error" do
+    @user.errors.add(:misc, "error for test")
+    Timecop.freeze(Time.utc(2012, 2, 3, 12, 0, 0)) do
+      expected = <<-HTML.strip_heredoc
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+        <input name="utf8" type="hidden" value="&#x2713;"/>
+        <div class="form-group">
+          <label for="user_misc">Misc</label>
+          <div class="rails-bootstrap-forms-time-select is-invalid">
+            <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="2012" />
+            <input id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="2" />
+            <input id="user_misc_3i" name="user[misc(3i)]" type="hidden" value="3" />
+            <select class="form-control" id="user_misc_4i" name="user[misc(4i)]">
+              #{options_range(start: "00", stop: "23", selected: "12")}
+            </select>
+            :
+            <select class="form-control" id="user_misc_5i" name="user[misc(5i)]">
+              #{options_range(start: "00", stop: "59", selected: "00")}
+            </select>
+          </div>
+          <div class="invalid-feedback">error for test</div>
+        </div>
+      </form>
+      HTML
+      assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.time_select(:misc) }
     end
   end
 
@@ -394,6 +449,41 @@ class BootstrapSelectsTest < ActionView::TestCase
             </select>
           </div>
         </div>
+      HTML
+      assert_equivalent_xml expected, @builder.datetime_select(:misc)
+    end
+  end
+
+  test "datetime selects are wrapped correctly with error" do
+    @user.errors.add(:misc, "error for test")
+    Timecop.freeze(Time.utc(2012, 2, 3, 12, 0, 0)) do
+      expected = <<-HTML.strip_heredoc
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+        <input name="utf8" type="hidden" value="&#x2713;"/>
+        <div class="form-group">
+          <label for="user_misc">Misc</label>
+          <div class="rails-bootstrap-forms-datetime-select is-invalid">
+            <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
+              #{options_range(start: 2007, stop: 2017, selected: 2012)}
+            </select>
+            <select class="form-control" id="user_misc_2i" name="user[misc(2i)]">
+              #{options_range(start: 1, stop: 12, selected: 2, months: true)}
+            </select>
+            <select class="form-control" id="user_misc_3i" name="user[misc(3i)]">
+              #{options_range(start: 1, stop: 31, selected: 3)}
+            </select>
+            &mdash;
+            <select class="form-control" id="user_misc_4i" name="user[misc(4i)]">
+              #{options_range(start: "00", stop: "23", selected: "12")}
+            </select>
+            :
+            <select class="form-control" id="user_misc_5i" name="user[misc(5i)]">
+              #{options_range(start: "00", stop: "59", selected: "00")}
+            </select>
+          </div>
+          <div class="invalid-feedback">error for test</div>
+        </div>
+      </form>
       HTML
       assert_equivalent_xml expected, @builder.datetime_select(:misc)
     end


### PR DESCRIPTION
It looks like Bootstrap 4 specifies that errors should be wrapped inside the input or form group (see https://github.com/twbs/bootstrap/pull/25020 and https://getbootstrap.com/docs/4.0/components/forms/#validation). This PR moves the error (and help) text inside the input-group and form-group.

(Based on the examples in the Bootstrap docs, the error and help text doesn't have to be inside an input or form group, but they do have to be within the same container as the `input` or `select`, and `label` (if any) of the control.)

The changes introduced by this PR can be summarized as:

- Since the majority of helpers called a method (`prepend_and_append_input`) to handle the `:append` and `:prepend` options, the error and help code was moved from `form_group` to `prepend_and_append_input`
- For the helpers that didn't call `prepend_and_append_input`, an "extract method" was done on `prepend_and_append_input` to separate out the code that makes the control, and optionally the error and help text (`control_error_help`). The helpers were modified to call `control_error_help`
- Help and error messages were added to `check_box` and `radio_button` methods, as they fit neither of the above models
- Tests were changed to move the help and error text inside the enclosing `div`

I couldn't see another way to move the error text inside the input group, without major changes to `form_group` and `form_group_builder`.

Because in effect the error handling is pushed down to the individual helpers, it's not longer possible to get an error message from `form_group` when the contents of the block that `form_group` calls don't include a call to a `bootstrap_form` helper. There is one test in `bootstrap_form_group_test.rb` that has a `form_group` around a `p` tag, and checks for the error message. This test has been commented out in this PR. 

NOTE: This PR contains the tests in PR #424, because the tests were needed to ensure this PR didn't introduce regressions.

Fixes #417.
Fixes #418.
