### PR TITLE
Fix TravisCI build for sqlite3 version change.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "http://rubygems.org"
 gemspec
 
 # Uncomment and change rails version for testing purposes
-# gem "rails", "~> 5.0.0"
+gem "rails", "~> 5.0.0"
 # gem "rails", "~> 6.0.0.beta1"
 
 group :development do
@@ -21,6 +21,7 @@ group :test do
   gem "diffy"
   gem "equivalent-xml"
   gem "mocha"
-  gem "sqlite3"
+  # sqlite3 1.4.0 breaks the test suite.
+  gem "sqlite3", "~> 1.3.0"
   gem "timecop", "~> 0.7.1"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "http://rubygems.org"
 gemspec
 
 # Uncomment and change rails version for testing purposes
-gem "rails", "~> 5.0.0"
+# gem "rails", "~> 5.0.0"
 # gem "rails", "~> 6.0.0.beta1"
 
 group :development do
@@ -22,6 +22,7 @@ group :test do
   gem "equivalent-xml"
   gem "mocha"
   # sqlite3 1.4.0 breaks the test suite.
-  gem "sqlite3", "~> 1.3.0"
+  # https://github.com/rails/rails/pull/35154
+  gem "sqlite3", "~> 1.3.6"
   gem "timecop", "~> 0.7.1"
 end

--- a/test/gemfiles/5.0.gemfile
+++ b/test/gemfiles/5.0.gemfile
@@ -13,6 +13,6 @@ group :test do
   gem "equivalent-xml"
   gem "minitest", "~> 5.10.3"
   gem "mocha"
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.3.6"
   gem "timecop", "~> 0.7.1"
 end

--- a/test/gemfiles/5.1.gemfile
+++ b/test/gemfiles/5.1.gemfile
@@ -12,6 +12,6 @@ group :test do
   gem "diffy"
   gem "equivalent-xml"
   gem "mocha"
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.3.6"
   gem "timecop", "~> 0.7.1"
 end

--- a/test/gemfiles/5.2.gemfile
+++ b/test/gemfiles/5.2.gemfile
@@ -12,6 +12,6 @@ group :test do
   gem "diffy"
   gem "equivalent-xml"
   gem "mocha"
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.3.6"
   gem "timecop", "~> 0.7.1"
 end

--- a/test/gemfiles/6.0.gemfile
+++ b/test/gemfiles/6.0.gemfile
@@ -12,6 +12,6 @@ group :test do
   gem "diffy"
   gem "equivalent-xml"
   gem "mocha"
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.3.6"
   gem "timecop", "~> 0.7.1"
 end


### PR DESCRIPTION
Sqlite3 is at a new version, which breaks Rails somehow. This will probably be fixed in a later version, but for now we need to specify the sqlite3 version in our gemfiles. See: https://github.com/rails/rails/pull/35154.
