### PR TITLE
Fix `wrapper_class` and `wrapper` options for helpers that have `html_options`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ In addition to these necessary markup changes, the bootstrap_form API itself has
 * [#357](https://github.com/bootstrap-ruby/bootstrap_form/pull/357) if provided,
   use html option `id` to specify `for` attribute on label
   [@duleorlovic](https://github.com/duleorlovic)
+* [#347](https://github.com/bootstrap-ruby/bootstrap_form/issues/347) Fix `wrapper_class` and `wrapper` options for helpers that have `html_options`.
 * Your contribution here!
 
 

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -392,6 +392,10 @@ module BootstrapForm
 
     def form_group_builder(method, options, html_options = nil)
       options.symbolize_keys!
+
+      wrapper_class = options.delete(:wrapper_class)
+      wrapper_options = options.delete(:wrapper)
+
       html_options.symbolize_keys! if html_options
 
       # Add control_class; allow it to be overridden by :control_class option
@@ -402,8 +406,6 @@ module BootstrapForm
 
       options = convert_form_tag_options(method, options) if acts_like_form_tag
 
-      wrapper_class = css_options.delete(:wrapper_class)
-      wrapper_options = css_options.delete(:wrapper)
       help = options.delete(:help)
       icon = options.delete(:icon)
       label_col = options.delete(:label_col)

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -24,6 +24,16 @@ class BootstrapSelectsTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.time_zone_select(:misc)
   end
 
+  test "time zone selects are wrapped correctly with wrapper" do
+    expected = <<-HTML.strip_heredoc
+      <div class="form-group none-margin">
+        <label for="user_misc">Misc</label>
+        <select class="form-control" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.time_zone_select(:misc, nil, wrapper: { class: "none-margin" })
+  end
+
   test "time zone selects are wrapped correctly with error" do
     @user.errors.add(:misc, "error for test")
     expected = <<-HTML.strip_heredoc
@@ -165,6 +175,16 @@ class BootstrapSelectsTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.collection_select(:status, [], :id, :name)
   end
 
+  test "collection_selects are wrapped correctly with wrapper" do
+    expected = <<-HTML.strip_heredoc
+      <div class="form-group none-margin">
+        <label for="user_status">Status</label>
+        <select class="form-control" id="user_status" name="user[status]"></select>
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.collection_select(:status, [], :id, :name, wrapper: { class: "none-margin" })
+  end
+
   test "collection_selects are wrapped correctly with error" do
     @user.errors.add(:status, "error for test")
     expected = <<-HTML.strip_heredoc
@@ -212,6 +232,16 @@ class BootstrapSelectsTest < ActionView::TestCase
       </div>
     HTML
     assert_equivalent_xml expected, @builder.grouped_collection_select(:status, [], :last, :first, :to_s, :to_s)
+  end
+
+  test "grouped_collection_selects are wrapped correctly with wrapper" do
+    expected = <<-HTML.strip_heredoc
+      <div class="form-group none-margin">
+        <label for="user_status">Status</label>
+        <select class="form-control" id="user_status" name="user[status]"></select>
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.grouped_collection_select(:status, [], :last, :first, :to_s, :to_s, wrapper_class: "none-margin")
   end
 
   test "grouped_collection_selects are wrapped correctly with error" do
@@ -272,6 +302,28 @@ class BootstrapSelectsTest < ActionView::TestCase
         </div>
       HTML
       assert_equivalent_xml expected, @builder.date_select(:misc)
+    end
+  end
+
+  test "date selects are wrapped correctly with wrapper class" do
+    Timecop.freeze(Time.utc(2012, 2, 3)) do
+      expected = <<-HTML.strip_heredoc
+        <div class="form-group none-margin">
+          <label for="user_misc">Misc</label>
+          <div class="rails-bootstrap-forms-date-select">
+            <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
+              #{options_range(start: 2007, stop: 2017, selected: 2012)}
+            </select>
+            <select class="form-control" id="user_misc_2i" name="user[misc(2i)]">
+              #{options_range(start: 1, stop: 12, selected: 2, months: true)}
+            </select>
+            <select class="form-control" id="user_misc_3i" name="user[misc(3i)]">
+              #{options_range(start: 1, stop: 31, selected: 3)}
+            </select>
+          </div>
+        </div>
+      HTML
+      assert_equivalent_xml expected, @builder.date_select(:misc, wrapper_class: "none-margin")
     end
   end
 


### PR DESCRIPTION
`wrapper` and `wrapper_class` options were ignored for `date_select` and `time_select`. Further investigation indicated that the options were ignored for all helpers that take an explicit `html_options` argument.

The processing of `wrapper` and `wrapper_class` are moved to earlier in `form_group_builder`, and they're pulled explicitly from `options`, and not `html_options`. I believe this is correct, as the intent of `html_options` appears to be as a way to simply pass attributes to the underlying control.

I believe this fixes the original issue reported in #347, but may not address other comments on the issue.
