### PR TITLE
error_summary: don't render surrounding div if there are errors

### DIFF
--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -34,9 +34,11 @@ module BootstrapForm
       end
 
       def error_summary
-        content_tag :ul, class: 'rails-bootstrap-forms-error-summary' do
-          object.errors.full_messages.each do |error|
-            concat content_tag(:li, error)
+        if object.errors.full_messages.any?
+          content_tag :ul, class: 'rails-bootstrap-forms-error-summary' do
+            object.errors.full_messages.each do |error|
+              concat content_tag(:li, error)
+            end
           end
         end
       end

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -34,7 +34,7 @@ module BootstrapForm
       end
 
       def error_summary
-        if object.errors.full_messages.any?
+        if object.errors.any?
           content_tag :ul, class: 'rails-bootstrap-forms-error-summary' do
             object.errors.full_messages.each do |error|
               concat content_tag(:li, error)

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -572,6 +572,12 @@ class BootstrapFormTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.error_summary
   end
 
+  test "error_summary returns nothing if no errors" do
+    assert @user.valid?
+
+    assert_equal nil, @builder.error_summary
+  end
+
   test 'errors_on renders the errors for a specific attribute when invalid' do
     @user.email = nil
     assert @user.invalid?

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -573,6 +573,7 @@ class BootstrapFormTest < ActionView::TestCase
   end
 
   test "error_summary returns nothing if no errors" do
+    @user.terms = true
     assert @user.valid?
 
     assert_equal nil, @builder.error_summary


### PR DESCRIPTION
When there are no errors the div with for the error messages was still rendered, making it impossible to use css to style that surrounding div.