### PR TITLE
Allow to configure default form attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### New features
 
-* Your contribution here!
+* [#562](https://github.com/bootstrap-ruby/bootstrap_form/pull/562): Allow to configure default form attributes - [@sharshenov](https://github.com/sharshenov).
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -153,12 +153,20 @@ in `form_with`.
 
 ## Configuration
 
-`bootstrap_form` has some default options that can be overriden:
+`bootstrap_form` can be used out-of-the-box without any configuration. However, `bootstrap_form` does have an optional configuration file at `config/initializers/bootstrap_form.rb` for setting options that affect all generated forms in an application.
 
+The current configuration options are:
+
+| Option | Default value | Description |
+|---------------------------|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `default_form_attributes` | `{role: "form"}` | version [2.2.0](https://github.com/bootstrap-ruby/bootstrap_form/blob/master/CHANGELOG.md#220-2014-09-16) added a role="form" attribute to all forms.   The W3C validator will raise a **warning** on forms with a role="form" attribute.   Set this option to `{}` to make forms be W3C compliant. |
+
+
+Example:
 ```ruby
 # config/initializers/bootstrap_form.rb
 BootstrapForm.configure do |c|
-  # c.default_form_attributes = { role: "form" }
+  c.default_form_attributes = {} # to make forms W3C compliant
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,18 @@ in `form_with`.
 
 `form_with` has some important differences compared to `form_for` and `form_tag`, and these differences apply to `bootstrap_form_with`. A good summary of the differences can be found at: https://m.patrikonrails.com/rails-5-1s-form-with-vs-old-form-helpers-3a5f72a8c78a, or in the [Rails documentation](api.rubyonrails.org).
 
+
+## Configuration
+
+`bootstrap_form` has some default options that can be overriden:
+
+```ruby
+# config/initializers/bootstrap_form.rb
+BootstrapForm.configure do |c|
+  # c.default_form_attributes = { role: "form" }
+end
+```
+
 ## Form Helpers
 
 `bootstrap_form` provides its own version of the following Rails form helpers:

--- a/bootstrap_form.gemspec
+++ b/bootstrap_form.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |s|
                   "easy to create beautiful-looking forms using Bootstrap 4"
   s.license     = "MIT"
 
+  s.post_install_message = "Default form attribute role=\"form\" will be dropped in 5.0.0"
+
   s.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test)/})
   end

--- a/lib/bootstrap_form.rb
+++ b/lib/bootstrap_form.rb
@@ -13,6 +13,7 @@ module BootstrapForm
   extend ActiveSupport::Autoload
 
   eager_autoload do
+    autoload :Configuration
     autoload :FormBuilder
     autoload :FormGroupBuilder
     autoload :FormGroup
@@ -21,11 +22,21 @@ module BootstrapForm
     autoload :Helpers
   end
 
-  def self.eager_load!
-    super
-    BootstrapForm::Components.eager_load!
-    BootstrapForm::Helpers.eager_load!
-    BootstrapForm::Inputs.eager_load!
+  class << self
+    def eager_load!
+      super
+      BootstrapForm::Components.eager_load!
+      BootstrapForm::Helpers.eager_load!
+      BootstrapForm::Inputs.eager_load!
+    end
+
+    def config
+      @config ||= BootstrapForm::Configuration.new
+    end
+
+    def configure
+      yield config
+    end
   end
 
   mattr_accessor :field_error_proc

--- a/lib/bootstrap_form/configuration.rb
+++ b/lib/bootstrap_form/configuration.rb
@@ -2,16 +2,22 @@
 
 module BootstrapForm
   class Configuration
-    DEFAULT = {
-      default_form_attributes: {
-        role: "form"
-      }
-    }.freeze
+    def default_form_attributes=(attributes)
+      case attributes
+      when nil
+        @default_form_attributes = {}
+      when Hash
+        @default_form_attributes = attributes
+      else
+        raise ArgumentError, "Unsupported default_form_attributes #{attributes.inspect}"
+      end
+    end
 
-    DEFAULT.keys.each { |key| attr_accessor key }
+    def default_form_attributes
+      return @default_form_attributes if defined? @default_form_attributes
 
-    def initialize
-      DEFAULT.each { |key, value| send("#{key}=", value) }
+      # TODO: Return blank hash ({}) in 5.0.0. Role "form" for form tags is redundant and makes W3C to raise a warning.
+      { role: "form" }
     end
   end
 end

--- a/lib/bootstrap_form/configuration.rb
+++ b/lib/bootstrap_form/configuration.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module BootstrapForm
+  class Configuration
+    DEFAULT = {
+      default_form_attributes: {
+        role: "form"
+      }
+    }.freeze
+
+    DEFAULT.keys.each { |key| attr_accessor key }
+
+    def initialize
+      DEFAULT.each { |key, value| send("#{key}=", value) }
+    end
+  end
+end

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -58,14 +58,14 @@ module BootstrapForm
                          options[:inline_errors] != false
                        end
       @acts_like_form_tag = options[:acts_like_form_tag]
-      add_form_role_and_form_inline options
+      add_default_form_attributes_and_form_inline options
       super
     end
     # rubocop:enable Metrics/AbcSize
 
-    def add_form_role_and_form_inline(options)
+    def add_default_form_attributes_and_form_inline(options)
       options[:html] ||= {}
-      options[:html][:role] ||= "form"
+      options[:html].reverse_merge!(BootstrapForm.config.default_form_attributes)
 
       return unless options[:layout] == :inline
 

--- a/test/bootstrap_configuration_test.rb
+++ b/test/bootstrap_configuration_test.rb
@@ -7,10 +7,26 @@ class BootstrapConfigurationTest < ActionView::TestCase
     assert_equal({ role: "form" }, config.default_form_attributes)
   end
 
-  test "allows to set default_form_attributes" do
+  test "allows to set default_form_attributes with custom value" do
     config = BootstrapForm::Configuration.new
     config.default_form_attributes = { foo: "bar" }
 
     assert_equal({ foo: "bar" }, config.default_form_attributes)
+  end
+
+  test "allows to set default_form_attributes with nil" do
+    config = BootstrapForm::Configuration.new
+    config.default_form_attributes = nil
+
+    assert_equal({ }, config.default_form_attributes)
+  end
+
+  test "does not allow to set default_form_attributes with unsupported value" do
+    config = BootstrapForm::Configuration.new
+
+    exception = assert_raises ArgumentError do
+      config.default_form_attributes = [1,2,3]
+    end
+    assert_equal('Unsupported default_form_attributes [1, 2, 3]', exception.message)
   end
 end

--- a/test/bootstrap_configuration_test.rb
+++ b/test/bootstrap_configuration_test.rb
@@ -1,0 +1,16 @@
+require_relative "./test_helper"
+
+class BootstrapConfigurationTest < ActionView::TestCase
+  test "has default form attributes" do
+    config = BootstrapForm::Configuration.new
+
+    assert_equal({ role: "form" }, config.default_form_attributes)
+  end
+
+  test "allows to set default_form_attributes" do
+    config = BootstrapForm::Configuration.new
+    config.default_form_attributes = { foo: "bar" }
+
+    assert_equal({ foo: "bar" }, config.default_form_attributes)
+  end
+end

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -341,6 +341,26 @@ class BootstrapFormTest < ActionView::TestCase
     assert_equivalent_xml expected, bootstrap_form_for(@user, html: { role: "not-a-form" }) { |_f| nil }
   end
 
+  test "allows to set blank default form attributes via configuration" do
+    BootstrapForm.config.stubs(:default_form_attributes).returns({})
+    expected = <<-HTML.strip_heredoc
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
+        #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
+      </form>
+    HTML
+    assert_equivalent_xml expected, bootstrap_form_for(@user) { |_f| nil }
+  end
+
+  test "allows to set custom default form attributes via configuration" do
+    BootstrapForm.config.stubs(:default_form_attributes).returns({ foo: "bar" })
+    expected = <<-HTML.strip_heredoc
+      <form accept-charset="UTF-8" action="/users" class="new_user" foo="bar" id="new_user" method="post">
+        #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
+      </form>
+    HTML
+    assert_equivalent_xml expected, bootstrap_form_for(@user) { |_f| nil }
+  end
+
   test "bootstrap_form_tag acts like a form tag" do
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" method="post" role="form">


### PR DESCRIPTION
This PR adds ability to configure `bootstrap_form` default form options

```ruby
# config/initializers/bootstrap_form.rb
BootstrapForm.configure do |c|
  c.default_form_attributes = { something: "custom" }
end
```

Current default value is `{role: "form"}` which is not semantically correct as described in #560. In order to resolve original issue, `default_form_attributes` should be set to `{}`

```ruby
BootstrapForm.configure do |c|
  c.default_form_attributes = {}
end
```



Closes #561
Closes #560 
