### PR TITLE
Set label's for: to id: option for checkbox and radio buttons.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ In addition to these necessary markup changes, the bootstrap_form API itself has
 * [#449](https://github.com/bootstrap-ruby/bootstrap_form/pull/449): Passing `.form-row` overrides default `.form-group.row` in horizontal layouts.
 * Added an option to the `submit` (and `primary`, by transitivity) form tag helper, `render_as_button`, which when truthy makes the submit button render as a button instead of an input. This allows you to easily provide further styling to your form submission buttons, without requiring you to reinvent the wheel and use the `button` helper (and having to manually insert the typical Bootstrap classes). - [@jsaraiva](https://github.com/jsaraiva).
 * Add `:error_message` option to `check_box` and `radio_button`, so they can output validation error messages if needed. [@lcreid](https://github.com/lcreid).
+- [#472](https://github.com/bootstrap-ruby/bootstrap_form/pull/472) Use `id` option's value as `for` attribute of label for custom checkboxes and radio buttons.
 * Your contribution here!
 
 ### Bugfixes

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -160,8 +160,10 @@ module BootstrapForm
           html = if options[:skip_label]
             checkbox_html
           else
-            # TODO: Notice we don't seem to pass the ID into the custom control.
-            checkbox_html.concat(label(label_name, label_description, class: label_class))
+            checkbox_html
+              .concat(label(label_name,
+                            label_description,
+                            { class: label_class }.merge(options[:id].present? ? { for: options[:id] } : {})))
           end
           html.concat(generate_error(name)) if options[:error_message]
           html
@@ -212,8 +214,8 @@ module BootstrapForm
           html = if options[:skip_label]
             radio_html
           else
-            # TODO: Notice we don't seem to pass the ID into the custom control.
-            radio_html.concat(label(name, options[:label], value: value, class: label_class))
+            radio_html
+              .concat(label(name, options[:label], { value: value, class: label_class }.merge(options[:id].present? ? { for: options[:id] } : {})))
           end
           html.concat(generate_error(name)) if options[:error_message]
           html

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -156,14 +156,16 @@ module BootstrapForm
         div_class = ["custom-control", "custom-checkbox"]
         div_class.append("custom-control-inline") if layout_inline?(options[:inline])
         label_class = label_classes.prepend("custom-control-label").compact.join(" ")
+
+        label_options = { class: label_class }
+        label_options[:for] = options[:id] if options[:id].present?
+
         content_tag(:div, class: div_class.compact.join(" ")) do
           html = if options[:skip_label]
             checkbox_html
           else
             checkbox_html
-              .concat(label(label_name,
-                            label_description,
-                            { class: label_class }.merge(options[:id].present? ? { for: options[:id] } : {})))
+              .concat(label(label_name, label_description, label_options))
           end
           html.concat(generate_error(name)) if options[:error_message]
           html
@@ -172,14 +174,16 @@ module BootstrapForm
         wrapper_class = "form-check"
         wrapper_class += " form-check-inline" if layout_inline?(options[:inline])
         label_class = label_classes.prepend("form-check-label").compact.join(" ")
+
+        label_options = { class: label_class }
+        label_options[:for] = options[:id] if options[:id].present?
+
         content_tag(:div, class: wrapper_class) do
           html = if options[:skip_label]
             checkbox_html
           else
             checkbox_html
-              .concat(label(label_name,
-                            label_description,
-                            { class: label_class }.merge(options[:id].present? ? { for: options[:id] } : {})))
+              .concat(label(label_name, label_description, label_options))
           end
           html.concat(generate_error(name)) if options[:error_message]
           html
@@ -210,12 +214,16 @@ module BootstrapForm
         div_class = ["custom-control", "custom-radio"]
         div_class.append("custom-control-inline") if layout_inline?(options[:inline])
         label_class = label_classes.prepend("custom-control-label").compact.join(" ")
+
+        label_options = { value: value, class: label_class }
+        label_options[:for] = options[:id] if options[:id].present?
+
         content_tag(:div, class: div_class.compact.join(" ")) do
           html = if options[:skip_label]
             radio_html
           else
             radio_html
-              .concat(label(name, options[:label], { value: value, class: label_class }.merge(options[:id].present? ? { for: options[:id] } : {})))
+              .concat(label(name, options[:label], label_options))
           end
           html.concat(generate_error(name)) if options[:error_message]
           html
@@ -224,12 +232,16 @@ module BootstrapForm
         wrapper_class = "form-check"
         wrapper_class += " form-check-inline" if layout_inline?(options[:inline])
         label_class = label_classes.prepend("form-check-label").compact.join(" ")
+
+        label_options = { value: value, class: label_class }
+        label_options[:for] = options[:id] if options[:id].present?
+
         content_tag(:div, class: "#{wrapper_class}#{disabled_class}") do
           html = if options[:skip_label]
             radio_html
           else
             radio_html
-              .concat(label(name, options[:label], { value: value, class: label_class }.merge(options[:id].present? ? { for: options[:id] } : {})))
+              .concat(label(name, options[:label], label_options))
           end
           html.concat(generate_error(name)) if options[:error_message]
           html

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -463,6 +463,17 @@ class BootstrapCheckboxTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.check_box(:terms, {label: 'I agree to the terms', custom: true})
   end
 
+  test "check_box is wrapped correctly with id option and custom option set" do
+    expected = <<-HTML.strip_heredoc
+      <div class="custom-control custom-checkbox">
+        <input name="user[terms]" type="hidden" value="0" />
+        <input class="custom-control-input" id="custom_id" name="user[terms]" type="checkbox" value="1" />
+        <label class="custom-control-label" for="custom_id">I agree to the terms</label>
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.check_box(:terms, {label: 'I agree to the terms', id: "custom_id", custom: true})
+  end
+
   test "check_box is wrapped correctly with custom and inline options set" do
     expected = <<-HTML.strip_heredoc
       <div class="custom-control custom-checkbox custom-control-inline">

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -379,6 +379,16 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.radio_button(:misc, '1', {label: 'This is a radio button', custom: true})
   end
 
+  test "radio_button is wrapped correctly with id option and custom option set" do
+    expected = <<-HTML.strip_heredoc
+      <div class="custom-control custom-radio">
+        <input class="custom-control-input" id="custom_id" name="user[misc]" type="radio" value="1" />
+        <label class="custom-control-label" for="custom_id">This is a radio button</label>
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.radio_button(:misc, '1', {label: 'This is a radio button', id: "custom_id", custom: true})
+  end
+
   test "radio_button with error is wrapped correctly with custom option set" do
     @user.errors.add(:misc, "error for test")
     expected = <<-HTML.strip_heredoc


### PR DESCRIPTION
If the programmer passes an `id` option to most helpers, our code sets the `for` attribute of the label to the value of the `id` option. However, this was not happening for custom check boxes and radio buttons. I can think of no reason why we shouldn't do the same for custom check boxes and radio buttons, so this PR does so.

Fixes #471.
