### PR TITLE
Add support for Ransack::Search object to the first argument of bootrap_form_for

### DIFF
--- a/lib/bootstrap_form/components/hints.rb
+++ b/lib/bootstrap_form/components/hints.rb
@@ -39,7 +39,13 @@ module BootstrapForm
       end
 
       def object_class
-        object.class.to_s == "Ransack::Search" ? object.klass : object.class
+        if object.class.is_a?(ActiveModel::Naming)
+          object.class
+        elsif object.respond_to?(:klass) && object.klass.is_a?(ActiveModel::Naming)
+          object.klass
+        else
+          object.class
+        end
       end
 
       def scoped_help_text(name, partial_scope)

--- a/lib/bootstrap_form/components/hints.rb
+++ b/lib/bootstrap_form/components/hints.rb
@@ -20,10 +20,10 @@ module BootstrapForm
       def get_help_text_by_i18n_key(name)
         return unless object
 
-        partial_scope = if object.class.respond_to?(:model_name)
-                          object.class.model_name.name
+        partial_scope = if object_class.respond_to?(:model_name)
+                          object_class.model_name.name
                         else
-                          object.class.name
+                          object_class.name
                         end
 
         # First check for a subkey :html, as it is also accepted by i18n, and the
@@ -36,6 +36,10 @@ module BootstrapForm
           help_text = scoped_help_text(scope, partial_scope)
         end
         help_text
+      end
+
+      def object_class
+        object.class.to_s == "Ransack::Search" ? object.klass : object.class
       end
 
       def scoped_help_text(name, partial_scope)


### PR DESCRIPTION
Fixes #546 

Add Support for Ransack::Search object to the first argument of bootrap_form_for. 

## Usage example:

Controller

```
def index
  @q = Invoice.ransack(params[:q])
  @invoices = @q.result(distinct: true)
end
```

View

```
= bootstrap_form_for @q, url: invoices_path, method: :get do |f|
  = f.search_field :file_name_cont
  = f.submit
```