### PR TITLE
Fixing input validation messaging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ div (field_with_errors), but this behavior is suppressed. Here's an example:
 <div class="form-group">
   <label class="form-control-label" for="user_email">Email</label>
   <input class="form-control is-invalid" id="user_email" name="user[email]" type="email" value="">
-  <small class="invalid-feedback">can't be blank</small>
+  <small class="form-control-feedback">can't be blank</small>
 </div>
 ```
 

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -248,7 +248,7 @@ module BootstrapForm
       options[:class] = ["form-group", options[:class]].compact.join(' ')
       options[:class] << " row" if get_group_layout(options[:layout]) == :horizontal
       options[:class] << " form-inline" if field_inline_override?(options[:layout])
-      options[:class] << " #{feedback_class}" if options[:icon]
+      options[:class] << " #{error_class}" if has_error?(name)
 
       content_tag(:div, options.except(:append, :id, :label, :help, :icon, :input_group_class, :label_col, :control_col, :layout, :prepend)) do
         label = generate_label(options[:id], name, options[:label], options[:label_col], options[:layout]) if options[:label]
@@ -336,8 +336,8 @@ module BootstrapForm
       "form-control"
     end
 
-    def feedback_class
-      "has-feedback"
+    def error_class
+      'has-danger'
     end
 
     def control_specific_class(method)
@@ -475,7 +475,7 @@ module BootstrapForm
     def generate_help(name, help_text)
       if has_error?(name) && inline_errors
         help_text = get_error_messages(name)
-        help_klass = 'invalid-feedback'
+        help_klass = 'form-control-feedback'
         help_tag = :div
       end
       return if help_text == false

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -101,13 +101,13 @@ class BootstrapFieldsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
     <form accept-charset="UTF-8" action="/users" class="new_user" enctype="multipart/form-data" id="new_user" method="post" role="form">
       <input name="utf8" type="hidden" value="&#x2713;"/>
-      <div class="form-group">
+      <div class="form-group has-danger">
         <label for="user_misc">Misc</label>
         <div class="custom-file">
           <input class="custom-file-input is-invalid" id="user_misc" name="user[misc]" type="file" />
           <label class="custom-file-label" for="user_misc">Choose file</label>
         </div>
-        <div class="invalid-feedback">error for test</div>
+        <div class="form-control-feedback">error for test</div>
       </div>
     </form>
     HTML

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -154,7 +154,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         <input name="utf8" type="hidden" value="&#x2713;"/>
-        <div class="form-group">
+        <div class="form-group has-danger">
           <label class="required" for="user_email">Email</label>
           <div class="input-group">
             <div class="input-group-prepend">
@@ -164,7 +164,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
             <div class="input-group-append">
               <span class="input-group-text">.00</span>
             </div>
-            <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</span>
+            <div class="form-control-feedback">can't be blank, is too short (minimum is 5 characters)</span>
           </div>
         </div>
       </form>
@@ -337,9 +337,9 @@ class BootstrapFormGroupTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="form-group has-danger">
         <p class="form-control-static">Bar</p>
-        <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
+        <div class="form-control-feedback">can't be blank, is too short (minimum is 5 characters)</div>
       </div>
     HTML
     assert_equivalent_xml expected, output
@@ -360,14 +360,14 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert @user.invalid?
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group none-margin">
+      <div class="form-group none-margin has-danger">
         <div class="field_with_errors">
           <label class="required" for="user_email">Email</label>
         </div>
         <div class="field_with_errors">
           <input class="form-control is-invalid" id="user_email" name="user[email]" type="email" />
         </div>
-        <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
+        <div class="form-control-feedback">can't be blank, is too short (minimum is 5 characters)</div>
       </div>
     HTML
     assert_equivalent_xml expected, @builder.email_field(:email, wrapper_class: 'none-margin')
@@ -384,10 +384,10 @@ class BootstrapFormGroupTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         <input name="utf8" type="hidden" value="&#x2713;" />
-        <div class="form-group none-margin">
+        <div class="form-group none-margin has-danger">
           <label class="required" for="user_email">Email</label>
           <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
-          <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
+          <div class="form-control-feedback">can't be blank, is too short (minimum is 5 characters)</div>
         </div>
       </form>
     HTML

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -407,7 +407,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         <input name="utf8" type="hidden" value="&#x2713;" />
-        <div class="form-group">
+        <div class="form-group has-danger">
           <label class="required" for="user_email">Email can't be blank, is too short (minimum is 5 characters)</label>
           <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
         </div>
@@ -423,10 +423,10 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         <input name="utf8" type="hidden" value="&#x2713;" />
-        <div class="form-group">
+        <div class="form-group has-danger">
           <label class="required" for="user_email">Email can&#39;t be blank, is too short (minimum is 5 characters)</label>
           <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
-          <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</span>
+          <div class="form-control-feedback">can't be blank, is too short (minimum is 5 characters)</span>
         </div>
       </form>
     HTML
@@ -443,10 +443,10 @@ class BootstrapFormTest < ActionView::TestCase
       expected = <<-HTML.strip_heredoc
         <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
           <input name="utf8" type="hidden" value="&#x2713;" />
-          <div class="form-group">
+          <div class="form-group has-danger">
             <label class="required" for="user_email">Your e-mail address can&#39;t be blank, is too short (minimum is 5 characters)</label>
             <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
-            <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
+            <div class="form-control-feedback">can't be blank, is too short (minimum is 5 characters)</div>
           </div>
         </form>
       HTML
@@ -637,10 +637,10 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         <input name="utf8" type="hidden" value="&#x2713;" />
-        <div class="form-group">
+        <div class="form-group has-danger">
           <label class="required" for="user_email">Email</label>
           <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
-          <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
+          <div class="form-control-feedback">can't be blank, is too short (minimum is 5 characters)</div>
         </div>
       </form>
     HTML
@@ -658,14 +658,14 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         <input name="utf8" type="hidden" value="&#x2713;" />
-        <div class="form-group">
+        <div class="form-group has-danger">
           <div class="field_with_errors">
             <label class="required" for="user_email">Email</label>
           </div>
           <div class="field_with_errors">
             <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           </div>
-          <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</span>
+          <div class="form-control-feedback">can't be blank, is too short (minimum is 5 characters)</span>
         </div>
       </form>
     HTML
@@ -683,7 +683,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         <input name="utf8" type="hidden" value="&#x2713;" />
-        <div class="form-group">
+        <div class="form-group has-danger">
           <label class="required" for="user_email">Email</label>
           <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           <small class="form-text text-muted">This is required</small>

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -29,10 +29,10 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
     <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
       <input name="utf8" type="hidden" value="&#x2713;"/>
-      <div class="form-group">
+      <div class="form-group has-danger">
         <label for="user_misc">Misc</label>
         <select class="form-control is-invalid" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
-        <div class="invalid-feedback">error for test</div>
+        <div class="form-control-feedback">error for test</div>
       </div>
     </form>
     HTML
@@ -170,10 +170,10 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
     <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
       <input name="utf8" type="hidden" value="&#x2713;"/>
-      <div class="form-group">
+      <div class="form-group has-danger">
         <label for="user_status">Status</label>
         <select class="form-control is-invalid" id="user_status" name="user[status]"></select>
-        <div class="invalid-feedback">error for test</div>
+        <div class="form-control-feedback">error for test</div>
       </div>
     </form>
     HTML
@@ -219,10 +219,10 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
     <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
       <input name="utf8" type="hidden" value="&#x2713;"/>
-      <div class="form-group">
+      <div class="form-group has-danger">
         <label for="user_status">Status</label>
         <select class="form-control is-invalid" id="user_status" name="user[status]"></select>
-        <div class="invalid-feedback">error for test</div>
+        <div class="form-control-feedback">error for test</div>
       </div>
     </form>
     HTML
@@ -281,7 +281,7 @@ class BootstrapSelectsTest < ActionView::TestCase
       expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         <input name="utf8" type="hidden" value="&#x2713;"/>
-        <div class="form-group">
+        <div class="form-group has-danger">
           <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
             <select class="form-control is-invalid" id="user_misc_1i" name="user[misc(1i)]">
@@ -294,7 +294,7 @@ class BootstrapSelectsTest < ActionView::TestCase
               #{options_range(start: 1, stop: 31, selected: 3)}
             </select>
           </div>
-          <div class="invalid-feedback">error for test</div>
+          <div class="form-control-feedback">error for test</div>
         </div>
       </form>
       HTML
@@ -382,7 +382,7 @@ class BootstrapSelectsTest < ActionView::TestCase
       expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         <input name="utf8" type="hidden" value="&#x2713;"/>
-        <div class="form-group">
+        <div class="form-group has-danger">
           <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-time-select">
             <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="2012" />
@@ -396,7 +396,7 @@ class BootstrapSelectsTest < ActionView::TestCase
               #{options_range(start: "00", stop: "59", selected: "00")}
             </select>
           </div>
-          <div class="invalid-feedback">error for test</div>
+          <div class="form-control-feedback">error for test</div>
         </div>
       </form>
       HTML
@@ -490,7 +490,7 @@ class BootstrapSelectsTest < ActionView::TestCase
       expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         <input name="utf8" type="hidden" value="&#x2713;"/>
-        <div class="form-group">
+        <div class="form-group has-danger">
           <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-datetime-select">
             <select class="form-control is-invalid" id="user_misc_1i" name="user[misc(1i)]">
@@ -511,7 +511,7 @@ class BootstrapSelectsTest < ActionView::TestCase
               #{options_range(start: "00", stop: "59", selected: "00")}
             </select>
           </div>
-          <div class="invalid-feedback">error for test</div>
+          <div class="form-control-feedback">error for test</div>
         </div>
       </form>
       HTML


### PR DESCRIPTION
In bootstrap 4 the classes for the input validations have changed. The
`form-group` div is now expected to have the `has-danger` class. The
message text is now supposed to have a `form-control-feedback` class
as opposed to an `invalid-feedback` class.

I removed the `icon` option as it doesn't seem to be supported by bootstrap anymore.

There are some parts I'm uncertain of, namely the places in the tests where it doesn't seem like the `form-control-feedback` is rendered.  I'm not sure if we are supposed to put the `has-danger` class on the div in these instances.

This also includes an update to the README to reflect this change.

If there is anything that needs to be changed, let me know.