### PR TITLE
Update collection_check_boxes.rb

### DIFF
--- a/lib/bootstrap_form/inputs/collection_check_boxes.rb
+++ b/lib/bootstrap_form/inputs/collection_check_boxes.rb
@@ -11,6 +11,8 @@ module BootstrapForm
         def collection_check_boxes_with_bootstrap(*args)
           html = inputs_collection(*args) do |name, value, options|
             options[:multiple] = true
+            options[:id] = "#{name}_#{value}" if options[:id].blank?
+
             check_box(name, options, value, nil)
           end
           hidden_field(args.first, value: "", multiple: true).concat(html)


### PR DESCRIPTION
set ids for collection_check_boxes if not supplied. this allows custom checkboxes to work and it is an html5 best practice for usability purposes. this fixes #531