### PR TITLE
Add Rails 6 to TravisCI build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,13 @@ script:
 
 matrix:
   include:
-    # Bleeding edge
+    # Bleeding edge Ruby
     - rvm: ruby-head
       gemfile: test/gemfiles/5.2.gemfile
+
+    # Next version of Rails
+    - rvm: 2.5.0
+      gemfile: test/gemfiles/6.0.gemfile
 
     # Running one job to execute DANGER bot and linting
     - rvm: 2.5.0
@@ -30,3 +34,5 @@ matrix:
 
   allow_failures:
     - rvm: ruby-head
+    - rvm: 2.5.0
+      gemfile: test/gemfiles/6.0.gemfile

--- a/test/gemfiles/6.0.gemfile
+++ b/test/gemfiles/6.0.gemfile
@@ -1,0 +1,17 @@
+source "http://rubygems.org"
+
+gemspec path: "../../"
+
+gem "rails", "~> 6.0.0"
+
+group :development do
+  gem "rubocop", require: false
+end
+
+group :test do
+  gem "diffy"
+  gem "equivalent-xml"
+  gem "mocha"
+  gem "sqlite3"
+  gem "timecop", "~> 0.7.1"
+end

--- a/test/gemfiles/6.0.gemfile
+++ b/test/gemfiles/6.0.gemfile
@@ -2,7 +2,7 @@ source "http://rubygems.org"
 
 gemspec path: "../../"
 
-gem "rails", "~> 6.0.0"
+gem "rails", "~> 6.0.0.beta1"
 
 group :development do
   gem "rubocop", require: false


### PR DESCRIPTION
This PR adds Rails 6 to the TravisCI build, but allows failures for the Rails 6 tests. There are at least two issues with Rails 6, one of which causes failure of the build.

Part of #503.
