### PR TITLE
default form-inline class applied to parent content div on date select helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### New features
 
+* [461](https://github.com/bootstrap-ruby/bootstrap_form/pull/461): default form-inline class applied to parent content div on date select helpers. Can override with a :skip_inline option on the field helper - [@lancecarlson](https://github.com/lancecarlson).
 * Your contribution here!
 
 ### Bugfixes
@@ -51,6 +52,7 @@ In addition to these necessary markup changes, the bootstrap_form API itself has
 * [#449](https://github.com/bootstrap-ruby/bootstrap_form/pull/449): Passing `.form-row` overrides default `.form-group.row` in horizontal layouts.
 * Added an option to the `submit` (and `primary`, by transitivity) form tag helper, `render_as_button`, which when truthy makes the submit button render as a button instead of an input. This allows you to easily provide further styling to your form submission buttons, without requiring you to reinvent the wheel and use the `button` helper (and having to manually insert the typical Bootstrap classes). - [@jsaraiva](https://github.com/jsaraiva).
 * Add `:error_message` option to `check_box` and `radio_button`, so they can output validation error messages if needed. [@lcreid](https://github.com/lcreid).
+* Your contribution here!
 
 ### Bugfixes
 

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -54,7 +54,9 @@ module BootstrapForm
       define_method(with_method_name) do |name, options = {}, html_options = {}|
         form_group_builder(name, options, html_options) do
           html_class = control_specific_class(method_name)
-          html_class = "#{html_class} form-inline" unless options[:skip_inline]
+          if @layout == :horizontal && !options[:skip_inline].present?
+            html_class = "#{html_class} form-inline"
+          end
           content_tag(:div, class: html_class) do
             input_with_error(name) do
               send(without_method_name, name, options, html_options)

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -53,7 +53,9 @@ module BootstrapForm
 
       define_method(with_method_name) do |name, options = {}, html_options = {}|
         form_group_builder(name, options, html_options) do
-          content_tag(:div, class: control_specific_class(method_name)) do
+          html_class = control_specific_class(method_name)
+          html_class = "#{html_class} form-inline" unless options[:skip_inline]
+          content_tag(:div, class: html_class) do
             input_with_error(name) do
               send(without_method_name, name, options, html_options)
             end

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -326,6 +326,33 @@ class BootstrapSelectsTest < ActionView::TestCase
       assert_equivalent_xml expected, @builder.date_select(:misc, wrapper_class: "none-margin")
     end
   end
+  
+  test "date selects inline when layout is horizontal" do
+    Timecop.freeze(Time.utc(2012, 2, 3)) do
+      expected = <<-HTML.strip_heredoc
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+        <input name="utf8" type="hidden" value="&#x2713;"/>
+        <div class="form-group row">
+          <label class="col-form-label col-sm-2" for="user_misc">Misc</label>
+          <div class="col-sm-10">
+            <div class="rails-bootstrap-forms-date-select form-inline">
+              <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
+                #{options_range(start: 2007, stop: 2017, selected: 2012)}
+              </select>
+              <select class="form-control" id="user_misc_2i" name="user[misc(2i)]">
+                #{options_range(start: 1, stop: 12, selected: 2, months: true)}
+              </select>
+              <select class="form-control" id="user_misc_3i" name="user[misc(3i)]">
+                #{options_range(start: 1, stop: 31, selected: 3)}
+              </select>
+            </div>
+          </div>
+        </div>
+      </form>
+      HTML
+      assert_equivalent_xml expected, bootstrap_form_for(@user, layout: :horizontal) { |f| f.date_select(:misc) }
+    end
+  end
 
   test "date selects are wrapped correctly with error" do
     @user.errors.add(:misc, "error for test")


### PR DESCRIPTION
can also override this behavior with skip_inline: true