### PR TITLE
Bootstrap v4 file input

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -61,9 +61,18 @@ module BootstrapForm
 
     def file_field_with_bootstrap(name, options = {})
       prevent_prepend_and_append!(options)
-      options = options.reverse_merge(control_class: 'form-control-file')
+      options = options.reverse_merge(control_class: "custom-file-input")
       form_group_builder(name, options) do
-        file_field_without_bootstrap(name, options)
+        content_tag(:div, :class => "custom-file") do
+          placeholder = options.delete(:placeholder) || "Choose file"
+          placeholder_opts = { class: "custom-file-label" }
+          placeholder_opts[:for] = options[:id] if acts_like_form_tag
+
+          input = file_field_without_bootstrap(name, options)
+          placeholder_label = label(name, placeholder, placeholder_opts)
+          concat(input)
+          concat(placeholder_label)
+        end
       end
     end
 

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -63,10 +63,10 @@ module BootstrapForm
       prevent_prepend_and_append!(options)
       options = options.reverse_merge(control_class: "custom-file-input")
       form_group_builder(name, options) do
-        content_tag(:div, :class => "custom-file") do
+        content_tag(:div, class: "custom-file") do
           placeholder = options.delete(:placeholder) || "Choose file"
           placeholder_opts = { class: "custom-file-label" }
-          placeholder_opts[:for] = options[:id] if acts_like_form_tag
+          placeholder_opts[:for] = options[:id] if options[:id].present?
 
           input = file_field_without_bootstrap(name, options)
           placeholder_label = label(name, placeholder, placeholder_opts)

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -59,7 +59,10 @@ class BootstrapFieldsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
         <label for="user_misc">Misc</label>
-        <input class="form-control-file" id="user_misc" name="user[misc]" type="file" />
+        <div class="custom-file">
+          <input class="custom-file-input" id="user_misc" name="user[misc]" type="file" />
+          <label class="custom-file-label" for="user_misc">Choose file</label>
+        </div>
       </div>
     HTML
     assert_equivalent_xml expected, @builder.file_field(:misc)
@@ -72,7 +75,10 @@ class BootstrapFieldsTest < ActionView::TestCase
       <input name="utf8" type="hidden" value="&#x2713;"/>
       <div class="form-group">
         <label for="user_misc">Misc</label>
-        <input class="form-control-file is-invalid" id="user_misc" name="user[misc]" type="file" />
+        <div class="custom-file">
+          <input class="custom-file-input is-invalid" id="user_misc" name="user[misc]" type="file" />
+          <label class="custom-file-label" for="user_misc">Choose file</label>
+        </div>
         <div class="invalid-feedback">error for test</div>
       </div>
     </form>

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -81,6 +81,21 @@ class BootstrapFieldsTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.file_field(:misc, placeholder: "Pick a file")
   end
 
+  if ::Rails::VERSION::STRING > '5.1' && ::Rails::VERSION::STRING < '5.2'
+    test "file field placeholder has appropriate `for` attribute when used in form_with" do
+      expected = <<-HTML.strip_heredoc
+        <div class="form-group">
+          <label for="misc_file">Misc</label>
+          <div class="custom-file">
+            <input class="custom-file-input" id="misc_file" name="user[misc]" type="file" />
+            <label class="custom-file-label" for="misc_file">Choose file</label>
+          </div>
+        </div>
+      HTML
+      assert_equivalent_xml expected, form_with_builder.file_field(:misc, id: "misc_file")
+    end
+  end
+
   test "file fields are wrapped correctly with error" do
     @user.errors.add(:misc, "error for test")
     expected = <<-HTML.strip_heredoc

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -68,6 +68,19 @@ class BootstrapFieldsTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.file_field(:misc)
   end
 
+  test "file field placeholder can be customized" do
+    expected = <<-HTML.strip_heredoc
+      <div class="form-group">
+        <label for="user_misc">Misc</label>
+        <div class="custom-file">
+          <input class="custom-file-input" id="user_misc" name="user[misc]" type="file" />
+          <label class="custom-file-label" for="user_misc">Pick a file</label>
+        </div>
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.file_field(:misc, placeholder: "Pick a file")
+  end
+
   test "file fields are wrapped correctly with error" do
     @user.errors.add(:misc, "error for test")
     expected = <<-HTML.strip_heredoc

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -81,18 +81,18 @@ class BootstrapFieldsTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.file_field(:misc, placeholder: "Pick a file")
   end
 
-  if ::Rails::VERSION::STRING > '5.1' && ::Rails::VERSION::STRING < '5.2'
+  if ::Rails::VERSION::STRING > '5.1'
     test "file field placeholder has appropriate `for` attribute when used in form_with" do
       expected = <<-HTML.strip_heredoc
         <div class="form-group">
-          <label for="misc_file">Misc</label>
+          <label for="custom-id">Misc</label>
           <div class="custom-file">
-            <input class="custom-file-input" id="misc_file" name="user[misc]" type="file" />
-            <label class="custom-file-label" for="misc_file">Choose file</label>
+            <input class="custom-file-input" id="custom-id" name="user[misc]" type="file" />
+            <label class="custom-file-label" for="custom-id">Choose file</label>
           </div>
         </div>
       HTML
-      assert_equivalent_xml expected, form_with_builder.file_field(:misc, id: "misc_file")
+      assert_equivalent_xml expected, form_with_builder.file_field(:misc, id: "custom-id")
     end
   end
 


### PR DESCRIPTION
This is a rebase and redo of #306 by @trammel.

I did the minimum necessary (I think) to generate the appropriate markup [explained in the v4 docs](http://getbootstrap.com/docs/4.0/components/forms/#file-browser).

```html
<div class="form-group">
  <label for="user_misc">Misc</label>
  <div class="custom-file">
    <input class="custom-file-input" id="user_misc" name="user[misc]" type="file" />
    <label class="custom-file-label" for="user_misc">Choose file</label>
  </div>
</div>
```

Note that in Bootstrap v4:

> We hide the default file `<input>` via opacity and instead style the `<label>`.

In other words, the `label.custom-file-label` is styled to look like a text input, and the contents of that label are used for the placeholder text inside that pseudo-text input. The placeholder is "Choose file" by default and can be customized using the `:placeholder` option, if desired.

There might be some edge cases I missed. But, good enough for alpha?