### PR TITLE
allow static_control to force a nil value

### DIFF
--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -64,7 +64,7 @@ module BootstrapForm
           control_class: [options[:control_class], static_class].compact.join(" ")
         })
 
-        static_options[:value] = object.send(name) if static_options[:value].nil?
+        static_options[:value] = object.send(name) unless static_options.has_key?(:value)
 
         text_field_with_bootstrap(name, static_options)
       end

--- a/test/bootstrap_other_components_test.rb
+++ b/test/bootstrap_other_components_test.rb
@@ -61,6 +61,20 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
     assert_equivalent_xml expected, output
   end
 
+  test "static control support a nil value" do
+    output = @horizontal_builder.static_control label: "Custom Label", value: nil
+
+    expected = <<-HTML.strip_heredoc
+      <div class="form-group row">
+        <label class="col-form-label col-sm-2" for="user_">Custom Label</label>
+        <div class="col-sm-10">
+          <input class="form-control-plaintext" id="user_" name="user[]" readonly="readonly" type="text" value=""/>
+        </div>
+      </div>
+    HTML
+    assert_equivalent_xml expected, output
+  end
+
   test "static control won't overwrite a control_class that is passed by the user" do
     output = @horizontal_builder.static_control :email, control_class: "test_class"
 

--- a/test/bootstrap_other_components_test.rb
+++ b/test/bootstrap_other_components_test.rb
@@ -68,7 +68,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
       <div class="form-group row">
         <label class="col-form-label col-sm-2" for="user_">Custom Label</label>
         <div class="col-sm-10">
-          <input class="form-control-plaintext" id="user_" name="user[]" readonly="readonly" type="text" value=""/>
+          <input class="form-control-plaintext" id="user_" name="user[]" readonly="readonly" type="text"/>
         </div>
       </div>
     HTML


### PR DESCRIPTION
This pull request allows one to force a nil value with static_control.

    # Say you have this model
    class Model
      def attr
        1
      end
    end
    
    # in the view, you build a static_control and force the value :
    f.static_control :attr, value: nil
    
    # =>
    # with this PR, displayed value is an empty string
    # before PR, displayed value is 1