### PR TITLE
Only concat help_text if it exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * Your contribution here!
 * [#522](https://github.com/bootstrap-ruby/bootstrap_form/pull/522): Clean up rubocop offences - [@simmerz](https://github.com/simmerz)
+* [#524](https://github.com/bootstrap-ruby/bootstrap_form/pull/524): Fix non-inline layout rendering without help text - [@simmerz](https://github.com/simmerz)
 
 ## [4.1.0][] (2019-01-19)
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -29,7 +29,7 @@ end
 # Have you updated CHANGELOG.md?
 # ------------------------------------------------------------------------------
 if !has_changelog_changes && has_lib_changes
-  markdown <<-MARKDOWN.strip_heredoc
+  markdown <<~MARKDOWN
     Here's an example of a CHANGELOG.md entry (place it immediately under the `* Your contribution here!` line):
 
     ```markdown

--- a/Dangerfile
+++ b/Dangerfile
@@ -29,12 +29,12 @@ end
 # Have you updated CHANGELOG.md?
 # ------------------------------------------------------------------------------
 if !has_changelog_changes && has_lib_changes
-  markdown <<~MARKDOWN
-    Here's an example of a CHANGELOG.md entry (place it immediately under the `* Your contribution here!` line):
+  markdown <<-MARKDOWN
+  Here's an example of a CHANGELOG.md entry (place it immediately under the `* Your contribution here!` line):
 
-    ```markdown
-    * [##{pr_number}](#{pr_url}): #{github.pr_title} - [@#{github.pr_author}](https://github.com/#{github.pr_author}).
-    ```
+  ```markdown
+  * [##{pr_number}](#{pr_url}): #{github.pr_title} - [@#{github.pr_author}](https://github.com/#{github.pr_author}).
+  ```
   MARKDOWN
   warn("Please update CHANGELOG.md with a description of your changes. "\
        "If this PR is not a user-facing change (e.g. just refactoring), "\

--- a/lib/bootstrap_form/form_group.rb
+++ b/lib/bootstrap_form/form_group.rb
@@ -36,7 +36,9 @@ module BootstrapForm
       if group_layout_horizontal?(options[:layout])
         concat(label).concat(content_tag(:div, capture(&block) + help_text, class: form_group_control_class(options)))
       else
-        concat(label).concat(capture(&block)).concat(help_text)
+        concat(label)
+        concat(capture(&block))
+        concat(help_text) if help_text
       end
     end
 


### PR DESCRIPTION
@lcreid I found a bug in my own code. This little fix allows help_text to be nil, and still work :|