### PR TITLE
Test the rendering of errors for various controls.

### DIFF
--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -65,6 +65,21 @@ class BootstrapFieldsTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.file_field(:misc)
   end
 
+  test "file fields are wrapped correctly with error" do
+    @user.errors.add(:misc, "error for test")
+    expected = <<-HTML.strip_heredoc
+    <form accept-charset="UTF-8" action="/users" class="new_user" enctype="multipart/form-data" id="new_user" method="post" role="form">
+      <input name="utf8" type="hidden" value="&#x2713;"/>
+      <div class="form-group">
+        <label for="user_misc">Misc</label>
+        <input class="form-control-file is-invalid" id="user_misc" name="user[misc]" type="file" />
+        <div class="invalid-feedback">error for test</div>
+      </div>
+    </form>
+    HTML
+    assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.file_field(:misc) }
+  end
+
   test "hidden fields are supported" do
     expected = %{<input id="user_misc" name="user[misc]" type="hidden" />}
     assert_equivalent_xml expected, @builder.hidden_field(:misc)

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -24,6 +24,21 @@ class BootstrapSelectsTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.time_zone_select(:misc)
   end
 
+  test "time zone selects are wrapped correctly with error" do
+    @user.errors.add(:misc, "error for test")
+    expected = <<-HTML.strip_heredoc
+    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <input name="utf8" type="hidden" value="&#x2713;"/>
+      <div class="form-group">
+        <label for="user_misc">Misc</label>
+        <select class="form-control is-invalid" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
+        <div class="invalid-feedback">error for test</div>
+      </div>
+    </form>
+    HTML
+    assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.time_zone_select(:misc) }
+  end
+
   test "selects are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -253,14 +253,14 @@ class BootstrapSelectsTest < ActionView::TestCase
         <input name="utf8" type="hidden" value="&#x2713;"/>
         <div class="form-group">
           <label for="user_misc">Misc</label>
-          <div class="rails-bootstrap-forms-date-select is-invalid">
-            <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
+          <div class="rails-bootstrap-forms-date-select">
+            <select class="form-control is-invalid" id="user_misc_1i" name="user[misc(1i)]">
               #{options_range(start: 2007, stop: 2017, selected: 2012)}
             </select>
-            <select class="form-control" id="user_misc_2i" name="user[misc(2i)]">
+            <select class="form-control is-invalid" id="user_misc_2i" name="user[misc(2i)]">
               #{options_range(start: 1, stop: 12, selected: 2, months: true)}
             </select>
-            <select class="form-control" id="user_misc_3i" name="user[misc(3i)]">
+            <select class="form-control is-invalid" id="user_misc_3i" name="user[misc(3i)]">
               #{options_range(start: 1, stop: 31, selected: 3)}
             </select>
           </div>
@@ -354,15 +354,15 @@ class BootstrapSelectsTest < ActionView::TestCase
         <input name="utf8" type="hidden" value="&#x2713;"/>
         <div class="form-group">
           <label for="user_misc">Misc</label>
-          <div class="rails-bootstrap-forms-time-select is-invalid">
+          <div class="rails-bootstrap-forms-time-select">
             <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="2012" />
             <input id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="2" />
             <input id="user_misc_3i" name="user[misc(3i)]" type="hidden" value="3" />
-            <select class="form-control" id="user_misc_4i" name="user[misc(4i)]">
+            <select class="form-control is-invalid" id="user_misc_4i" name="user[misc(4i)]">
               #{options_range(start: "00", stop: "23", selected: "12")}
             </select>
             :
-            <select class="form-control" id="user_misc_5i" name="user[misc(5i)]">
+            <select class="form-control is-invalid" id="user_misc_5i" name="user[misc(5i)]">
               #{options_range(start: "00", stop: "59", selected: "00")}
             </select>
           </div>
@@ -462,22 +462,22 @@ class BootstrapSelectsTest < ActionView::TestCase
         <input name="utf8" type="hidden" value="&#x2713;"/>
         <div class="form-group">
           <label for="user_misc">Misc</label>
-          <div class="rails-bootstrap-forms-datetime-select is-invalid">
-            <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
+          <div class="rails-bootstrap-forms-datetime-select">
+            <select class="form-control is-invalid" id="user_misc_1i" name="user[misc(1i)]">
               #{options_range(start: 2007, stop: 2017, selected: 2012)}
             </select>
-            <select class="form-control" id="user_misc_2i" name="user[misc(2i)]">
+            <select class="form-control is-invalid" id="user_misc_2i" name="user[misc(2i)]">
               #{options_range(start: 1, stop: 12, selected: 2, months: true)}
             </select>
-            <select class="form-control" id="user_misc_3i" name="user[misc(3i)]">
+            <select class="form-control is-invalid" id="user_misc_3i" name="user[misc(3i)]">
               #{options_range(start: 1, stop: 31, selected: 3)}
             </select>
             &mdash;
-            <select class="form-control" id="user_misc_4i" name="user[misc(4i)]">
+            <select class="form-control is-invalid" id="user_misc_4i" name="user[misc(4i)]">
               #{options_range(start: "00", stop: "23", selected: "12")}
             </select>
             :
-            <select class="form-control" id="user_misc_5i" name="user[misc(5i)]">
+            <select class="form-control is-invalid" id="user_misc_5i" name="user[misc(5i)]">
               #{options_range(start: "00", stop: "59", selected: "00")}
             </select>
           </div>
@@ -485,7 +485,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         </div>
       </form>
       HTML
-      assert_equivalent_xml expected, @builder.datetime_select(:misc)
+      assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.datetime_select(:misc) }
     end
   end
 

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -245,6 +245,33 @@ class BootstrapSelectsTest < ActionView::TestCase
     end
   end
 
+  test "date selects are wrapped correctly with error" do
+    @user.errors.add(:misc, "error for test")
+    Timecop.freeze(Time.utc(2012, 2, 3)) do
+      expected = <<-HTML.strip_heredoc
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+        <input name="utf8" type="hidden" value="&#x2713;"/>
+        <div class="form-group">
+          <label for="user_misc">Misc</label>
+          <div class="rails-bootstrap-forms-date-select is-invalid">
+            <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
+              #{options_range(start: 2007, stop: 2017, selected: 2012)}
+            </select>
+            <select class="form-control" id="user_misc_2i" name="user[misc(2i)]">
+              #{options_range(start: 1, stop: 12, selected: 2, months: true)}
+            </select>
+            <select class="form-control" id="user_misc_3i" name="user[misc(3i)]">
+              #{options_range(start: 1, stop: 31, selected: 3)}
+            </select>
+          </div>
+          <div class="invalid-feedback">error for test</div>
+        </div>
+      </form>
+      HTML
+      assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.date_select(:misc) }
+    end
+  end
+
   test "date selects with options are wrapped correctly" do
     Timecop.freeze(Time.utc(2012, 2, 3)) do
       expected = <<-HTML.strip_heredoc
@@ -316,6 +343,34 @@ class BootstrapSelectsTest < ActionView::TestCase
         </div>
       HTML
       assert_equivalent_xml expected, @builder.time_select(:misc)
+    end
+  end
+
+  test "time selects are wrapped correctly with error" do
+    @user.errors.add(:misc, "error for test")
+    Timecop.freeze(Time.utc(2012, 2, 3, 12, 0, 0)) do
+      expected = <<-HTML.strip_heredoc
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+        <input name="utf8" type="hidden" value="&#x2713;"/>
+        <div class="form-group">
+          <label for="user_misc">Misc</label>
+          <div class="rails-bootstrap-forms-time-select is-invalid">
+            <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="2012" />
+            <input id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="2" />
+            <input id="user_misc_3i" name="user[misc(3i)]" type="hidden" value="3" />
+            <select class="form-control" id="user_misc_4i" name="user[misc(4i)]">
+              #{options_range(start: "00", stop: "23", selected: "12")}
+            </select>
+            :
+            <select class="form-control" id="user_misc_5i" name="user[misc(5i)]">
+              #{options_range(start: "00", stop: "59", selected: "00")}
+            </select>
+          </div>
+          <div class="invalid-feedback">error for test</div>
+        </div>
+      </form>
+      HTML
+      assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.time_select(:misc) }
     end
   end
 
@@ -394,6 +449,41 @@ class BootstrapSelectsTest < ActionView::TestCase
             </select>
           </div>
         </div>
+      HTML
+      assert_equivalent_xml expected, @builder.datetime_select(:misc)
+    end
+  end
+
+  test "datetime selects are wrapped correctly with error" do
+    @user.errors.add(:misc, "error for test")
+    Timecop.freeze(Time.utc(2012, 2, 3, 12, 0, 0)) do
+      expected = <<-HTML.strip_heredoc
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+        <input name="utf8" type="hidden" value="&#x2713;"/>
+        <div class="form-group">
+          <label for="user_misc">Misc</label>
+          <div class="rails-bootstrap-forms-datetime-select is-invalid">
+            <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
+              #{options_range(start: 2007, stop: 2017, selected: 2012)}
+            </select>
+            <select class="form-control" id="user_misc_2i" name="user[misc(2i)]">
+              #{options_range(start: 1, stop: 12, selected: 2, months: true)}
+            </select>
+            <select class="form-control" id="user_misc_3i" name="user[misc(3i)]">
+              #{options_range(start: 1, stop: 31, selected: 3)}
+            </select>
+            &mdash;
+            <select class="form-control" id="user_misc_4i" name="user[misc(4i)]">
+              #{options_range(start: "00", stop: "23", selected: "12")}
+            </select>
+            :
+            <select class="form-control" id="user_misc_5i" name="user[misc(5i)]">
+              #{options_range(start: "00", stop: "59", selected: "00")}
+            </select>
+          </div>
+          <div class="invalid-feedback">error for test</div>
+        </div>
+      </form>
       HTML
       assert_equivalent_xml expected, @builder.datetime_select(:misc)
     end

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -165,6 +165,21 @@ class BootstrapSelectsTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.collection_select(:status, [], :id, :name)
   end
 
+  test "collection_selects are wrapped correctly with error" do
+    @user.errors.add(:status, "error for test")
+    expected = <<-HTML.strip_heredoc
+    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <input name="utf8" type="hidden" value="&#x2713;"/>
+      <div class="form-group">
+        <label for="user_status">Status</label>
+        <select class="form-control is-invalid" id="user_status" name="user[status]"></select>
+        <div class="invalid-feedback">error for test</div>
+      </div>
+    </form>
+    HTML
+    assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.collection_select(:status, [], :id, :name) }
+  end
+
   test "collection_selects with options are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
@@ -197,6 +212,21 @@ class BootstrapSelectsTest < ActionView::TestCase
       </div>
     HTML
     assert_equivalent_xml expected, @builder.grouped_collection_select(:status, [], :last, :first, :to_s, :to_s)
+  end
+
+  test "grouped_collection_selects are wrapped correctly with error" do
+    @user.errors.add(:status, "error for test")
+    expected = <<-HTML.strip_heredoc
+    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <input name="utf8" type="hidden" value="&#x2713;"/>
+      <div class="form-group">
+        <label for="user_status">Status</label>
+        <select class="form-control is-invalid" id="user_status" name="user[status]"></select>
+        <div class="invalid-feedback">error for test</div>
+      </div>
+    </form>
+    HTML
+    assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.grouped_collection_select(:status, [], :last, :first, :to_s, :to_s) }
   end
 
   test "grouped_collection_selects with options are wrapped correctly" do


### PR DESCRIPTION
This pull request adds tests for various controls when there is an validation failure on the control. All these tests document the behaviour of the master branch as of the time the PR was created. 

Bootstrap 4's handling of errors is different that Bootstrap 3's, and has led to some issues already, e.g. #417 and #395. The tests here, therefore, document current functionality, so they give us a baseline for any required changes. These tests should not be considered a declaration about how `bootstrap_form` should render errors with Bootstrap 4. 

These tests also provide more coverage to ensure we don't introduce regressions as we address #417, #395 and any other issues that come up.

Given this PR contains only a few tests which don't significantly increase the run time of the test suite, I hope it's easy to merge. It would be great if someone other that @mattbrictson can review this PR, to take some of the load off Matt's shoulders.
