### PR TITLE
consider human attribute name for labels

### DIFF
--- a/lib/bootstrap_form/components/labels.rb
+++ b/lib/bootstrap_form/components/labels.rb
@@ -48,7 +48,7 @@ module BootstrapForm
         if label_errors && error?(name)
           (options[:text] || object.class.human_attribute_name(name)).to_s.concat(" #{get_error_messages(name)}")
         else
-          options[:text] || object.class.human_attribute_name(name)
+          options[:text] || object&.class&.human_attribute_name(name)
         end
       end
     end

--- a/lib/bootstrap_form/components/labels.rb
+++ b/lib/bootstrap_form/components/labels.rb
@@ -48,7 +48,7 @@ module BootstrapForm
         if label_errors && error?(name)
           (options[:text] || object.class.human_attribute_name(name)).to_s.concat(" #{get_error_messages(name)}")
         else
-          options[:text]
+          options[:text] || object.class.human_attribute_name(name)
         end
       end
     end


### PR DESCRIPTION
I'm not sure if it's like this intentionally, but the `human_attribute_name` was only used when there are errors.