### PR TITLE
Fix "Could not find table 'users'" during tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+ENV['RAILS_ENV'] ||= 'test'
+
 require 'timecop'
 require 'diffy'
 require 'nokogiri'


### PR DESCRIPTION
Setting the RAILS_ENV to `test` ensures that the Rails test setup happens as expected, loading the schema into the test database before the tests are run. This fixes a problem where the tests would fail with this message if `bundle exec rake test` is run on a fresh checkout:

    ActiveRecord::StatementInvalid:  Could not find table 'users'

This is an alternative to the documentation change proposed in #462.

Note that `ENV['RAILS_ENV'] = 'test'` was originally removed by me in #403 to fix bug #402. I re-tested that scenario after making the change in this PR, and could not reproduce the original bug. So it appears it is perfectly safe to add the code back in.