### PR TITLE
Issue #444 - Help text rendered in wrong place.

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -263,7 +263,11 @@ module BootstrapForm
           control = content_tag(:div, control, class: control_class)
         end
 
-        concat(label).concat(control)
+        help = options[:help]
+
+        help_text = generate_help(name, help).to_s
+
+        concat(label).concat(control).concat(help_text)
       end
     end
 
@@ -472,13 +476,22 @@ module BootstrapForm
       end
     end
 
-    def generate_help(name, help_text)
-      if has_error?(name) && inline_errors
+    def has_inline_error?(name)
+      has_error?(name) && inline_errors
+    end
+
+    def generate_error(name)
+      if has_inline_error?(name)
         help_text = get_error_messages(name)
         help_klass = 'invalid-feedback'
         help_tag = :div
+
+        content_tag(help_tag, help_text, class: help_klass)
       end
-      return if help_text == false
+    end
+
+    def generate_help(name, help_text)
+      return if help_text == false || has_inline_error?(name)
 
       help_klass ||= 'form-text text-muted'
       help_text ||= get_help_text_by_i18n_key(name)

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -67,7 +67,6 @@ module BootstrapForm
       end
 
       def prepend_and_append_input(name, options, &block)
-        help = options[:help]
         options = options.extract!(:prepend, :append, :input_group_class)
         input_group_class = ["input-group", options[:input_group_class]].compact.join(' ')
 
@@ -75,7 +74,7 @@ module BootstrapForm
 
         input = content_tag(:div, input_group_content(options[:prepend]), class: 'input-group-prepend') + input if options[:prepend]
         input << content_tag(:div, input_group_content(options[:append]), class: 'input-group-append') if options[:append]
-        input << generate_help(name, help).to_s
+        input << generate_error(name)
         input = content_tag(:div, input, class: input_group_class) unless options.empty?
         input
       end

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -189,8 +189,8 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
           <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
-          <small class="form-text text-muted">This is required</small>
         </div>
+        <small class="form-text text-muted">This is required</small>
       </div>
     HTML
     assert_equivalent_xml expected, @horizontal_builder.text_field(:email, help: "This is required")


### PR DESCRIPTION
The help text and error message are no longer rendered in the same
place. The help text is now rendered in the `form-group` div instead
of in the `input-group` div. Before we could render the error and help
text together, however that has changed and they need to be separate.

With this separation we need to check in the `generate_help` method to
see if there are errors and if inline errors are being rendered; as we
don't want to render the help text then.

Note - 
At first it seemed a little strange that the help text is not being rendered in the event of an error. It does seem to make sense and look better if they aren't both rendered at the same time. I don't know if I'd want to render them both at the same time ever, but I'm curious of others might. They could make the failing validation message say the same thing that the help text said. This project looks like it could go option crazy if the maintainers aren't careful so it might be best to not have this. Just a thought I had while working on this.
