### PR TITLE
Add support for `label_as_placeholder` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ In addition to these necessary markup changes, the bootstrap_form API itself has
 * Allow HTML in help translations by using the `_html` suffix on the key - [@unikitty37](https://github.com/unikitty37)
 * [#408](https://github.com/bootstrap-ruby/bootstrap_form/pull/408): Add option[:id] on static control #245 - [@duleorlovic](https://github.com/duleorlovic).
 * [#455](https://github.com/bootstrap-ruby/bootstrap_form/pull/455): Support for i18n `:html` subkeys in help text - [@jsaraiva](https://github.com/jsaraiva).
+* Adds support for `label_as_placeholder` option, which will set the label text as an input fields placeholder (and hiding the label for sr_only).
 * Your contribution here!
 
 ### Bugfixes

--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ To add custom classes to the field's label:
 <%= f.text_field :email, label_class: "custom-class" %>
 ```
 
+Or you can add the label as input placeholder instead (this automatically hides the label):
+
+```erb
+<%= f.text_field :email, label_as_placeholder: true %>
+```
+
 #### Required Fields
 
 A label that is associated with a required field is automatically annotated with

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -419,7 +419,7 @@ module BootstrapForm
           options.delete(:label)
         end
         label_class ||= options.delete(:label_class)
-        label_class = hide_class if options.delete(:hide_label)
+        label_class = hide_class if options.delete(:hide_label) || options[:label_as_placeholder]
 
         if options[:label].is_a?(String)
           label_text ||= options.delete(:label)
@@ -430,6 +430,10 @@ module BootstrapForm
           class: label_class,
           skip_required: options.delete(:skip_required)
         }.merge(css_options[:id].present? ? { for: css_options[:id] } : {})
+
+        if options.delete(:label_as_placeholder)
+          css_options[:placeholder] = label_text || object.class.human_attribute_name(method)
+        end
       end
 
       form_group(method, form_group_options) do

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -84,6 +84,16 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.text_field(:email, skip_required: true)
   end
 
+  test "label as placeholder" do
+    expected = <<-HTML.strip_heredoc
+      <div class="form-group">
+        <label class="sr-only required" for="user_email">Email</label>
+        <input class="form-control" id="user_email" placeholder="Email" name="user[email]" type="text" value="steve@example.com" />
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.text_field(:email, label_as_placeholder: true)
+  end
+
   test "adding prepend text" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">


### PR DESCRIPTION
Per #332 this PR will add support for a `label_as_placeholder` option allowing you to add the field title to an input fields `placeholder` attribute and hiding the label simultaneously.