### PR TITLE
add required option on form_group_builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [461](https://github.com/bootstrap-ruby/bootstrap_form/pull/461): default form-inline class applied to parent content div on date select helpers. Can override with a :skip_inline option on the field helper - [@lancecarlson](https://github.com/lancecarlson).
 * Your contribution here!
 * The `button`, `submit`, and `primary` helpers can now receive an additional option, `extra_class`. This option allows us to specify additional CSS classes to be added to the corresponding button/input, _while_ maintaining the original default ones. E.g., a primary button with an `extra_class` 'test-button' will have its final CSS classes declaration as 'btn btn-primary test-button'.
+* [#488](https://github.com/bootstrap-ruby/bootstrap_form/pull/488): add required option on form_group_builder - [@ThomasSevestre](https://github.com/ThomasSevestre).
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,12 @@ In cases where this behavior is undesirable, use the `skip_required` option:
 <%= f.password_field :password, label: "New Password", skip_required: true %>
 ```
 
+In cases where the label `required` class should be added but the associated model has no presence validation, use the `required` option:
+
+```erb
+<%= f.password_field :password, label: "New Password", required: true %>
+```
+
 ### Input Elements / Controls
 
 To specify the class of the generated input tag, use the `control_class` option:

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ validator with the associated model attribute. Presently this is one of:
 ActiveRecord::Validations::PresenceValidator or
 ActiveModel::Validations::PresenceValidator.
 
-In cases where this behavior is undesirable, use the `required` to force the class to be present or absent :
+In cases where this behavior is undesirable, use the `required` option to force the class to be present or absent:
 
 ```erb
 <%= f.password_field :login, label: "New Username", required: true %>

--- a/README.md
+++ b/README.md
@@ -213,16 +213,11 @@ validator with the associated model attribute. Presently this is one of:
 ActiveRecord::Validations::PresenceValidator or
 ActiveModel::Validations::PresenceValidator.
 
-In cases where this behavior is undesirable, use the `skip_required` option:
+In cases where this behavior is undesirable, use the `required` to force the class to be present or absent :
 
 ```erb
-<%= f.password_field :password, label: "New Password", skip_required: true %>
-```
-
-In cases where the label `required` class should be added but the associated model has no presence validation, use the `required` option:
-
-```erb
-<%= f.password_field :password, label: "New Password", required: true %>
+<%= f.password_field :login, label: "New Username", required: true %>
+<%= f.password_field :password, label: "New Password", required: false %>
 ```
 
 ### Input Elements / Controls

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -427,6 +427,7 @@ module BootstrapForm
         form_group_options[:label] = {
           text: label_text,
           class: label_class,
+          required: options.delete(:required),
           skip_required: options.delete(:skip_required)
         }.merge(css_options[:id].present? ? { for: css_options[:id] } : {})
 
@@ -463,8 +464,8 @@ module BootstrapForm
         classes << "mr-sm-2"
       end
 
-      unless options.delete(:skip_required)
-        classes << "required" if required_attribute?(object, name)
+      if options.delete(:required) || (!options.delete(:skip_required) && required_attribute?(object, name))
+        classes << "required"
       end
 
       options[:class] = classes.compact.join(" ").strip

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -425,11 +425,11 @@ module BootstrapForm
         end
 
         if options.has_key?(:skip_required)
-          warn ":skip_required is deprecated, use :required instead"
+          warn "`:skip_required` is deprecated, use `:required: false` instead"
           if options.delete(:skip_required)
-            options[:required]= false
+            options[:required] = false
           else
-            options[:required]= :default
+            options[:required] = :default
           end
         end
 

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -424,10 +424,10 @@ module BootstrapForm
           label_text ||= options.delete(:label)
         end
 
-        options[:required] = if options.key?(:skip_required)
-                               warn "`:skip_required` is deprecated, use `:required: false` instead"
-                               options.delete(:skip_required) ? false : :default
-                             end
+        if options.key?(:skip_required)
+          warn "`:skip_required` is deprecated, use `:required: false` instead"
+          options[:required] = options.delete(:skip_required) ? false : :default
+        end
 
         form_group_options[:label] = {
           text: label_text,

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -424,11 +424,19 @@ module BootstrapForm
           label_text ||= options.delete(:label)
         end
 
+        if options.has_key?(:skip_required)
+          warn ":skip_required is deprecated, use :required instead"
+          if options.delete(:skip_required)
+            options[:required]= false
+          else
+            options[:required]= :default
+          end
+        end
+
         form_group_options[:label] = {
           text: label_text,
           class: label_class,
-          required: options.delete(:required),
-          skip_required: options.delete(:skip_required)
+          required: options.delete(:required)
         }.merge(css_options[:id].present? ? { for: css_options[:id] } : {})
 
         if options.delete(:label_as_placeholder)
@@ -464,8 +472,11 @@ module BootstrapForm
         classes << "mr-sm-2"
       end
 
-      if options.delete(:required) || (!options.delete(:skip_required) && required_attribute?(object, name))
+      case options.delete(:required)
+      when true
         classes << "required"
+      when nil, :default
+        classes << "required" if required_attribute?(object, name)
       end
 
       options[:class] = classes.compact.join(" ").strip

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -424,14 +424,10 @@ module BootstrapForm
           label_text ||= options.delete(:label)
         end
 
-        if options.has_key?(:skip_required)
-          warn "`:skip_required` is deprecated, use `:required: false` instead"
-          if options.delete(:skip_required)
-            options[:required] = false
-          else
-            options[:required] = :default
-          end
-        end
+        options[:required] = if options.key?(:skip_required)
+                               warn "`:skip_required` is deprecated, use `:required: false` instead"
+                               options.delete(:skip_required) ? false : :default
+                             end
 
         form_group_options[:label] = {
           text: label_text,

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -74,7 +74,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.text_field(:email, skip_label: true)
   end
 
-  test "preventing a label from having the required class" do
+  test "preventing a label from having the required class with :skip_required" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
         <label for="user_email">Email</label>
@@ -82,6 +82,16 @@ class BootstrapFormGroupTest < ActionView::TestCase
       </div>
     HTML
     assert_equivalent_xml expected, @builder.text_field(:email, skip_required: true)
+  end
+
+  test "preventing a label from having the required class" do
+    expected = <<-HTML.strip_heredoc
+      <div class="form-group">
+        <label for="user_email">Email</label>
+        <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.text_field(:email, required: false)
   end
 
   test "forcing a label to have the required class" do

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -84,6 +84,16 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.text_field(:email, skip_required: true)
   end
 
+  test "forcing a label to have the required class" do
+    expected = <<-HTML.strip_heredoc
+      <div class="form-group">
+        <label class="required" for="user_comments">Comments</label>
+        <input class="form-control" id="user_comments" name="user[comments]" type="text" value="my comment" />
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.text_field(:comments, required: true)
+  end
+
   test "label as placeholder" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">


### PR DESCRIPTION
Add required option on form_group_builder :

            = f.text_field :firstname, required: true

This option forces required class to be added, even if the there is no presence validation on the model.
This is usefull when the object model is not an active record model.

I will add tests and doc if you are interested