### PR TITLE
Support for i18n :html subkeys in help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ In addition to these necessary markup changes, the bootstrap_form API itself has
   [@duleorlovic](https://github.com/duleorlovic)
 * Your contribution here!
 
+* [#455](https://github.com/bootstrap-ruby/bootstrap_form/pull/455): Support for i18n :html subkeys in help text - [@jsaraiva](https://github.com/jsaraiva).
+
 ## [2.7.0][] (2017-04-21)
 
 Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ In addition to these necessary markup changes, the bootstrap_form API itself has
 * Support Bootstrap v4's [Custom Checkboxes and Radios](https://getbootstrap.com/docs/4.0/components/forms/#checkboxes-and-radios-1) with a new `custom: true` option
 * Allow HTML in help translations by using the `_html` suffix on the key - [@unikitty37](https://github.com/unikitty37)
 * [#408](https://github.com/bootstrap-ruby/bootstrap_form/pull/408): Add option[:id] on static control #245 - [@duleorlovic](https://github.com/duleorlovic).
+* [#455](https://github.com/bootstrap-ruby/bootstrap_form/pull/455): Support for i18n `:html` subkeys in help text - [@jsaraiva](https://github.com/jsaraiva).
 * Your contribution here!
 
 ### Bugfixes
@@ -35,7 +36,6 @@ In addition to these necessary markup changes, the bootstrap_form API itself has
   [@duleorlovic](https://github.com/duleorlovic)
 * Your contribution here!
 
-* [#455](https://github.com/bootstrap-ruby/bootstrap_form/pull/455): Support for i18n :html subkeys in help text - [@jsaraiva](https://github.com/jsaraiva).
 
 ## [2.7.0][] (2017-04-21)
 

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -539,7 +539,13 @@ module BootstrapForm
 
         underscored_scope = "activerecord.help.#{partial_scope.underscore}"
         downcased_scope = "activerecord.help.#{partial_scope.downcase}"
-        help_text = I18n.t(name, scope: underscored_scope, default: '').presence
+        # First check for a subkey :html, as it is also accepted by i18n, and the simple check for name would return an hash instead of a string (both with .presence returning true!)
+        help_text = I18n.t("#{name}.html", scope: underscored_scope, default: '').html_safe.presence
+        help_text ||= if text = I18n.t("#{name}.html", scope: downcased_scope, default: '').html_safe.presence
+                        warn "I18n key '#{downcased_scope}.#{name}' is deprecated, use '#{underscored_scope}.#{name}' instead"
+                        text
+                      end
+        help_text ||= I18n.t(name, scope: underscored_scope, default: '').presence
         help_text ||= if text = I18n.t(name, scope: downcased_scope, default: '').presence
                         warn "I18n key '#{downcased_scope}.#{name}' is deprecated, use '#{underscored_scope}.#{name}' instead"
                         text

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -207,6 +207,27 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.text_field(:password)
   end
 
+  test "help messages to look up I18n automatically using HTML key" do
+    I18n.backend.store_translations(:en, activerecord: {
+      help: {
+        user: {
+          password: {
+            html: 'A <strong>good</strong> password should be at least six characters long'
+          }
+        }
+      }
+    })
+
+    expected = <<-HTML.strip_heredoc
+      <div class="form-group">
+        <label for="user_password">Password</label>
+        <input class="form-control" id="user_password" name="user[password]" type="text" value="secret" />
+        <small class="form-text text-muted">A <strong>good</strong> password should be at least six characters long</small>
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.text_field(:password)
+  end
+
   test "help messages to warn about deprecated I18n key" do
     super_user = SuperUser.new(@user.attributes)
     builder = BootstrapForm::FormBuilder.new(:super_user, super_user, self, {})


### PR DESCRIPTION
This adds support for help text using :html subkey instead of the "_html" suffix to the attribute name.
Both are supported by i18n, actually: http://guides.rubyonrails.org/i18n.html#using-safe-html-translations .

This code just makes an additional check for an html subkey. If none is found, it continues in the regular fashion.