### PR TITLE
Fix label `for` attribute when passing non-english characters using `collection_check_boxes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ In addition to these necessary markup changes, the bootstrap_form API itself has
 * `static_control` will no longer properly show error messages. This is the result of bootstrap changes.
 * `static_control` will also no longer accept a block, use the `value` option instead.
 * Your contribution here!
+* [#456](https://github.com/bootstrap-ruby/bootstrap_form/pull/456): Fix label `for` attribute when passing non-english characters using `collection_check_boxes` - [@ug0](https://github.com/ug0).
 
 ### New features
 

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -134,10 +134,10 @@ module BootstrapForm
       label_name = name
       # label's `for` attribute needs to match checkbox tag's id,
       # IE sanitized value, IE
-      # https://github.com/rails/rails/blob/c57e7239a8b82957bcb07534cb7c1a3dcef71864/actionview/lib/action_view/helpers/tags/base.rb#L116-L118
+      # https://github.com/rails/rails/blob/5-0-stable/actionview/lib/action_view/helpers/tags/base.rb#L123-L125
       if options[:multiple]
         label_name =
-          "#{name}_#{checked_value.to_s.gsub(/\s/, "_").gsub(/[^-\w]/, "").downcase}"
+          "#{name}_#{checked_value.to_s.gsub(/\s/, "_").gsub(/[^-[[:word:]]]/, "").mb_chars.downcase.to_s}"
       end
 
       label_classes = [options[:label_class]]

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -176,6 +176,31 @@ class BootstrapCheckboxTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.collection_check_boxes(:misc, collection, :id, :street)
   end
 
+  test 'collection_check_boxes renders multiple checkboxes contains unicode characters in IDs correctly' do
+    struct = Struct.new(:id, :name)
+    collection = [struct.new(1, 'Foo'), struct.new('二', 'Bar')]
+    expected = <<-HTML.strip_heredoc
+      <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <div class="form-group">
+        <label for="user_misc">Misc</label>
+        <div class="form-check">
+          <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
+          <label class="form-check-label" for="user_misc_1">
+            Foo
+          </label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input" id="user_misc_二" name="user[misc][]" type="checkbox" value="二" />
+          <label class="form-check-label" for="user_misc_二">
+            Bar
+          </label>
+        </div>
+      </div>
+    HTML
+
+    assert_equivalent_xml expected, @builder.collection_check_boxes(:misc, collection, :id, :name)
+  end
+
   test 'collection_check_boxes renders inline checkboxes correctly' do
     collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
     expected = <<-HTML.strip_heredoc


### PR DESCRIPTION
Fixed a problem that `FormBuilder#check_box_with_bootstrap` https://github.com/bootstrap-ruby/bootstrap_form/blob/master/lib/bootstrap_form/form_builder.rb#L140 will remove any non-English letters passed in as the `for` attribute for the label tag. Therefore any group of checkboxes contains non-English values won't work.