### PR TITLE
Cache bundler to speed up travis build

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,7 @@ AllCops:
     - "demo/tmp/**/*"
     - "demo/vendor/**/*"
     - Gemfile
+    - gemfiles/vendor/bundle/**/*
     - Guardfile
     - Rakefile
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,33 +4,32 @@ rvm:
   - 2.5.6
   - 2.6.4
 gemfile:
-  - test/gemfiles/5.0.gemfile
-  - test/gemfiles/5.1.gemfile
-  - test/gemfiles/5.2.gemfile
-  - test/gemfiles/6.0.gemfile
-before_install:
-  - gem i rubygems-update -v '<3' && update_rubygems
-  - gem install bundler -v 1.17.3 --no-document
+  - gemfiles/5.0.gemfile
+  - gemfiles/5.1.gemfile
+  - gemfiles/5.2.gemfile
+  - gemfiles/6.0.gemfile
+cache:
+  bundler: true
 script:
   - bundle exec rake test
 
 matrix:
   exclude:
     - rvm: 2.4.6
-      gemfile: test/gemfiles/6.0.gemfile
+      gemfile: gemfiles/6.0.gemfile
 
   include:
     # Bleeding edge Ruby
     - rvm: ruby-head
-      gemfile: test/gemfiles/6.0.gemfile
+      gemfile: gemfiles/6.0.gemfile
 
     # Next version of Rails
     - rvm: 2.5.0
-      gemfile: test/gemfiles/edge.gemfile
+      gemfile: gemfiles/edge.gemfile
 
     # Running one job to execute DANGER bot and linting
     - rvm: 2.5.0
-      gemfile: test/gemfiles/6.0.gemfile
+      gemfile: gemfiles/6.0.gemfile
       script:
         - gem install danger
         - danger
@@ -39,4 +38,4 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: 2.5.0
-      gemfile: test/gemfiles/edge.gemfile
+      gemfile: gemfiles/edge.gemfile

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -1,19 +1,18 @@
 source "http://rubygems.org"
 
-gemspec path: "../../"
+gemspec path: "../"
 
-gem "rails", git: "https://github.com/rails/rails.git"
+gem "rails", "~> 5.0.0"
 
 group :development do
   gem "rubocop-rails", require: false
-  gem "sassc-rails"
-  gem "webpacker"
 end
 
 group :test do
   gem "diffy"
   gem "equivalent-xml"
+  gem "minitest", "~> 5.10.3"
   gem "mocha"
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.3.6"
   gem "timecop", "~> 0.7.1"
 end

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gemspec path: "../../"
+gemspec path: "../"
 
 gem "rails", "~> 5.1.0"
 

--- a/gemfiles/5.2.gemfile
+++ b/gemfiles/5.2.gemfile
@@ -1,8 +1,8 @@
 source "http://rubygems.org"
 
-gemspec path: "../../"
+gemspec path: "../"
 
-gem "rails", "~> 5.0.0"
+gem "rails", "~> 5.2.0"
 
 group :development do
   gem "rubocop-rails", require: false
@@ -11,8 +11,7 @@ end
 group :test do
   gem "diffy"
   gem "equivalent-xml"
-  gem "minitest", "~> 5.10.3"
   gem "mocha"
-  gem "sqlite3", "~> 1.3.6"
+  gem "sqlite3", "~> 1.4"
   gem "timecop", "~> 0.7.1"
 end

--- a/gemfiles/6.0.gemfile
+++ b/gemfiles/6.0.gemfile
@@ -1,17 +1,19 @@
 source "http://rubygems.org"
 
-gemspec path: "../../"
+gemspec path: "../"
 
-gem "rails", "~> 5.2.0"
+gem "rails", "~> 6.0.0"
 
 group :development do
   gem "rubocop-rails", require: false
+  gem "sassc"
+  gem "webpacker", ">= 4.0.0.rc.3"
 end
 
 group :test do
   gem "diffy"
   gem "equivalent-xml"
   gem "mocha"
-  gem "sqlite3", "~> 1.4"
+  gem "sqlite3"
   gem "timecop", "~> 0.7.1"
 end

--- a/gemfiles/edge.gemfile
+++ b/gemfiles/edge.gemfile
@@ -1,13 +1,13 @@
 source "http://rubygems.org"
 
-gemspec path: "../../"
+gemspec path: "../"
 
-gem "rails", "~> 6.0.0"
+gem "rails", git: "https://github.com/rails/rails.git"
 
 group :development do
   gem "rubocop-rails", require: false
-  gem "sassc"
-  gem "webpacker", ">= 4.0.0.rc.3"
+  gem "sassc-rails"
+  gem "webpacker"
 end
 
 group :test do


### PR DESCRIPTION
Travis uses about 40 seconds to install gems.  The goal is to reduce this as much as possible.