### PR TITLE
Do not set role="form" by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bugfixes
 
-* Your contribution here!
+* [#560](https://github.com/bootstrap-ruby/bootstrap_form/pull/560): Do not set role="form" by default - [@sharshenov](https://github.com/sharshenov).
 
 ## [4.4.0][] (2020-03-08)
 

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -65,7 +65,6 @@ module BootstrapForm
 
     def add_form_role_and_form_inline(options)
       options[:html] ||= {}
-      options[:html][:role] ||= "form"
 
       return unless options[:layout] == :inline
 

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -123,7 +123,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
 
   test "inline checkboxes from form layout" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user form-inline" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user form-inline" id="new_user" method="post">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-check form-check-inline">
           <input name="user[terms]" type="hidden" value="0" />
@@ -581,7 +581,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     @user.errors.add(:misc, "a box must be checked")
 
     expected = <<-HTML.strip_heredoc
-    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="form-group">
@@ -610,7 +610,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     @user.errors.add(:misc, "error for test")
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
         <div class="form-group">
@@ -637,7 +637,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "check_box renders error when asked" do
     @user.errors.add(:terms, "You must accept the terms.")
     expected = <<-HTML.strip_heredoc
-    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
@@ -658,7 +658,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "check_box with error is wrapped correctly with custom option set" do
     @user.errors.add(:terms, "You must accept the terms.")
     expected = <<-HTML.strip_heredoc
-    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       <div class="custom-control custom-checkbox">
         <input name="user[terms]" type="hidden" value="0" />

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -99,7 +99,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "file fields are wrapped correctly with error" do
     @user.errors.add(:misc, "error for test")
     expected = <<-HTML.strip_heredoc
-    <form accept-charset="UTF-8" action="/users" class="new_user" enctype="multipart/form-data" id="new_user" method="post" role="form">
+    <form accept-charset="UTF-8" action="/users" class="new_user" enctype="multipart/form-data" id="new_user" method="post">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       <div class="form-group">
         <label for="user_misc">Misc</label>
@@ -321,7 +321,7 @@ class BootstrapFieldsTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group">
           <label for="user_address_attributes_street">Street</label>
@@ -342,7 +342,7 @@ class BootstrapFieldsTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group">
           <label for="user_preferences_favorite_color">Favorite color</label>
@@ -363,7 +363,7 @@ class BootstrapFieldsTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group row">
           <label class="col-form-label col-sm-2" for="user_address_attributes_street">Street</label>
@@ -387,7 +387,7 @@ class BootstrapFieldsTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user form-inline" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user form-inline" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group">
           <label class="mr-sm-2" for="user_address_attributes_street">Street</label>

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -186,7 +186,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert @user.invalid?
 
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group">
           <label class="required" for="user_email">Email</label>
@@ -432,7 +432,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group">
           <div class="form-check">
@@ -491,7 +491,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group none-margin">
           <label class="required" for="user_email">Email</label>
@@ -595,7 +595,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "custom form group layout option" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group form-inline">
           <label class="mr-sm-2 required" for="user_email">Email</label>

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -7,7 +7,7 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "default-style forms" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       </form>
     HTML
@@ -16,7 +16,7 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "default-style form fields layout horizontal" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group row">
           <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
@@ -68,7 +68,7 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "default-style form fields layout inline" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group form-inline">
           <label class="mr-sm-2 required" for="user_email">Email</label>
@@ -120,7 +120,7 @@ class BootstrapFormTest < ActionView::TestCase
     # generate a default ID for the form element.
     test "default-style forms bootstrap_form_with Rails 5.1+" do
       expected = <<-HTML.strip_heredoc
-        <form accept-charset="UTF-8" action="/users" data-remote="true" method="post" role="form">
+        <form accept-charset="UTF-8" action="/users" data-remote="true" method="post">
           #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         </form>
       HTML
@@ -130,7 +130,7 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "inline-style forms" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user form-inline" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user form-inline" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group">
           <label class="mr-sm-2 required" for="user_email">Email</label>
@@ -175,7 +175,7 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "horizontal-style forms" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group row">
           <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
@@ -226,7 +226,7 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "horizontal-style form fields layout default" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group">
           <label class="required" for="user_email">Email</label>
@@ -272,7 +272,7 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "horizontal-style form fields layout inline" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group form-inline">
           <label class="mr-sm-2 required" for="user_email">Email</label>
@@ -318,7 +318,7 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "existing styles aren't clobbered when specifying a form style" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="my-style" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="my-style" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group row">
           <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
@@ -332,7 +332,7 @@ class BootstrapFormTest < ActionView::TestCase
                           bootstrap_form_for(@user, layout: :horizontal, html: { class: "my-style" }) { |f| f.email_field :email }
   end
 
-  test "given role attribute should not be covered by default role attribute" do
+  test "given role attribute be applied" do
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="not-a-form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
@@ -343,7 +343,7 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "bootstrap_form_tag acts like a form tag" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group">
           <label for="email">Your Email</label>
@@ -357,7 +357,7 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "bootstrap_form_for does not clobber custom options" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group">
           <label class="required" for="ID">Email</label>
@@ -370,7 +370,7 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "bootstrap_form_tag does not clobber custom options" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group">
           <label for="ID">Email</label>
@@ -390,7 +390,7 @@ class BootstrapFormTest < ActionView::TestCase
       name = "[misc]"
     end
     expected = <<-HTML.strip_heredoc
-    <form accept-charset="UTF-8" action="/users" method="post" role="form">
+    <form accept-charset="UTF-8" action="/users" method="post">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       <div class="form-check">
         <input class="form-check-input" id="#{id}" name="#{name}" type="checkbox" value="1" />
@@ -407,7 +407,7 @@ class BootstrapFormTest < ActionView::TestCase
     assert @user.invalid?
 
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group">
           <label class="required text-danger" for="user_email">Email can't be blank, is too short (minimum is 5 characters)</label>
@@ -423,7 +423,7 @@ class BootstrapFormTest < ActionView::TestCase
     assert @user.invalid?
 
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group">
           <label class="required text-danger" for="user_email">Email can&#39;t be blank, is too short (minimum is 5 characters)</label>
@@ -443,7 +443,7 @@ class BootstrapFormTest < ActionView::TestCase
       assert @user.invalid?
 
       expected = <<-HTML.strip_heredoc
-        <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+        <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
           #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
           <div class="form-group">
             <label class="required text-danger" for="user_email">Your e-mail address can&#39;t be blank, is too short (minimum is 5 characters)</label>
@@ -501,7 +501,7 @@ class BootstrapFormTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="alert alert-danger">
           <p>Please fix the following errors:</p>
@@ -525,7 +525,7 @@ class BootstrapFormTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="alert alert-danger">
           <p>Please fix the following errors:</p>
@@ -544,7 +544,7 @@ class BootstrapFormTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="alert alert-danger">
           <p>Please fix the following errors:</p>
@@ -592,7 +592,7 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "custom label width for horizontal forms" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group row">
           <label class="col-form-label col-sm-1 required" for="user_email">Email</label>
@@ -608,7 +608,7 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "offset for form group without label respects label width for horizontal forms" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group row">
           <div class="col-md-10 offset-md-2">
@@ -624,7 +624,7 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "offset for form group without label respects multiple label widths for horizontal forms" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group row">
           <div class="col-sm-8 col-md-10 offset-sm-4 offset-md-2">
@@ -640,7 +640,7 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "custom input width for horizontal forms" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group row">
           <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
@@ -656,7 +656,7 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "additional input col class" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group row">
           <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
@@ -680,7 +680,7 @@ class BootstrapFormTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group">
           <label class="required" for="user_email">Email</label>
@@ -701,7 +701,7 @@ class BootstrapFormTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group">
           <div class="field_with_errors">
@@ -726,7 +726,7 @@ class BootstrapFormTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group">
           <label class="required" for="user_email">Email</label>
@@ -747,7 +747,7 @@ class BootstrapFormTest < ActionView::TestCase
       end
 
       expected = <<-HTML.strip_heredoc
-        <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+        <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
           #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
           <div class="form-group">
             <label class="required" for="user_email">Email</label>

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -31,7 +31,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "radio_button with error is wrapped correctly" do
     @user.errors.add(:misc, "error for test")
     expected = <<-HTML.strip_heredoc
-    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       <div class="form-check">
         <input class="form-check-input is-invalid" id="user_misc_1" name="user[misc]" type="radio" value="1" />
@@ -98,7 +98,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "radio_button inline label is set correctly from form level" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user form-inline" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user form-inline" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-check form-check-inline">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
@@ -182,7 +182,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     @user.errors.add(:misc, "error for test")
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group">
           <label for="user_misc">Misc</label>
@@ -417,7 +417,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "radio_button with error is wrapped correctly with custom option set" do
     @user.errors.add(:misc, "error for test")
     expected = <<-HTML.strip_heredoc
-    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       <div class="custom-control custom-radio">
         <input class="custom-control-input is-invalid" id="user_misc_1" name="user[misc]" type="radio" value="1" />

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -37,7 +37,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "time zone selects are wrapped correctly with error" do
     @user.errors.add(:misc, "error for test")
     expected = <<-HTML.strip_heredoc
-    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       <div class="form-group">
         <label for="user_misc">Misc</label>
@@ -192,7 +192,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "collection_selects are wrapped correctly with error" do
     @user.errors.add(:status, "error for test")
     expected = <<-HTML.strip_heredoc
-    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       <div class="form-group">
         <label for="user_status">Status</label>
@@ -253,7 +253,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "grouped_collection_selects are wrapped correctly with error" do
     @user.errors.add(:status, "error for test")
     expected = <<-HTML.strip_heredoc
-    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       <div class="form-group">
         <label for="user_status">Status</label>
@@ -340,7 +340,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "date selects inline when layout is horizontal" do
     Timecop.freeze(Time.utc(2012, 2, 3)) do
       expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group row">
           <label class="col-form-label col-sm-2" for="user_misc">Misc</label>
@@ -368,7 +368,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     @user.errors.add(:misc, "error for test")
     Timecop.freeze(Time.utc(2012, 2, 3)) do
       expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group">
           <label for="user_misc">Misc</label>
@@ -469,7 +469,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     @user.errors.add(:misc, "error for test")
     Timecop.freeze(Time.utc(2012, 2, 3, 12, 0, 0)) do
       expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group">
           <label for="user_misc">Misc</label>
@@ -577,7 +577,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     @user.errors.add(:misc, "error for test")
     Timecop.freeze(Time.utc(2012, 2, 3, 12, 0, 0)) do
       expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-group">
           <label for="user_misc">Misc</label>


### PR DESCRIPTION
First of all, thank you (all contributors of this project) for the excellent gem. I use it in all projects with bootstrap :1st_place_medal: 

There is a problem with default `role` attribute of generated form. W3C validator shows a warning for `role="form"` attribute of form tag:

> The `form` role is unnecessary for element `form`.

Steps to reproduce:
1. Open [W3C validator with text input](https://validator.w3.org/nu/#textarea)
2. Paste code below
3. Inspect warning

```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <title>title</title>
  </head>
  <body>
    <form role="form">
      <button>submit</button>
    </form>
  </body>
</html>
```

[Explanation why the validator raises the warning.](https://stackoverflow.com/a/35402845) 

This PR drops default `form` role attribute, but still allows to set role attribute explicitly:
```ruby
bootstrap_form_for(@user, html: { role: "not-a-form" }) { |_f| nil }
```