### PR TITLE
Fix offset for form group without label when multiple label widths are specified.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Your contribution here!
 * [#347](https://github.com/bootstrap-ruby/bootstrap_form/issues/347) Fix `wrapper_class` and `wrapper` options for helpers that have `html_options`.
 * [#472](https://github.com/bootstrap-ruby/bootstrap_form/pull/472) Use `id` option value as `for` attribute of label for custom checkboxes and radio buttons.
+* [#478](https://github.com/bootstrap-ruby/bootstrap_form/issues/478) Fix offset for form group without label when multiple label widths are specified.
 
 
 ## [4.0.0.alpha1][] (2018-06-16)

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -354,7 +354,7 @@ module BootstrapForm
     end
 
     def offset_col(label_col)
-      label_col.sub(/^col-(\w+)-(\d)$/, 'offset-\1-\2')
+      label_col.gsub(/\bcol-(\w+)-(\d)\b/, 'offset-\1-\2')
     end
 
     def default_control_col

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -611,6 +611,20 @@ class BootstrapFormTest < ActionView::TestCase
     assert_equivalent_xml expected, bootstrap_form_for(@user, layout: :horizontal, label_col: 'col-md-2', control_col: 'col-md-10') { |f| f.form_group { f.submit } }
   end
 
+  test "offset for form group without label respects multiple label widths for horizontal forms" do
+    expected = <<-HTML.strip_heredoc
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+        <input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="form-group row">
+          <div class="col-sm-8 col-md-10 offset-sm-4 offset-md-2">
+            <input class="btn btn-secondary" name="commit" type="submit" value="Create User" />
+          </div>
+        </div>
+      </form>
+    HTML
+    assert_equivalent_xml expected, bootstrap_form_for(@user, layout: :horizontal, label_col: 'col-sm-4 col-md-2', control_col: 'col-sm-8 col-md-10') { |f| f.form_group { f.submit } }
+  end
+
   test "custom input width for horizontal forms" do
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">


### PR DESCRIPTION
Make sure multiple label widths are converted into offsets for form groups without labels in horizontal forms.

Fixes #478 