### PR TITLE
Bootstrap 4 offset classes.

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -287,7 +287,7 @@ module BootstrapForm
     end
 
     def offset_col(label_col)
-      label_col.sub(/^col-(\w+)-(\d)$/, 'col-\1-offset-\2')
+      label_col.sub(/^col-(\w+)-(\d)$/, 'offset-\1-\2')
     end
 
     def default_control_col

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -233,7 +233,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group row">
-        <div class="col-sm-10 col-sm-offset-2">
+        <div class="col-sm-10 offset-sm-2">
           <p class="form-control-static">Bar</p>
         </div>
       </div>
@@ -264,7 +264,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group foo row">
-        <div class="col-sm-10 col-sm-offset-2">
+        <div class="col-sm-10 offset-sm-2">
           <p class="form-control-static">Bar</p>
         </div>
       </div>
@@ -279,7 +279,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group foo row">
-        <div class="col-sm-10 col-sm-offset-2">
+        <div class="col-sm-10 offset-sm-2">
           <p class="form-control-static">Bar</p>
         </div>
       </div>
@@ -376,7 +376,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group row">
-        <div class="col-sm-10 col-sm-offset-2">
+        <div class="col-sm-10 offset-sm-2">
           <input class="btn btn-secondary" name="commit" type="submit" value="Create User" />
         </div>
       </div>
@@ -391,7 +391,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group row">
-        <div class="col-sm-8 col-sm-offset-5">
+        <div class="col-sm-8 offset-sm-5">
           <input class="btn btn-secondary" name="commit" type="submit" value="Create User" />
         </div>
       </div>
@@ -409,7 +409,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group row">
-        <div class="col-sm-10 col-sm-offset-2">Hallo</div>
+        <div class="col-sm-10 offset-sm-2">Hallo</div>
       </div>
       <div class="form-group row">
         <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
@@ -475,7 +475,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group row">
-        <div class="col-sm-9 col-sm-offset-3">
+        <div class="col-sm-9 offset-sm-3">
           <p class="form-control-static">Bar</p>
         </div>
       </div>
@@ -487,7 +487,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     frozen_horizontal_builder = BootstrapForm::FormBuilder.new(:user, @user, self, { layout: :horizontal, label_col: "col-sm-3".freeze, control_col: "col-sm-9".freeze })
     output = frozen_horizontal_builder.form_group { 'test' }
 
-    expected = %{<div class="form-group row"><div class="col-sm-9 col-sm-offset-3">test</div></div>}
+    expected = %{<div class="form-group row"><div class="col-sm-9 offset-sm-3">test</div></div>}
     assert_equivalent_xml expected, output
   end
 

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -337,7 +337,7 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         <input name="utf8" type="hidden" value="&#x2713;" />
         <div class="form-group row">
-          <div class="col-md-10 col-md-offset-2">
+          <div class="col-md-10 offset-md-2">
             <input class="btn btn-secondary" name="commit" type="submit" value="Create User" />
           </div>
         </div>


### PR DESCRIPTION
Bootstrap 4 has different [offset classes](https://getbootstrap.com/docs/4.0/layout/grid/#offsetting-columns). This PR changes test cases and changes the method that generates the offset class.

Fixes #425.