### PR TITLE
Add text-danger to label when label_errors: true

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -470,6 +470,7 @@ module BootstrapForm
       if label_errors && has_error?(name)
         error_messages = get_error_messages(name)
         label_text = (options[:text] || object.class.human_attribute_name(name)).to_s.concat(" #{error_messages}")
+        options[:class] = [options[:class], "text-danger"].compact.join(" ")
         label(name, label_text, options.except(:text))
       else
         label(name, options[:text], options.except(:text))

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -408,7 +408,7 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         <input name="utf8" type="hidden" value="&#x2713;" />
         <div class="form-group">
-          <label class="required" for="user_email">Email can't be blank, is too short (minimum is 5 characters)</label>
+          <label class="required text-danger" for="user_email">Email can't be blank, is too short (minimum is 5 characters)</label>
           <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
         </div>
       </form>
@@ -424,7 +424,7 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         <input name="utf8" type="hidden" value="&#x2713;" />
         <div class="form-group">
-          <label class="required" for="user_email">Email can&#39;t be blank, is too short (minimum is 5 characters)</label>
+          <label class="required text-danger" for="user_email">Email can&#39;t be blank, is too short (minimum is 5 characters)</label>
           <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</span>
         </div>
@@ -444,7 +444,7 @@ class BootstrapFormTest < ActionView::TestCase
         <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
           <input name="utf8" type="hidden" value="&#x2713;" />
           <div class="form-group">
-            <label class="required" for="user_email">Your e-mail address can&#39;t be blank, is too short (minimum is 5 characters)</label>
+            <label class="required text-danger" for="user_email">Your e-mail address can&#39;t be blank, is too short (minimum is 5 characters)</label>
             <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
             <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
           </div>


### PR DESCRIPTION
This maintains the appearance of label errors consistent with v2.7 (Bootstrap 3).

With Bootstrap 4's way of marking up validation errors, the label text with a label error was not displaying in the error colour (default red). This PR adds `.text-danger` to a label when `label_errors: true` and there is a validation error on the field.

`invalid-feedback` was rejected as it changes the font appearance, and also doesn't appear to display, even though it's a sibling of the `input.is-invalid`. It looks like `.text-danger` is always the colour of validation errors, unless the programmer is doing some really interesting customization of Bootstrap colours.

No issue was entered for this as the fix was so quick. (My bad.)
