### PR TITLE
Allow rendering of form submit buttons as HTML buttons, instead of input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ In addition to these necessary markup changes, the bootstrap_form API itself has
 * [#455](https://github.com/bootstrap-ruby/bootstrap_form/pull/455): Support for i18n `:html` subkeys in help text - [@jsaraiva](https://github.com/jsaraiva).
 * Adds support for `label_as_placeholder` option, which will set the label text as an input fields placeholder (and hiding the label for sr_only).
 * [#449](https://github.com/bootstrap-ruby/bootstrap_form/pull/449): Passing `.form-row` overrides default `.form-group.row` in horizontal layouts.
+* Added an option to the `submit` (and `primary`, by transitivity) form tag helper, `render_as_button`, which when truthy makes the submit button render as a button instead of an input. This allows you to easily provide further styling to your form submission buttons, without requiring you to reinvent the wheel and use the `button` helper (and having to manually insert the typical Bootstrap classes). - [@jsaraiva](https://github.com/jsaraiva).
 * Your contribution here!
 
 ### Bugfixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ You may find using demo application useful for development and debugging.
 ### 6. Done!
 
 Somebody will shortly review your pull request and if everything is good will be
-merged into master brach. Eventually gem will be published with your changes.
+merged into master branch. Eventually gem will be published with your changes.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ This gem wraps the following Rails form helpers:
 * time_zone_select
 * url_field
 * week_field
+* submit
+* button
 
 These helpers accept the same options as the standard Rails form helpers, with
 a few extra options:
@@ -419,6 +421,26 @@ You can specify your own classes like this:
 
 ```erb
 <%= f.submit "Log In", class: "btn btn-success" %>
+```
+
+If the `primary` helper receives a `render_as_button: true` option or a block,
+it will be rendered as an HTML button, instead of an input tag. This allows you
+to specify HTML content and styling for your buttons (such as adding
+illustrative icons to them). For example, the following statements
+
+```erb
+<%= f.primary "Save changes <span class='fa fa-save'></span>".html_safe, render_as_button: true %>
+
+<%= f.primary do
+      concat 'Save changes '
+      concat content_tag(:span, nil, class: 'fa fa-save')
+    end %>
+```
+
+are equivalent, and each of them both be rendered as
+
+```html
+<button name="button" type="submit" class="btn btn-primary">Save changes <span class="fa fa-save"></span></button>
 ```
 
 ### Accessing Rails Form Helpers

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -6,7 +6,6 @@ module BootstrapForm
 
         if options[:render_as_button]
           options.except! :render_as_button
-          options.reverse_merge! type: 'submit'
           button(name, options)
         else
           super(name, options)

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -3,7 +3,14 @@ module BootstrapForm
     module Bootstrap
       def submit(name = nil, options = {})
         options.reverse_merge! class: 'btn btn-secondary'
-        super(name, options)
+
+        if options[:render_as_button]
+          options.except! :render_as_button
+          options.reverse_merge! type: 'submit'
+          button(name, options)
+        else
+          super(name, options)
+        end
       end
 
       def primary(name = nil, options = {})

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -1,20 +1,25 @@
 module BootstrapForm
   module Helpers
     module Bootstrap
-      def submit(name = nil, options = {})
+      def button(value = nil, options = {}, &block)
         options.reverse_merge! class: 'btn btn-secondary'
-
-        if options[:render_as_button]
-          options.except! :render_as_button
-          button(name, options)
-        else
-          super(name, options)
-        end
+        super
       end
 
-      def primary(name = nil, options = {})
+      def submit(name = nil, options = {})
+        options.reverse_merge! class: 'btn btn-secondary'
+        super
+      end
+
+      def primary(name = nil, options = {}, &block)
         options.reverse_merge! class: 'btn btn-primary'
-        submit(name, options)
+
+        if options[:render_as_button] || block_given?
+          options.except! :render_as_button
+          button(name, options, &block)
+        else
+          submit(name, options)
+        end
       end
 
       def alert_message(title, options = {})

--- a/test/bootstrap_other_components_test.rb
+++ b/test/bootstrap_other_components_test.rb
@@ -132,6 +132,14 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.submit("Submit Form", class: "btn btn-primary")
   end
 
+  test "submit button can render as HTML button" do
+    expected = %{<button class="btn btn-primary" name="button" type="submit"><span>I'm HTML!</span> Submit Form</button>}
+    assert_equivalent_xml expected,
+                          @builder.submit("<span>I'm HTML!</span> Submit Form".html_safe,
+                                          render_as_button: true,
+                                          class: "btn btn-primary")
+  end
+
   test "primary button uses proper css classes" do
     expected = %{<input class="btn btn-primary" name="commit" type="submit" value="Submit Form" />}
     assert_equivalent_xml expected, @builder.primary("Submit Form")

--- a/test/bootstrap_other_components_test.rb
+++ b/test/bootstrap_other_components_test.rb
@@ -117,6 +117,12 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
     assert_equivalent_xml expected, output
   end
 
+  test "regular button uses proper css classes" do
+    expected = %{<button class="btn btn-secondary" name="button" type="submit"><span>I'm HTML!</span> in a button!</button>}
+    assert_equivalent_xml expected,
+                          @builder.button("<span>I'm HTML!</span> in a button!".html_safe)
+  end
+
   test "submit button defaults to rails action name" do
     expected = %{<input class="btn btn-secondary" name="commit" type="submit" value="Create User" />}
     assert_equivalent_xml expected, @builder.submit
@@ -132,17 +138,24 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.submit("Submit Form", class: "btn btn-primary")
   end
 
-  test "submit button can render as HTML button" do
-    expected = %{<button class="btn btn-primary" name="button" type="submit"><span>I'm HTML!</span> Submit Form</button>}
-    assert_equivalent_xml expected,
-                          @builder.submit("<span>I'm HTML!</span> Submit Form".html_safe,
-                                          render_as_button: true,
-                                          class: "btn btn-primary")
-  end
-
   test "primary button uses proper css classes" do
     expected = %{<input class="btn btn-primary" name="commit" type="submit" value="Submit Form" />}
     assert_equivalent_xml expected, @builder.primary("Submit Form")
+  end
+
+  test "primary button can render as HTML button" do
+    expected = %{<button class="btn btn-primary" name="button" type="submit"><span>I'm HTML!</span> Submit Form</button>}
+    assert_equivalent_xml expected,
+                          @builder.primary("<span>I'm HTML!</span> Submit Form".html_safe,
+                                           render_as_button: true)
+  end
+
+  test "primary button with content block renders as HTML button" do
+    output = @builder.primary do
+      "<span>I'm HTML!</span> Submit Form".html_safe
+    end
+    expected = %{<button class="btn btn-primary" name="button" type="submit"><span>I'm HTML!</span> Submit Form</button>}
+    assert_equivalent_xml expected, output
   end
 
   test "override primary button classes" do


### PR DESCRIPTION
As the title says, this PR allows devs to render submit buttons as HTML buttons, instead of using input tags.
The major advantage of this is that these submit buttons can then be styled, because they can have HTML content, as well as support for CSS pseudo-selectors.

All existing code should keep working normally. To use buttons instead of input tags, provide the `render_as_button` option with a truthy value:
`<%= f.primary t('.signin_button'), render_as_button: true %>`

Cheers!