### PR TITLE
Ensure tests work with mocha 1.5.0

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,10 +2,10 @@ require 'timecop'
 require 'diffy'
 require 'nokogiri'
 require 'equivalent-xml'
-require 'mocha/mini_test'
 
 require_relative "../demo/config/environment.rb"
 require "rails/test_help"
+require 'mocha/minitest'
 
 Rails.backtrace_cleaner.remove_silencers!
 


### PR DESCRIPTION
Fixes 2 issues:

```
`require': `require 'mocha/mini_test'` has been deprecated. Please use `require 'mocha/minitest' instead.
```

and

```
BootstrapFormGroupTest#test_help_messages_to_warn_about_deprecated_I18n_key:
Mocha::NotInitializedError: Mocha methods cannot be used outside the context of a test
```