### PR TITLE
Fix code example for select

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ You still can use `wrapper_class` option to set only a css class. This is just a
 Our select helper accepts the same arguments as the [default Rails helper](http://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-select). Here's an example of how you pass both options and html_options hashes:
 
 ```erb
-<%= f.select :product, [["Apple", 1], ["Grape", 2]], { label: "Choose your favorite fruit:" }, { class: "selectpicker",  wrapper: { class: 'has-warning', data: { foo: 'bar' } } } %>
+<%= f.select :product, [["Apple", 1], ["Grape", 2]], { label: "Choose your favorite fruit:", wrapper: { class: 'has-warning', data: { foo: 'bar' } } }, { class: "selectpicker" } %>
 ```
 
 ### Checkboxes and Radios


### PR DESCRIPTION
The wrapper option is added to the wrong options hash in the example.