### PR TITLE
Remove minitest workarounds that are no longer needed

### DIFF
--- a/test/gemfiles/5.1.gemfile
+++ b/test/gemfiles/5.1.gemfile
@@ -5,9 +5,6 @@ gemspec path: "../../"
 gem "rails", "~> 5.1.0"
 
 group :test do
-  # TODO: remove once Rails 5.1.5 is released
-  gem "minitest", "~> 5.10.3"
-
   gem "diffy"
   gem "equivalent-xml"
   gem "mocha"

--- a/test/gemfiles/5.2.gemfile
+++ b/test/gemfiles/5.2.gemfile
@@ -5,9 +5,6 @@ gemspec path: "../../"
 gem "rails", "~> 5.2.0.beta2"
 
 group :test do
-  # TODO: remove once Rails > 5.2.0.beta2 is released
-  gem "minitest", "~> 5.10.3"
-
   gem "diffy"
   gem "equivalent-xml"
   gem "mocha"


### PR DESCRIPTION
The Rails incompatibilities with minitest have been fixed in the most recent Rails releases. We therefore no longer need to pin to an old version of minitest as a workaround.