### PR TITLE
Fixes #443 - Updates `static_control` method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ In addition to these necessary markup changes, the bootstrap_form API itself has
 * The `icon` option is no longer supported (Bootstrap v4 does not include icons)
 * The deprecated Rails methods `check_boxes_collection` and `radio_buttons_collection` have been removed
 * `hide_label: true` and `skip_label: true` on individual check boxes and radio buttons apply Bootstrap 4 markup. This means the appearance of a page may change if you're upgrading from the Bootstrap 3 version of `bootstrap_form`, and you used `check_box` or `radio_button` with either of those options
+* `static_control` will no longer properly show error messages. This is the result of bootstrap changes.
+* `static_control` will also no longer accept a block, use the `value` option instead.
 * Your contribution here!
 
 ### New features
@@ -31,6 +33,7 @@ In addition to these necessary markup changes, the bootstrap_form API itself has
 * [#357](https://github.com/bootstrap-ruby/bootstrap_form/pull/357) if provided,
   use html option `id` to specify `for` attribute on label
   [@duleorlovic](https://github.com/duleorlovic)
+*
 * Your contribution here!
 
 ## [2.7.0][] (2017-04-21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ In addition to these necessary markup changes, the bootstrap_form API itself has
 * [#357](https://github.com/bootstrap-ruby/bootstrap_form/pull/357) if provided,
   use html option `id` to specify `for` attribute on label
   [@duleorlovic](https://github.com/duleorlovic)
-*
 * Your contribution here!
 
 ## [2.7.0][] (2017-04-21)

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Here's the output for a horizontal layout:
 <div class="form-group">
   <label class="col-sm-2 form-control-label" for="user_email">Email</label>
   <div class="col-sm-10">
-    <p class="form-control-static">test@email.com</p>
+    <input class="form-control-plaintext" id="user_email" name="user[email]" readonly="readonly" type="text" value="test@email.com"/>
   </div>
 </div>
 ```

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -48,15 +48,20 @@ module BootstrapForm
         options = args.extract_options!
         name = args.first
 
-        html = if block_given?
+        value = if block_given?
           capture(&block)
         else
           object.send(name)
         end
 
-        form_group_builder(name, options) do
-          content_tag(:p, html, { class: static_class }.merge(options[:id].present? ? { id: options[:id] } : {}))
-        end
+        static_options = {
+          value: value,
+          class: static_class,
+          readonly: true,
+          control_class: nil
+        }
+
+        text_field_with_bootstrap(name, options.merge(static_options))
       end
 
       def custom_control(*args, &block)
@@ -94,7 +99,7 @@ module BootstrapForm
       end
 
       def static_class
-        "form-control-static"
+        "form-control-plaintext"
       end
     end
   end

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -44,25 +44,18 @@ module BootstrapForm
         end
       end
 
-      def static_control(*args, &block)
+      def static_control(*args)
         options = args.extract_options!
         name = args.first
 
-        value = if block_given?
-          capture(&block)
-        elsif options[:value]
-          options[:value]
-        else
-          object.send(name)
-        end
-
-        static_options = {
-          value: value,
+        static_options = options.merge({
           readonly: true,
-          control_class: static_class
-        }
+          control_class: [options[:control_class], static_class].compact.join(" ")
+        })
 
-        text_field_with_bootstrap(name, options.merge(static_options))
+        static_options[:value] = object.send(name) if static_options[:value].nil?
+
+        text_field_with_bootstrap(name, static_options)
       end
 
       def custom_control(*args, &block)

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -50,15 +50,16 @@ module BootstrapForm
 
         value = if block_given?
           capture(&block)
+        elsif options[:value]
+          options[:value]
         else
           object.send(name)
         end
 
         static_options = {
           value: value,
-          class: static_class,
           readonly: true,
-          control_class: nil
+          control_class: static_class
         }
 
         text_field_with_bootstrap(name, options.merge(static_options))

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -237,14 +237,14 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "form_group creates a valid structure and allows arbitrary html to be added via a block" do
     output = @horizontal_builder.form_group :nil, label: { text: 'Foo' } do
-      %{<p class="form-control-static">Bar</p>}.html_safe
+      %{<input class="form-control-plaintext" value="Bar">}.html_safe
     end
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group row">
         <label class="col-form-label col-sm-2" for="user_nil">Foo</label>
         <div class="col-sm-10">
-          <p class="form-control-static">Bar</p>
+          <input class="form-control-plaintext" value="Bar">
         </div>
       </div>
     HTML
@@ -253,13 +253,13 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "form_group adds a spacer when no label exists for a horizontal form" do
     output = @horizontal_builder.form_group do
-      %{<p class="form-control-static">Bar</p>}.html_safe
+      %{<input class="form-control-plaintext" value="Bar">}.html_safe
     end
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group row">
         <div class="col-sm-10 offset-sm-2">
-          <p class="form-control-static">Bar</p>
+          <input class="form-control-plaintext" value="Bar">
         </div>
       </div>
     HTML
@@ -268,14 +268,14 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "form_group renders the label correctly" do
     output = @horizontal_builder.form_group :email, label: { text: 'Custom Control' } do
-      %{<p class="form-control-static">Bar</p>}.html_safe
+      %{<input class="form-control-plaintext" value="Bar">}.html_safe
     end
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group row">
         <label class="col-form-label col-sm-2 required" for="user_email">Custom Control</label>
         <div class="col-sm-10">
-          <p class="form-control-static">Bar</p>
+          <input class="form-control-plaintext" value="Bar">
         </div>
       </div>
     HTML
@@ -284,13 +284,13 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "form_group accepts class thorugh options hash" do
     output = @horizontal_builder.form_group :email, class: "foo" do
-      %{<p class="form-control-static">Bar</p>}.html_safe
+      %{<input class="form-control-plaintext" value="Bar">}.html_safe
     end
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group foo row">
         <div class="col-sm-10 offset-sm-2">
-          <p class="form-control-static">Bar</p>
+          <input class="form-control-plaintext" value="Bar">
         </div>
       </div>
     HTML
@@ -299,13 +299,13 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "form_group accepts class thorugh options hash without needing a name" do
     output = @horizontal_builder.form_group class: "foo" do
-      %{<p class="form-control-static">Bar</p>}.html_safe
+      %{<input class="form-control-plaintext" value="Bar">}.html_safe
     end
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group foo row">
         <div class="col-sm-10 offset-sm-2">
-          <p class="form-control-static">Bar</p>
+          <input class="form-control-plaintext" value="Bar">
         </div>
       </div>
     HTML
@@ -314,31 +314,31 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "form_group overrides the label's 'class' and 'for' attributes if others are passed" do
     output = @horizontal_builder.form_group nil, label: { text: 'Custom Control', class: 'foo', for: 'bar' } do
-      %{<p class="form-control-static">Bar</p>}.html_safe
+      %{<input class="form-control-plaintext" value="Bar">}.html_safe
     end
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group row">
         <label class="foo col-form-label col-sm-2" for="bar">Custom Control</label>
         <div class="col-sm-10">
-          <p class="form-control-static">Bar</p>
+          <input class="form-control-plaintext" value="Bar">
         </div>
       </div>
     HTML
     assert_equivalent_xml expected, output
   end
 
-  test 'form_group renders the "error" class and message corrrectly when object is invalid' do
+  test 'form_group renders the "error" class and message correctly when object is invalid' do
     @user.email = nil
     assert @user.invalid?
 
     output = @builder.form_group :email do
-      %{<p class="form-control-static">Bar</p>}.html_safe
+      %{<input class="form-control-plaintext" value="Bar">}.html_safe
     end
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <p class="form-control-static">Bar</p>
+        <input class="form-control-plaintext" value="Bar">
         <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
       </div>
     HTML
@@ -495,13 +495,13 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "non-default column span on form is reflected in form_group" do
     non_default_horizontal_builder = BootstrapForm::FormBuilder.new(:user, @user, self, { layout: :horizontal, label_col: "col-sm-3", control_col: "col-sm-9" })
     output = non_default_horizontal_builder.form_group do
-      %{<p class="form-control-static">Bar</p>}.html_safe
+      %{<input class="form-control-plaintext" value="Bar">}.html_safe
     end
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group row">
         <div class="col-sm-9 offset-sm-3">
-          <p class="form-control-static">Bar</p>
+          <input class="form-control-plaintext" value="Bar">
         </div>
       </div>
     HTML

--- a/test/bootstrap_other_components_test.rb
+++ b/test/bootstrap_other_components_test.rb
@@ -12,7 +12,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
       <div class="form-group row">
         <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
-          <p class="form-control-static">steve@example.com</p>
+          <input class="form-control-plaintext" id="user_email" name="user[email]" readonly="readonly" type="text" value="steve@example.com"/>
         </div>
       </div>
     HTML
@@ -26,7 +26,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
       <div class="form-group row">
         <label class="col-form-label col-sm-2 required" for="custom_id">Email</label>
         <div class="col-sm-10">
-          <p class="form-control-static" id="custom_id">steve@example.com</p>
+          <input class="form-control-plaintext" id="custom_id" name="user[email]" readonly="readonly" type="text" value="steve@example.com"/>
         </div>
       </div>
     HTML
@@ -42,7 +42,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
       <div class="form-group row">
         <label class="col-form-label col-sm-2" for="user_">My Label</label>
         <div class="col-sm-10">
-          <p class="form-control-static">this is a test</p>
+          <input class="form-control-plaintext" id="user_" name="user[]" readonly="readonly" type="text" value="this is a test"/>
         </div>
       </div>
     HTML
@@ -58,7 +58,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
       <div class="form-group row">
         <label class="col-form-label col-sm-2" for="user_">Custom Label</label>
         <div class="col-sm-10">
-          <p class="form-control-static">Custom Control</p>
+          <input class="form-control-plaintext" id="user_" name="user[]" readonly="readonly" type="text" value="Custom Control"/>
         </div>
       </div>
     HTML

--- a/test/bootstrap_other_components_test.rb
+++ b/test/bootstrap_other_components_test.rb
@@ -34,9 +34,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
   end
 
   test "static control doesn't require an actual attribute" do
-    output = @horizontal_builder.static_control nil, label: "My Label" do
-      "this is a test"
-    end
+    output = @horizontal_builder.static_control nil, label: "My Label", value: "this is a test"
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group row">
@@ -50,15 +48,27 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
   end
 
   test "static control doesn't require a name" do
-    output = @horizontal_builder.static_control label: "Custom Label" do
-      "Custom Control"
-    end
+    output = @horizontal_builder.static_control label: "Custom Label", value: "Custom Control"
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group row">
         <label class="col-form-label col-sm-2" for="user_">Custom Label</label>
         <div class="col-sm-10">
           <input class="form-control-plaintext" id="user_" name="user[]" readonly="readonly" type="text" value="Custom Control"/>
+        </div>
+      </div>
+    HTML
+    assert_equivalent_xml expected, output
+  end
+
+  test "static control won't overwrite a control_class that is passed by the user" do
+    output = @horizontal_builder.static_control :email, control_class: "test_class"
+
+    expected = <<-HTML.strip_heredoc
+      <div class="form-group row">
+        <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
+        <div class="col-sm-10">
+          <input class="test_class form-control-plaintext" id="user_email" name="user[email]" readonly="readonly" type="text" value="steve@example.com"/>
         </div>
       </div>
     HTML


### PR DESCRIPTION
In Bootstrap 4 the `form-control-static` class no longer exists. It
has been replaced with using the `form-control-plaintext` class on a
readonly input. This reflects that change in approach.

There are a couple of potential problems/oddities.

From a backwards-compatabilty standpoint, if people have been putting
other tags inside of the block this will likely break whatever they
may have been trying to do. There doesn't seem to be any way around
this limitation as it is caused by the text input approach.

Secondly, this approach seems to break convention in this project a
little. It doesn't seem as if any of the `_with_bootstrap` methods are
directly referenced anywhere. I'm not sure how much of a problem this
is, it seemed like the best way to stay DRY.

Should I also update the CHANGELOG? I don't know if it was an accident or not with the last contribution, but nothing was added to it.