### PR TITLE
Document how to generate empty label.

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,21 @@ Which outputs:
 bootstrap_form follows standard rails conventions so it's i18n-ready. See more
 here: http://guides.rubyonrails.org/i18n.html#translations-for-active-record-models
 
+## Other Tips and Edge Cases
+By their very nature, forms are extremely diverse. It would be extremely difficult to provide a gem that could handle every need. Here are some tips for handling edge cases.
+
+### Empty But Visible Labels
+Some third party plug-ins require an empty but visible label on an input control. The `hide_label` option generates a label that won't appear on the screen, but it's considered invisible and therefore doesn't work with such a plug-in. An empty label (e.g. `""`) causes the underlying Rails helper to generate a label based on the field's attribute's name.
+
+The solution is to use a zero-width character for the label, or some other "empty" HTML. For example:
+```
+label: "&#8203;".html_safe
+```
+or
+```
+label: "<span></span>".html_safe
+```
+
 ## Code Triage page
 
 http://www.codetriage.com/potenza/bootstrap_form

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -18,6 +18,18 @@ class BootstrapCheckboxTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.check_box(:terms, label: 'I agree to the terms')
   end
 
+  test "check_box empty label" do
+    expected = <<-HTML.strip_heredoc
+      <div class="form-check">
+        <input name="user[terms]" type="hidden" value="0" />
+        <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
+        <label class="form-check-label" for="user_terms">&#8203;</label>
+      </div>
+    HTML
+    # &#8203; is a zero-width space.
+    assert_equivalent_xml expected, @builder.check_box(:terms, label: "&#8203;".html_safe)
+  end
+
   test "disabled check_box has proper wrapper classes" do
     expected = <<-HTML.strip_heredoc
       <div class="form-check">

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -17,6 +17,17 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.radio_button(:misc, '1', label: 'This is a radio button')
   end
 
+  test "radio_button no label" do
+    expected = <<-HTML.strip_heredoc
+      <div class="form-check">
+        <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
+        <label class="form-check-label" for="user_misc_1">&#8203;</label>
+      </div>
+    HTML
+    # &#8203; is a zero-width space.
+    assert_equivalent_xml expected, @builder.radio_button(:misc, '1', label: '&#8203;'.html_safe)
+  end
+
   test "radio_button with error is wrapped correctly" do
     @user.errors.add(:misc, "error for test")
     expected = <<-HTML.strip_heredoc


### PR DESCRIPTION
Some third-party plugins require an empty but visible label on controls. Since `hide_label` makes the label invisible, another solution is required.

Since this seems like an edge case, rather than add another option, this PR proposes a documentation change to show how to generate an empty, visible label.

Test cases were added to confirm the functionality, but are not really required as this is a documentation-only change.

Fixes #457.
