### PR TITLE
Moves help text in horiz. forms under the control

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -254,20 +254,20 @@ module BootstrapForm
         label = generate_label(options[:id], name, options[:label], options[:label_col], options[:layout]) if options[:label]
         control = prepend_and_append_input(name, options, &block).to_s
 
+        help = options[:help]
+        help_text = generate_help(name, help).to_s
+
         if get_group_layout(options[:layout]) == :horizontal
           control_class = options[:control_col] || control_col
           unless options[:label]
             control_offset = offset_col(options[:label_col] || @label_col)
             control_class = "#{control_class} #{control_offset}"
           end
-          control = content_tag(:div, control, class: control_class)
+          control = content_tag(:div, control + help_text, class: control_class)
+          concat(label).concat(control)
+        else
+          concat(label).concat(control).concat(help_text)
         end
-
-        help = options[:help]
-
-        help_text = generate_help(name, help).to_s
-
-        concat(label).concat(control).concat(help_text)
       end
     end
 

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -189,8 +189,8 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
           <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+          <small class="form-text text-muted">This is required</small>
         </div>
-        <small class="form-text text-muted">This is required</small>
       </div>
     HTML
     assert_equivalent_xml expected, @horizontal_builder.text_field(:email, help: "This is required")


### PR DESCRIPTION
When using horizontal forms the help text is placed inside the created row but as sibling of the cols for label and control. This codechange moves the help text inside the col of the control so it gets aligned with/under the control.

Before:
![from](https://user-images.githubusercontent.com/578661/37559878-e27c8c0a-2a2d-11e8-8eb6-f035dbafa297.png)

After:
![to](https://user-images.githubusercontent.com/578661/37559879-eaefff7a-2a2d-11e8-81a5-cc435ff91cf2.png)
