### PR TITLE
Add add_control_col option on form_group.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ In addition to these necessary markup changes, the bootstrap_form API itself has
 * [#449](https://github.com/bootstrap-ruby/bootstrap_form/pull/449): Passing `.form-row` overrides default `.form-group.row` in horizontal layouts.
 * Added an option to the `submit` (and `primary`, by transitivity) form tag helper, `render_as_button`, which when truthy makes the submit button render as a button instead of an input. This allows you to easily provide further styling to your form submission buttons, without requiring you to reinvent the wheel and use the `button` helper (and having to manually insert the typical Bootstrap classes). - [@jsaraiva](https://github.com/jsaraiva).
 * Add `:error_message` option to `check_box` and `radio_button`, so they can output validation error messages if needed. [@lcreid](https://github.com/lcreid).
+* [#487](https://github.com/bootstrap-ruby/bootstrap_form/pull/487): Add add_control_col_class option on form_group. - [@ThomasSevestre](https://github.com/ThomasSevestre).
 * Your contribution here!
 
 ### Bugfixes

--- a/README.md
+++ b/README.md
@@ -539,6 +539,18 @@ The `label_col` and `control_col` css classes can also be changed per control:
 <% end %>
 ```
 
+Control col wrapper class can be modified with `add_control_col_class`. This option will preserve column definition:
+
+```erb
+<%= bootstrap_form_for(@user, layout: :horizontal) do |f| %>
+  <%= f.email_field :email %>
+  <%= f.text_field :age, add_control_col_class: "additional-control-col-class" %>
+  <%= f.form_group do %>
+    <%= f.submit %>
+  <% end %>
+<% end %>
+```
+
 ### Custom Field Layout
 
 The form-level `layout` can be overridden per field, unless the form-level layout was `inline`:

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -251,7 +251,7 @@ module BootstrapForm
       options[:class] << " form-inline" if field_inline_override?(options[:layout])
       options[:class] << " #{feedback_class}" if options[:icon]
 
-      content_tag(:div, options.except(:append, :id, :label, :help, :icon, :input_group_class, :label_col, :control_col, :layout, :prepend)) do
+      content_tag(:div, options.except(:append, :id, :label, :help, :icon, :input_group_class, :label_col, :control_col, :add_control_col, :layout, :prepend)) do
         label = generate_label(options[:id], name, options[:label], options[:label_col], options[:layout]) if options[:label]
         control = capture(&block)
 
@@ -260,6 +260,9 @@ module BootstrapForm
 
         if get_group_layout(options[:layout]) == :horizontal
           control_class = options[:control_col] || control_col
+          if options[:add_control_col]
+            control_class= [control_class, options[:add_control_col]].compact.join(' ')
+          end
           unless options[:label]
             control_offset = offset_col(options[:label_col] || @label_col)
             control_class = "#{control_class} #{control_offset}"
@@ -396,6 +399,7 @@ module BootstrapForm
       icon = options.delete(:icon)
       label_col = options.delete(:label_col)
       control_col = options.delete(:control_col)
+      add_control_col = options.delete(:add_control_col)
       layout = get_group_layout(options.delete(:layout))
       form_group_options = {
         id: options[:id],
@@ -403,6 +407,7 @@ module BootstrapForm
         icon: icon,
         label_col: label_col,
         control_col: control_col,
+        add_control_col: add_control_col,
         layout: layout,
         class: wrapper_class
       }

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -251,7 +251,7 @@ module BootstrapForm
       options[:class] << " form-inline" if field_inline_override?(options[:layout])
       options[:class] << " #{feedback_class}" if options[:icon]
 
-      content_tag(:div, options.except(:append, :id, :label, :help, :icon, :input_group_class, :label_col, :control_col, :add_control_col, :layout, :prepend)) do
+      content_tag(:div, options.except(:append, :id, :label, :help, :icon, :input_group_class, :label_col, :control_col, :add_control_col_class, :layout, :prepend)) do
         label = generate_label(options[:id], name, options[:label], options[:label_col], options[:layout]) if options[:label]
         control = capture(&block)
 
@@ -260,8 +260,8 @@ module BootstrapForm
 
         if get_group_layout(options[:layout]) == :horizontal
           control_class = options[:control_col] || control_col
-          if options[:add_control_col]
-            control_class= [control_class, options[:add_control_col]].compact.join(' ')
+          if options[:add_control_col_class]
+            control_class= [control_class, options[:add_control_col_class]].compact.join(' ')
           end
           unless options[:label]
             control_offset = offset_col(options[:label_col] || @label_col)
@@ -399,7 +399,7 @@ module BootstrapForm
       icon = options.delete(:icon)
       label_col = options.delete(:label_col)
       control_col = options.delete(:control_col)
-      add_control_col = options.delete(:add_control_col)
+      add_control_col_class = options.delete(:add_control_col_class)
       layout = get_group_layout(options.delete(:layout))
       form_group_options = {
         id: options[:id],
@@ -407,7 +407,7 @@ module BootstrapForm
         icon: icon,
         label_col: label_col,
         control_col: control_col,
-        add_control_col: add_control_col,
+        add_control_col_class: add_control_col_class,
         layout: layout,
         class: wrapper_class
       }

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -647,6 +647,21 @@ class BootstrapFormTest < ActionView::TestCase
     assert_equivalent_xml expected, bootstrap_form_for(@user, layout: :horizontal) { |f| f.email_field :email, control_col: 'col-sm-5' }
   end
 
+  test "additional input col class" do
+    expected = <<-HTML.strip_heredoc
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+        <input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="form-group row">
+          <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
+          <div class="col-sm-10 custom-class">
+            <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
+          </div>
+        </div>
+      </form>
+    HTML
+    assert_equivalent_xml expected, bootstrap_form_for(@user, layout: :horizontal) { |f| f.email_field :email, add_control_col_class: 'custom-class' }
+  end
+
   test "the field contains the error and is not wrapped in div.field_with_errors when bootstrap_form_for is used" do
     @user.email = nil
     assert @user.invalid?


### PR DESCRIPTION
Add add_control_col option on form_group.
This options allows caller to add classes on control col div, in addtion to the classes defined on the form.
