### PR TITLE
Add `default_layout` so we can use it for all forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,10 @@ module BootstrapForm
     def default_control_col
       'col-sm-8'
     end
+    def default_layout
+      # :default, :horizontal or :inline
+      :horizontal
+    end
   end
 end
 ```

--- a/lib/bootstrap_form/action_view_extensions/form_helper.rb
+++ b/lib/bootstrap_form/action_view_extensions/form_helper.rb
@@ -20,8 +20,6 @@ module BootstrapForm
       def bootstrap_form_for(record, options={}, &block)
         options.reverse_merge!(builder: BootstrapForm::FormBuilder)
 
-        options = process_options(options)
-
         with_bootstrap_form_field_error_proc do
           form_for(record, options, &block)
         end
@@ -29,8 +27,6 @@ module BootstrapForm
 
       def bootstrap_form_with(options={}, &block)
         options.reverse_merge!(builder: BootstrapForm::FormBuilder)
-
-        options = process_options(options)
 
         with_bootstrap_form_field_error_proc do
           form_with(options, &block)
@@ -44,16 +40,6 @@ module BootstrapForm
       end
 
       private
-
-      def process_options(options)
-        options[:html] ||= {}
-        options[:html][:role] ||= "form"
-
-        options[:layout] == :inline &&
-          options[:html][:class] = [options[:html][:class], "form-inline"].compact.join(" ")
-
-        options
-      end
 
       def with_bootstrap_form_field_error_proc
         original_proc = ActionView::Base.field_error_proc

--- a/lib/bootstrap_form/components/layout.rb
+++ b/lib/bootstrap_form/components/layout.rb
@@ -8,7 +8,7 @@ module BootstrapForm
       private
 
       def layout_default?(field_layout=nil)
-        [:default, nil].include? layout_in_effect(field_layout)
+        layout_in_effect(field_layout) == :default
       end
 
       def layout_horizontal?(field_layout=nil)

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -45,8 +45,9 @@ module BootstrapForm
 
     delegate :content_tag, :capture, :concat, to: :@template
 
+    # rubocop:disable Metrics/AbcSize
     def initialize(object_name, object, template, options)
-      @layout = options[:layout]
+      @layout = options[:layout] || default_layout
       @label_col = options[:label_col] || default_label_col
       @control_col = options[:control_col] || default_control_col
       @label_errors = options[:label_errors] || false
@@ -57,7 +58,18 @@ module BootstrapForm
                          options[:inline_errors] != false
                        end
       @acts_like_form_tag = options[:acts_like_form_tag]
+      add_form_role_and_form_inline options
       super
+    end
+    # rubocop:enable Metrics/AbcSize
+
+    def add_form_role_and_form_inline(options)
+      options[:html] ||= {}
+      options[:html][:role] ||= "form"
+
+      return unless options[:layout] == :inline
+
+      options[:html][:class] = [options[:html][:class], "form-inline"].compact.join(" ")
     end
 
     def fields_for_with_bootstrap(record_name, record_object=nil, fields_options={}, &block)
@@ -84,6 +96,11 @@ module BootstrapForm
       end
       field_options[:label_col] = field_options[:label_col].present? ? (field_options[:label_col]).to_s : options[:label_col]
       field_options
+    end
+
+    def default_layout
+      # :default, :horizontal or :inline
+      :default
     end
 
     def default_label_col

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -123,7 +123,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
 
   test "inline checkboxes from form layout" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="form-inline" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user form-inline" id="new_user" method="post" role="form">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-check form-check-inline">
           <input name="user[terms]" type="hidden" value="0" />

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -387,7 +387,7 @@ class BootstrapFieldsTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="form-inline" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user form-inline" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group">
           <label class="mr-sm-2" for="user_address_attributes_street">Street</label>

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -130,7 +130,7 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "inline-style forms" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="form-inline" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user form-inline" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group">
           <label class="mr-sm-2 required" for="user_email">Email</label>
@@ -701,7 +701,7 @@ class BootstrapFormTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group">
           <div class="field_with_errors">

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -98,7 +98,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "radio_button inline label is set correctly from form level" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="form-inline" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user form-inline" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-check form-check-inline">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />


### PR DESCRIPTION
Move `process_options` from helper since we can not override helper.
When someone wants to extend `BootstrapForm::FormBuilder` and use it in
`form_with .... builder: MyFormBuilder`, before this change he could not
use in this way since determination whether it is :inline :horizontal
was done in helper.