### PR TITLE
Preliminary support for Bootstrap 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,17 +74,17 @@ This generates the following HTML:
 ```html
 <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
   <div class="mb-3">
-    <label for="user_email">Email</label>
+    <label class="form-label" for="user_email">Email</label>
     <input class="form-control" id="user_email" name="user[email]" type="email">
   </div>
   <div class="mb-3">
-    <label for="user_password">Password</label>
+    <label class="form-label" for="user_password">Password</label>
     <input class="form-control" id="user_password" name="user[password]" type="password">
   </div>
   <div class="form-check">
     <input name="user[remember_me]" type="hidden" value="0">
     <input class="form-check-input" id="user_remember_me" name="user[remember_me]" type="checkbox" value="1">
-    <label class="form-check-label" for="user_remember_me">Remember me</label>
+    <label class="form-label form-check-label" for="user_remember_me">Remember me</label>
   </div>
   <input class="btn btn-secondary" name="commit" type="submit" value="Log In">
 </form>
@@ -122,18 +122,18 @@ This generates:
 <form role="form" action="/users" accept-charset="UTF-8" method="post">
   <input name="utf8" type="hidden" value="&#x2713;" />
   <div class="mb-3">
-    <label class="required" for="user_email">Email</label>
+    <label class="form-label required" for="user_email">Email</label>
     <input class="form-control" type="email" value="steve@example.com" name="user[email]" />
   </div>
   <div class="mb-3">
-    <label for="user_password">Password</label>
+    <label class="form-label" for="user_password">Password</label>
     <input class="form-control" type="password" name="user[password]" />
     <small class="form-text text-muted">A good password should be at least six characters long</small>
   </div>
   <div class="form-check">
     <input name="user[remember_me]" type="hidden" value="0">
     <input class="form-check-input" id="user_remember_me" name="user[remember_me]" type="checkbox" value="1">
-    <label class="form-check-label" for="user_remember_me">Remember me</label>
+    <label class="form-label form-check-label" for="user_remember_me">Remember me</label>
   </div>
   <input type="submit" name="commit" value="Log In" class="btn btn-secondary" data-disable-with="Log In" />
 </form>
@@ -326,7 +326,7 @@ Which produces the following output:
 
 ```erb
 <div class="mb-3 has-warning" data-foo="bar">
-  <label class="form-control-label" for="user_name">Id</label>
+  <label class="form-label form-control-label" for="user_name">Id</label>
   <input class="form-control" id="user_name" name="user[name]" type="text">
 </div>
 ```
@@ -436,7 +436,7 @@ Here's the output for a horizontal layout:
 
 ```html
 <div class="mb-3">
-  <label class="col-sm-2 form-control-label" for="user_email">Email</label>
+  <label class="form-label col-sm-2 form-control-label" for="user_email">Email</label>
   <div class="col-sm-10">
     <input class="form-control-plaintext" id="user_email" name="user[email]" readonly="readonly" type="text" value="test@email.com"/>
   </div>
@@ -549,7 +549,7 @@ will be rendered as:
 
 ```html
 <div class="mb-3">
-  <label for="user_life_story">Life story</label>
+  <label class="form-label" for="user_life_story">Life story</label>
   <input type="hidden" name="user[life_story]" id="user_life_story_trix_input_user"/>
   <trix-editor id="user_life_story" data-blob-url-template="http://test.host/rails/active_storage/blobs/:signed_id/:filename" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" input="user_life_story_trix_input_user" class="trix-content form-control"/>
   </trix-editor>
@@ -706,7 +706,7 @@ error will be displayed below the field. Here's an example:
 
 ```html
 <div class="mb-3">
-  <label form-control-label" for="user_email">Email</label>
+  <label class="form-label form-control-label" for="user_email">Email</label>
   <input class="form-control is-invalid" id="user_email" name="user[email]" type="email" value="">
   <small class="invalid-feedback">can't be blank</small>
 </div>

--- a/README.md
+++ b/README.md
@@ -399,10 +399,10 @@ Check boxes and radio buttons are wrapped in a `div.form-check`. You can add cla
 
 ### Switches
 
-To render checkboxes as switches with Bootstrap 4.2+, use `custom: :switch`:
+To render checkboxes as switches with Bootstrap 4.2+, use `switch: true`:
 
 ```erb
-<%= f.check_box :remember_me, custom: :switch %>
+<%= f.check_box :remember_me, switch: true %>
 ```
 
 ### Collections

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ This generates the following HTML:
 
 ```html
 <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
-  <div class="form-group">
+  <div class="mb-3">
     <label for="user_email">Email</label>
     <input class="form-control" id="user_email" name="user[email]" type="email">
   </div>
-  <div class="form-group">
+  <div class="mb-3">
     <label for="user_password">Password</label>
     <input class="form-control" id="user_password" name="user[password]" type="password">
   </div>
@@ -121,11 +121,11 @@ This generates:
 ```html
 <form role="form" action="/users" accept-charset="UTF-8" method="post">
   <input name="utf8" type="hidden" value="&#x2713;" />
-  <div class="form-group">
+  <div class="mb-3">
     <label class="required" for="user_email">Email</label>
     <input class="form-control" type="email" value="steve@example.com" name="user[email]" />
   </div>
-  <div class="form-group">
+  <div class="mb-3">
     <label for="user_password">Password</label>
     <input class="form-control" type="password" name="user[password]" />
     <small class="form-text text-muted">A good password should be at least six characters long</small>
@@ -314,7 +314,7 @@ To add a class to the input group wrapper, use the `:input_group_class` option.
 
 ### Additional Form Group Attributes
 
-Bootstrap mark-up dictates that most input field types have the label and input wrapped in a `div.form-group`.
+Bootstrap mark-up dictates that most input field types have the label and input wrapped in a `div.mb-3`.
 
 If you want to add an additional CSS class or any other attribute to the form group div, you can use the `wrapper: { class: 'additional-class', data: { foo: 'bar' } }` option.
 
@@ -325,7 +325,7 @@ If you want to add an additional CSS class or any other attribute to the form gr
 Which produces the following output:
 
 ```erb
-<div class="form-group has-warning" data-foo="bar">
+<div class="mb-3 has-warning" data-foo="bar">
   <label class="form-control-label" for="user_name">Id</label>
   <input class="form-control" id="user_name" name="user[name]" type="text">
 </div>
@@ -435,7 +435,7 @@ You can create a static control like this:
 Here's the output for a horizontal layout:
 
 ```html
-<div class="form-group">
+<div class="mb-3">
   <label class="col-sm-2 form-control-label" for="user_email">Email</label>
   <div class="col-sm-10">
     <input class="form-control-plaintext" id="user_email" name="user[email]" readonly="readonly" type="text" value="test@email.com"/>
@@ -548,7 +548,7 @@ If you're using Rails 6, `bootstrap_form` supports the `rich_text_area` helper.
 will be rendered as:
 
 ```html
-<div class="form-group">
+<div class="mb-3">
   <label for="user_life_story">Life story</label>
   <input type="hidden" name="user[life_story]" id="user_life_story_trix_input_user"/>
   <trix-editor id="user_life_story" data-blob-url-template="http://test.host/rails/active_storage/blobs/:signed_id/:filename" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" input="user_life_story_trix_input_user" class="trix-content form-control"/>
@@ -705,8 +705,8 @@ By default, fields that have validation errors will be outlined in red and the
 error will be displayed below the field. Here's an example:
 
 ```html
-<div class="form-group">
-  <label class="form-control-label" for="user_email">Email</label>
+<div class="mb-3">
+  <label form-control-label" for="user_email">Email</label>
   <input class="form-control is-invalid" id="user_email" name="user[email]" type="email" value="">
   <small class="invalid-feedback">can't be blank</small>
 </div>

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This generates the following HTML:
   <div class="form-check">
     <input name="user[remember_me]" type="hidden" value="0">
     <input class="form-check-input" id="user_remember_me" name="user[remember_me]" type="checkbox" value="1">
-    <label class="form-label form-check-label" for="user_remember_me">Remember me</label>
+    <label class="form-check-label" for="user_remember_me">Remember me</label>
   </div>
   <input class="btn btn-secondary" name="commit" type="submit" value="Log In">
 </form>
@@ -133,7 +133,7 @@ This generates:
   <div class="form-check">
     <input name="user[remember_me]" type="hidden" value="0">
     <input class="form-check-input" id="user_remember_me" name="user[remember_me]" type="checkbox" value="1">
-    <label class="form-label form-check-label" for="user_remember_me">Remember me</label>
+    <label class="form-check-label" for="user_remember_me">Remember me</label>
   </div>
   <input type="submit" name="commit" value="Log In" class="btn btn-secondary" data-disable-with="Log In" />
 </form>

--- a/demo/app/views/layouts/application.html.erb
+++ b/demo/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
     <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/5.0.0-alpha1/css/bootstrap.min.css" integrity="sha384-r4NyP46KrjDleawBgD5tp8Y7UzmLA05oM1iAEQ17CSuDqnUK2+k9luXQOfXJCJ4I" crossorigin="anonymous">
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.33.0/codemirror.min.css">
 

--- a/lib/bootstrap_form/components/labels.rb
+++ b/lib/bootstrap_form/components/labels.rb
@@ -23,7 +23,7 @@ module BootstrapForm
       end
 
       def label_classes(name, options, custom_label_col, group_layout)
-        classes = [options[:class], label_layout_classes(custom_label_col, group_layout)]
+        classes = ["form-label", options[:class], label_layout_classes(custom_label_col, group_layout)]
 
         case options.delete(:required)
         when true

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -69,7 +69,7 @@ module BootstrapForm
 
       return unless options[:layout] == :inline
 
-      options[:html][:class] = [options[:html][:class], "form-inline"].compact.join(" ")
+      options[:html][:class] = [options[:html][:class], "col-auto", "g-3"].compact.join(" ")
     end
 
     def fields_for_with_bootstrap(record_name, record_object=nil, fields_options={}, &block)

--- a/lib/bootstrap_form/form_group.rb
+++ b/lib/bootstrap_form/form_group.rb
@@ -50,7 +50,7 @@ module BootstrapForm
     end
 
     def form_group_classes(options)
-      classes = ["form-group", options[:class].try(:split)].flatten.compact
+      classes = ["mb-3", options[:class].try(:split)].flatten.compact
       classes << "row" if group_layout_horizontal?(options[:layout]) && classes.exclude?("form-row")
       classes << "form-inline" if field_inline_override?(options[:layout])
       classes << feedback_class if options[:icon]

--- a/lib/bootstrap_form/form_group.rb
+++ b/lib/bootstrap_form/form_group.rb
@@ -24,7 +24,7 @@ module BootstrapForm
 
     def form_group_content_tag(name, field_name, without_field_name, options, html_options)
       html_class = control_specific_class(field_name)
-      html_class = "#{html_class} form-inline" if @layout == :horizontal && options[:skip_inline].blank?
+      html_class = "#{html_class} col-auto g-3" if @layout == :horizontal && options[:skip_inline].blank?
       tag.div(class: html_class) do
         input_with_error(name) do
           send(without_field_name, name, options, html_options)
@@ -52,7 +52,7 @@ module BootstrapForm
     def form_group_classes(options)
       classes = ["mb-3", options[:class].try(:split)].flatten.compact
       classes << "row" if horizontal_group_with_gutters?(options[:layout], classes)
-      classes << "form-inline" if field_inline_override?(options[:layout])
+      classes << "col-auto g-3" if field_inline_override?(options[:layout])
       classes << feedback_class if options[:icon]
       classes
     end

--- a/lib/bootstrap_form/form_group.rb
+++ b/lib/bootstrap_form/form_group.rb
@@ -66,7 +66,7 @@ module BootstrapForm
     end
 
     def classes_include_gutters?(classes)
-      classes.any? { |c| c =~ /g-\d+/ }
+      classes.any? { |c| c =~ /^g-\d+$/ }
     end
   end
 end

--- a/lib/bootstrap_form/form_group.rb
+++ b/lib/bootstrap_form/form_group.rb
@@ -51,14 +51,22 @@ module BootstrapForm
 
     def form_group_classes(options)
       classes = ["mb-3", options[:class].try(:split)].flatten.compact
-      classes << "row" if group_layout_horizontal?(options[:layout]) && classes.exclude?("form-row")
+      classes << "row" if horizontal_group_with_gutters?(options[:layout], classes)
       classes << "form-inline" if field_inline_override?(options[:layout])
       classes << feedback_class if options[:icon]
       classes
     end
 
+    def horizontal_group_with_gutters?(layout, classes)
+      group_layout_horizontal?(layout) && !classes_include_gutters?(classes)
+    end
+
     def group_layout_horizontal?(layout)
       get_group_layout(layout) == :horizontal
+    end
+
+    def classes_include_gutters?(classes)
+      classes.any? { |c| c =~ /g-\d+/ }
     end
   end
 end

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -108,7 +108,7 @@ module BootstrapForm
 
       def attach_input(options, key)
         tags = [*options[key]].map do |item|
-          tag.div(input_group_content(item), class: "input-group-#{key}")
+          input_group_content(item)
         end
         ActiveSupport::SafeBuffer.new(tags.join)
       end

--- a/lib/bootstrap_form/inputs/base.rb
+++ b/lib/bootstrap_form/inputs/base.rb
@@ -22,6 +22,7 @@ module BootstrapForm
           with_field_name = "#{field_name}_with_bootstrap"
           without_field_name = "#{field_name}_without_bootstrap"
           define_method(with_field_name) do |name, options={}, html_options={}|
+            html_options = html_options.reverse_merge(control_class: "form-select")
             form_group_builder(name, options, html_options) do
               form_group_content_tag(name, field_name, without_field_name, options, html_options)
             end

--- a/lib/bootstrap_form/inputs/check_box.rb
+++ b/lib/bootstrap_form/inputs/check_box.rb
@@ -57,7 +57,7 @@ module BootstrapForm
       end
 
       def check_box_label_class(options)
-        classes = %w[form-label form-check-label]
+        classes = ["form-check-label"]
         classes << options[:label_class]
         classes << hide_class if options[:hide_label]
         classes.flatten.compact

--- a/lib/bootstrap_form/inputs/check_box.rb
+++ b/lib/bootstrap_form/inputs/check_box.rb
@@ -50,7 +50,7 @@ module BootstrapForm
       end
 
       def check_box_classes(name, options)
-        classes = [options[:class], "form-check-input"]
+        classes = Array(options[:class]) << "form-check-input"
         classes << "is-invalid" if error?(name)
         classes << "position-static" if options[:skip_label] || options[:hide_label]
         classes.flatten.compact

--- a/lib/bootstrap_form/inputs/check_box.rb
+++ b/lib/bootstrap_form/inputs/check_box.rb
@@ -10,7 +10,7 @@ module BootstrapForm
         def check_box_with_bootstrap(name, options={}, checked_value="1", unchecked_value="0", &block)
           options = options.symbolize_keys!
           check_box_options = options.except(:class, :label, :label_class, :error_message, :help,
-                                             :inline, :hide_label, :skip_label, :wrapper_class)
+                                             :inline, :hide_label, :skip_label, :wrapper_class, :switch)
           check_box_options[:class] = check_box_classes(name, options)
 
           tag.div(class: check_box_wrapper_class(options)) do
@@ -66,6 +66,7 @@ module BootstrapForm
       def check_box_wrapper_class(options)
         classes = ["form-check"]
         classes << "form-check-inline" if layout_inline?(options[:inline])
+        classes << "form-switch" if options[:switch]
         classes << options[:wrapper_class] if options[:wrapper_class].present?
         classes.flatten.compact
       end

--- a/lib/bootstrap_form/inputs/check_box.rb
+++ b/lib/bootstrap_form/inputs/check_box.rb
@@ -10,7 +10,7 @@ module BootstrapForm
         def check_box_with_bootstrap(name, options={}, checked_value="1", unchecked_value="0", &block)
           options = options.symbolize_keys!
           check_box_options = options.except(:class, :label, :label_class, :error_message, :help,
-                                             :inline, :custom, :hide_label, :skip_label, :wrapper_class)
+                                             :inline, :hide_label, :skip_label, :wrapper_class)
           check_box_options[:class] = check_box_classes(name, options)
 
           tag.div(class: check_box_wrapper_class(options)) do
@@ -50,39 +50,24 @@ module BootstrapForm
       end
 
       def check_box_classes(name, options)
-        classes = [options[:class]]
-        classes << (options[:custom] ? "custom-control-input" : "form-check-input")
+        classes = [options[:class], "form-check-input"]
         classes << "is-invalid" if error?(name)
         classes << "position-static" if options[:skip_label] || options[:hide_label]
         classes.flatten.compact
       end
 
       def check_box_label_class(options)
-        classes = []
-        classes << (options[:custom] ? "custom-control-label" : "form-check-label")
+        classes = ["form-check-label"]
         classes << options[:label_class]
         classes << hide_class if options[:hide_label]
         classes.flatten.compact
       end
 
       def check_box_wrapper_class(options)
-        classes = []
-        if options[:custom]
-          classes << custom_check_box_wrapper_class(options)
-        else
-          classes << "form-check"
-          classes << "form-check-inline" if layout_inline?(options[:inline])
-        end
+        classes = ["form-check"]
+        classes << "form-check-inline" if layout_inline?(options[:inline])
         classes << options[:wrapper_class] if options[:wrapper_class].present?
         classes.flatten.compact
-      end
-
-      def custom_check_box_wrapper_class(options)
-        classes = []
-        classes << "custom-control"
-        classes << (options[:custom] == :switch ? "custom-switch" : "custom-checkbox")
-        classes << "custom-control-inline" if layout_inline?(options[:inline])
-        classes
       end
     end
   end

--- a/lib/bootstrap_form/inputs/check_box.rb
+++ b/lib/bootstrap_form/inputs/check_box.rb
@@ -57,7 +57,7 @@ module BootstrapForm
       end
 
       def check_box_label_class(options)
-        classes = ["form-check-label"]
+        classes = %w[form-label form-check-label]
         classes << options[:label_class]
         classes << hide_class if options[:hide_label]
         classes.flatten.compact

--- a/lib/bootstrap_form/inputs/collection_select.rb
+++ b/lib/bootstrap_form/inputs/collection_select.rb
@@ -10,6 +10,7 @@ module BootstrapForm
         # Disabling Metrics/ParameterLists because the upstream Rails method has the same parameters
         # rubocop:disable Metrics/ParameterLists
         def collection_select_with_bootstrap(method, collection, value_method, text_method, options={}, html_options={})
+          html_options = html_options.reverse_merge(control_class: "form-select")
           form_group_builder(method, options, html_options) do
             input_with_error(method) do
               collection_select_without_bootstrap(method, collection, value_method, text_method, options, html_options)

--- a/lib/bootstrap_form/inputs/file_field.rb
+++ b/lib/bootstrap_form/inputs/file_field.rb
@@ -8,9 +8,9 @@ module BootstrapForm
 
       included do
         def file_field_with_bootstrap(name, options={})
-          options = options.reverse_merge(control_class: "custom-file-input")
+          options = options.reverse_merge(control_class: "form-file-input")
           form_group_builder(name, options) do
-            tag.div(class: "custom-file") do
+            tag.div(class: "form-file") do
               input_with_error(name) do
                 file_field_input(name, options)
               end
@@ -25,7 +25,7 @@ module BootstrapForm
 
       def file_field_input(name, options)
         placeholder = options.delete(:placeholder) || "Choose file"
-        placeholder_opts = { class: "custom-file-label" }
+        placeholder_opts = { class: "form-file-label" }
         placeholder_opts[:for] = options[:id] if options[:id].present?
 
         file_field_without_bootstrap(name, options) + label(name, placeholder, placeholder_opts)

--- a/lib/bootstrap_form/inputs/file_field.rb
+++ b/lib/bootstrap_form/inputs/file_field.rb
@@ -25,7 +25,7 @@ module BootstrapForm
 
       def file_field_input(name, options)
         placeholder = options.delete(:placeholder) || "Choose file"
-        placeholder_opts = { class: "form-file-label" }
+        placeholder_opts = { class: "form-label form-file-label" }
         placeholder_opts[:for] = options[:id] if options[:id].present?
 
         file_field_without_bootstrap(name, options) + label(name, placeholder, placeholder_opts)

--- a/lib/bootstrap_form/inputs/grouped_collection_select.rb
+++ b/lib/bootstrap_form/inputs/grouped_collection_select.rb
@@ -12,6 +12,7 @@ module BootstrapForm
         def grouped_collection_select_with_bootstrap(method, collection, group_method,
                                                      group_label_method, option_key_method,
                                                      option_value_method, options={}, html_options={})
+          html_options = html_options.reverse_merge(control_class: "form-select")
           form_group_builder(method, options, html_options) do
             input_with_error(method) do
               grouped_collection_select_without_bootstrap(method, collection, group_method,

--- a/lib/bootstrap_form/inputs/radio_button.rb
+++ b/lib/bootstrap_form/inputs/radio_button.rb
@@ -34,7 +34,7 @@ module BootstrapForm
       end
 
       def radio_button_classes(name, options)
-        classes = [options[:class], "form-check-input"]
+        classes = Array(options[:class]) << "form-check-input"
         classes << "is-invalid" if error?(name)
         classes << "position-static" if options[:skip_label] || options[:hide_label]
         classes.flatten.compact

--- a/lib/bootstrap_form/inputs/radio_button.rb
+++ b/lib/bootstrap_form/inputs/radio_button.rb
@@ -41,7 +41,7 @@ module BootstrapForm
       end
 
       def radio_button_label_class(options)
-        classes = %w[form-label form-check-label]
+        classes = ["form-check-label"]
         classes << options[:label_class]
         classes << hide_class if options[:hide_label]
         classes.flatten.compact

--- a/lib/bootstrap_form/inputs/radio_button.rb
+++ b/lib/bootstrap_form/inputs/radio_button.rb
@@ -10,7 +10,7 @@ module BootstrapForm
         def radio_button_with_bootstrap(name, value, *args)
           options = args.extract_options!.symbolize_keys!
           radio_button_options = options.except(:class, :label, :label_class, :error_message, :help,
-                                                :inline, :custom, :hide_label, :skip_label, :wrapper_class)
+                                                :inline, :hide_label, :skip_label, :wrapper_class)
 
           radio_button_options[:class] = radio_button_classes(name, options)
 
@@ -34,43 +34,25 @@ module BootstrapForm
       end
 
       def radio_button_classes(name, options)
-        classes = [options[:class]]
-        classes << (options[:custom] ? "custom-control-input" : "form-check-input")
+        classes = [options[:class], "form-check-input"]
         classes << "is-invalid" if error?(name)
         classes << "position-static" if options[:skip_label] || options[:hide_label]
         classes.flatten.compact
       end
 
       def radio_button_label_class(options)
-        classes = []
-        classes << (options[:custom] ? "custom-control-label" : "form-check-label")
+        classes = ["form-check-label"]
         classes << options[:label_class]
         classes << hide_class if options[:hide_label]
         classes.flatten.compact
       end
 
       def radio_button_wrapper_class(options)
-        classes = []
-        classes << if options[:custom]
-                     custom_radio_button_wrapper_class(options)
-                   else
-                     standard_radio_button_wrapper_class(options)
-                   end
-        classes << options[:wrapper_class] if options[:wrapper_class].present?
-        classes.flatten.compact
-      end
-
-      def standard_radio_button_wrapper_class(options)
-        classes = %w[form-check]
+        classes = ["form-check"]
         classes << "form-check-inline" if layout_inline?(options[:inline])
         classes << "disabled" if options[:disabled]
-        classes
-      end
-
-      def custom_radio_button_wrapper_class(options)
-        classes = %w[custom-control custom-radio]
-        classes << "custom-control-inline" if layout_inline?(options[:inline])
-        classes
+        classes << options[:wrapper_class] if options[:wrapper_class].present?
+        classes.flatten.compact
       end
     end
   end

--- a/lib/bootstrap_form/inputs/radio_button.rb
+++ b/lib/bootstrap_form/inputs/radio_button.rb
@@ -41,7 +41,7 @@ module BootstrapForm
       end
 
       def radio_button_label_class(options)
-        classes = ["form-check-label"]
+        classes = %w[form-label form-check-label]
         classes << options[:label_class]
         classes << hide_class if options[:hide_label]
         classes.flatten.compact

--- a/lib/bootstrap_form/inputs/select.rb
+++ b/lib/bootstrap_form/inputs/select.rb
@@ -8,6 +8,7 @@ module BootstrapForm
 
       included do
         def select_with_bootstrap(method, choices=nil, options={}, html_options={}, &block)
+          html_options = html_options.reverse_merge(control_class: "form-select")
           form_group_builder(method, options, html_options) do
             prepend_and_append_input(method, options) do
               select_without_bootstrap(method, choices, options, html_options, &block)

--- a/lib/bootstrap_form/inputs/time_zone_select.rb
+++ b/lib/bootstrap_form/inputs/time_zone_select.rb
@@ -8,6 +8,7 @@ module BootstrapForm
 
       included do
         def time_zone_select_with_bootstrap(method, priority_zones=nil, options={}, html_options={})
+          html_options = html_options.reverse_merge(control_class: "form-select")
           form_group_builder(method, options, html_options) do
             input_with_error(method) do
               time_zone_select_without_bootstrap(method, priority_zones, options, html_options)

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -171,7 +171,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foobar")]
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">This is a checkbox collection</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
@@ -189,7 +189,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
@@ -214,7 +214,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     collection = [struct.new(1, "Foo"), struct.new("二", "Bar")]
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
@@ -238,7 +238,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-check form-check-inline">
           <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
@@ -263,7 +263,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-check">
           <input checked="checked" class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
@@ -290,7 +290,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-check">
           <input checked="checked" class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
@@ -313,7 +313,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foo St")]
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_foo_st" name="user[misc][]" type="checkbox" value="Foo St" />
@@ -330,7 +330,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
@@ -354,7 +354,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
@@ -378,7 +378,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
@@ -402,7 +402,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
@@ -427,7 +427,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-check">
           <input checked="checked" class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
@@ -454,7 +454,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-check">
           <input checked="checked" class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
@@ -506,7 +506,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input is-invalid" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
@@ -535,7 +535,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
-        <div class="form-group">
+        <div class="mb-3">
           <label for="user_misc">Misc</label>
           <div class="form-check">
             <input checked="checked" class="form-check-input is-invalid" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -10,7 +10,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-check-label" for="user_terms">
+        <label class="form-label form-check-label" for="user_terms">
           I agree to the terms
         </label>
       </div>
@@ -23,7 +23,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-check-label" for="user_terms">&#8203;</label>
+        <label class="form-label form-check-label" for="user_terms">&#8203;</label>
       </div>
     HTML
     # &#8203; is a zero-width space.
@@ -35,7 +35,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" disabled="disabled" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" disabled="disabled" />
-        <label class="form-check-label" for="user_terms">
+        <label class="form-label form-check-label" for="user_terms">
           I agree to the terms
         </label>
       </div>
@@ -48,7 +48,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-check-label" for="user_terms">
+        <label class="form-label form-check-label" for="user_terms">
           I agree to the <a href="#">terms</a>
         </label>
       </div>
@@ -61,7 +61,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-check-label" for="user_terms">
+        <label class="form-label form-check-label" for="user_terms">
           I agree to the terms
         </label>
       </div>
@@ -74,7 +74,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-check-label btn" for="user_terms">
+        <label class="form-label form-check-label btn" for="user_terms">
           Terms
         </label>
       </div>
@@ -87,7 +87,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="custom_id" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-check-label" for="custom_id">
+        <label class="form-label form-check-label" for="custom_id">
           Terms
         </label>
       </div>
@@ -100,7 +100,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="no" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="yes" />
-        <label class="form-check-label" for="user_terms">
+        <label class="form-label form-check-label" for="user_terms">
           I agree to the terms
         </label>
       </div>
@@ -113,7 +113,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check form-check-inline">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-check-label" for="user_terms">
+        <label class="form-label form-check-label" for="user_terms">
           I agree to the terms
         </label>
       </div>
@@ -128,7 +128,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
         <div class="form-check form-check-inline">
           <input name="user[terms]" type="hidden" value="0" />
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-          <label class="form-check-label" for="user_terms">
+          <label class="form-label form-check-label" for="user_terms">
             I agree to the terms
           </label>
         </div>
@@ -145,7 +145,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check form-check-inline">
         <input name="user[terms]" type="hidden" value="0" disabled="disabled" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" disabled="disabled" />
-        <label class="form-check-label" for="user_terms">
+        <label class="form-label form-check-label" for="user_terms">
           I agree to the terms
         </label>
       </div>
@@ -159,7 +159,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     <div class="form-check form-check-inline">
       <input name="user[terms]" type="hidden" value="0" />
       <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-      <label class="form-check-label btn" for="user_terms">
+      <label class="form-label form-check-label btn" for="user_terms">
         Terms
       </label>
     </div>
@@ -172,10 +172,10 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
-        <label for="user_misc">This is a checkbox collection</label>
+        <label class="form-label" for="user_misc">This is a checkbox collection</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-          <label class="form-check-label" for="user_misc_1"> Foobar</label>
+          <label class="form-label form-check-label" for="user_misc_1"> Foobar</label>
         </div>
         <small class="form-text text-muted">With a help!</small>
       </div>
@@ -190,16 +190,16 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-          <label class="form-check-label" for="user_misc_1">
+          <label class="form-label form-check-label" for="user_misc_1">
             Foo
           </label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
-          <label class="form-check-label" for="user_misc_2">
+          <label class="form-label form-check-label" for="user_misc_2">
             Bar
           </label>
         </div>
@@ -215,16 +215,16 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-          <label class="form-check-label" for="user_misc_1">
+          <label class="form-label form-check-label" for="user_misc_1">
             Foo
           </label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_二" name="user[misc][]" type="checkbox" value="二" />
-          <label class="form-check-label" for="user_misc_二">
+          <label class="form-label form-check-label" for="user_misc_二">
             Bar
           </label>
         </div>
@@ -239,16 +239,16 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check form-check-inline">
           <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-          <label class="form-check-label" for="user_misc_1">
+          <label class="form-label form-check-label" for="user_misc_1">
             Foo
           </label>
         </div>
         <div class="form-check form-check-inline">
           <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
-          <label class="form-check-label" for="user_misc_2">
+          <label class="form-label form-check-label" for="user_misc_2">
             Bar
           </label>
         </div>
@@ -264,16 +264,16 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input checked="checked" class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-          <label class="form-check-label" for="user_misc_1">
+          <label class="form-label form-check-label" for="user_misc_1">
             Foo
           </label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
-          <label class="form-check-label" for="user_misc_2">
+          <label class="form-label form-check-label" for="user_misc_2">
             Bar
           </label>
         </div>
@@ -291,14 +291,14 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input checked="checked" class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-          <label class="form-check-label" for="user_misc_1"> Foo</label>
+          <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
         </div>
         <div class="form-check">
           <input checked="checked" class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
-          <label class="form-check-label" for="user_misc_2"> Bar</label>
+          <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
         </div>
       </div>
     HTML
@@ -314,10 +314,10 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_foo_st" name="user[misc][]" type="checkbox" value="Foo St" />
-          <label class="form-check-label" for="user_misc_foo_st">
+          <label class="form-label form-check-label" for="user_misc_foo_st">
             Foo St
           </label>
         </div>
@@ -331,16 +331,16 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-          <label class="form-check-label" for="user_misc_1">
+          <label class="form-label form-check-label" for="user_misc_1">
             ooF
           </label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
-          <label class="form-check-label" for="user_misc_2">
+          <label class="form-label form-check-label" for="user_misc_2">
             raB
           </label>
         </div>
@@ -355,16 +355,16 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
-          <label class="form-check-label" for="user_misc_address_1">
+          <label class="form-label form-check-label" for="user_misc_address_1">
             Foo
           </label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_2" name="user[misc][]" type="checkbox" value="address_2" />
-          <label class="form-check-label" for="user_misc_address_2">
+          <label class="form-label form-check-label" for="user_misc_address_2">
             Bar
           </label>
         </div>
@@ -379,16 +379,16 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-          <label class="form-check-label" for="user_misc_1">
+          <label class="form-label form-check-label" for="user_misc_1">
             ooF
           </label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
-          <label class="form-check-label" for="user_misc_2">
+          <label class="form-label form-check-label" for="user_misc_2">
             raB
           </label>
         </div>
@@ -403,16 +403,16 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
-          <label class="form-check-label" for="user_misc_address_1">
+          <label class="form-label form-check-label" for="user_misc_address_1">
             Foo
           </label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_2" name="user[misc][]" type="checkbox" value="address_2" />
-          <label class="form-check-label" for="user_misc_address_2">
+          <label class="form-label form-check-label" for="user_misc_address_2">
             Bar
           </label>
         </div>
@@ -428,16 +428,16 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input checked="checked" class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
-          <label class="form-check-label" for="user_misc_address_1">
+          <label class="form-label form-check-label" for="user_misc_address_1">
             Foo
           </label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_2" name="user[misc][]" type="checkbox" value="address_2" />
-          <label class="form-check-label" for="user_misc_address_2">
+          <label class="form-label form-check-label" for="user_misc_address_2">
             Bar
           </label>
         </div>
@@ -455,16 +455,16 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input checked="checked" class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
-          <label class="form-check-label" for="user_misc_address_1">
+          <label class="form-label form-check-label" for="user_misc_address_1">
             Foo
           </label>
         </div>
         <div class="form-check">
           <input checked="checked" class="form-check-input" id="user_misc_address_2" name="user[misc][]" type="checkbox" value="address_2" />
-          <label class="form-check-label" for="user_misc_address_2">
+          <label class="form-label form-check-label" for="user_misc_address_2">
             Bar
           </label>
         </div>
@@ -492,7 +492,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input position-static" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-check-label sr-only" for="user_terms">I agree to the terms</label>
+        <label class="form-label form-check-label sr-only" for="user_terms">I agree to the terms</label>
       </div>
     HTML
     assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", hide_label: true)
@@ -507,14 +507,14 @@ class BootstrapCheckboxTest < ActionView::TestCase
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input is-invalid" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-          <label class="form-check-label" for="user_misc_1">Foo</label>
+          <label class="form-label form-check-label" for="user_misc_1">Foo</label>
         </div>
         <div class="form-check">
           <input class="form-check-input is-invalid" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
-          <label class="form-check-label" for="user_misc_2">Bar</label>
+          <label class="form-label form-check-label" for="user_misc_2">Bar</label>
           <div class="invalid-feedback">a box must be checked</div>
         </div>
       </div>
@@ -536,14 +536,14 @@ class BootstrapCheckboxTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
         <div class="mb-3">
-          <label for="user_misc">Misc</label>
+          <label class="form-label" for="user_misc">Misc</label>
           <div class="form-check">
             <input checked="checked" class="form-check-input is-invalid" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-            <label class="form-check-label" for="user_misc_1"> Foo</label>
+            <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
           </div>
           <div class="form-check">
             <input checked="checked" class="form-check-input is-invalid" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
-            <label class="form-check-label" for="user_misc_2"> Bar</label>
+            <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
             <div class="invalid-feedback">error for test</div>
           </div>
         </div>
@@ -564,7 +564,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input is-invalid" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-check-label" for="user_terms">
+        <label class="form-label form-check-label" for="user_terms">
           I agree to the terms
         </label>
         <div class="invalid-feedback">You must accept the terms.</div>
@@ -582,7 +582,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check custom-class">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-check-label" for="user_terms">
+        <label class="form-label form-check-label" for="user_terms">
           I agree to the terms
         </label>
       </div>
@@ -595,7 +595,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check form-check-inline custom-class">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-check-label" for="user_terms">
+        <label class="form-label form-check-label" for="user_terms">
           I agree to the terms
         </label>
       </div>

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -10,7 +10,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-label form-check-label" for="user_terms">
+        <label class="form-check-label" for="user_terms">
           I agree to the terms
         </label>
       </div>
@@ -23,7 +23,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-label form-check-label" for="user_terms">&#8203;</label>
+        <label class="form-check-label" for="user_terms">&#8203;</label>
       </div>
     HTML
     # &#8203; is a zero-width space.
@@ -35,7 +35,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" disabled="disabled" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" disabled="disabled" />
-        <label class="form-label form-check-label" for="user_terms">
+        <label class="form-check-label" for="user_terms">
           I agree to the terms
         </label>
       </div>
@@ -48,7 +48,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-label form-check-label" for="user_terms">
+        <label class="form-check-label" for="user_terms">
           I agree to the <a href="#">terms</a>
         </label>
       </div>
@@ -61,7 +61,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-label form-check-label" for="user_terms">
+        <label class="form-check-label" for="user_terms">
           I agree to the terms
         </label>
       </div>
@@ -74,7 +74,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-label form-check-label btn" for="user_terms">
+        <label class="form-check-label btn" for="user_terms">
           Terms
         </label>
       </div>
@@ -87,7 +87,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="custom_id" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-label form-check-label" for="custom_id">
+        <label class="form-check-label" for="custom_id">
           Terms
         </label>
       </div>
@@ -100,7 +100,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="no" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="yes" />
-        <label class="form-label form-check-label" for="user_terms">
+        <label class="form-check-label" for="user_terms">
           I agree to the terms
         </label>
       </div>
@@ -113,7 +113,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check form-check-inline">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-label form-check-label" for="user_terms">
+        <label class="form-check-label" for="user_terms">
           I agree to the terms
         </label>
       </div>
@@ -128,7 +128,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
         <div class="form-check form-check-inline">
           <input name="user[terms]" type="hidden" value="0" />
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-          <label class="form-label form-check-label" for="user_terms">
+          <label class="form-check-label" for="user_terms">
             I agree to the terms
           </label>
         </div>
@@ -145,7 +145,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check form-check-inline">
         <input name="user[terms]" type="hidden" value="0" disabled="disabled" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" disabled="disabled" />
-        <label class="form-label form-check-label" for="user_terms">
+        <label class="form-check-label" for="user_terms">
           I agree to the terms
         </label>
       </div>
@@ -159,7 +159,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     <div class="form-check form-check-inline">
       <input name="user[terms]" type="hidden" value="0" />
       <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-      <label class="form-label form-check-label btn" for="user_terms">
+      <label class="form-check-label btn" for="user_terms">
         Terms
       </label>
     </div>
@@ -175,7 +175,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
         <label class="form-label" for="user_misc">This is a checkbox collection</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-          <label class="form-label form-check-label" for="user_misc_1"> Foobar</label>
+          <label class="form-check-label" for="user_misc_1"> Foobar</label>
         </div>
         <small class="form-text text-muted">With a help!</small>
       </div>
@@ -193,13 +193,13 @@ class BootstrapCheckboxTest < ActionView::TestCase
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-          <label class="form-label form-check-label" for="user_misc_1">
+          <label class="form-check-label" for="user_misc_1">
             Foo
           </label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
-          <label class="form-label form-check-label" for="user_misc_2">
+          <label class="form-check-label" for="user_misc_2">
             Bar
           </label>
         </div>
@@ -218,13 +218,13 @@ class BootstrapCheckboxTest < ActionView::TestCase
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-          <label class="form-label form-check-label" for="user_misc_1">
+          <label class="form-check-label" for="user_misc_1">
             Foo
           </label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_二" name="user[misc][]" type="checkbox" value="二" />
-          <label class="form-label form-check-label" for="user_misc_二">
+          <label class="form-check-label" for="user_misc_二">
             Bar
           </label>
         </div>
@@ -242,13 +242,13 @@ class BootstrapCheckboxTest < ActionView::TestCase
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check form-check-inline">
           <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-          <label class="form-label form-check-label" for="user_misc_1">
+          <label class="form-check-label" for="user_misc_1">
             Foo
           </label>
         </div>
         <div class="form-check form-check-inline">
           <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
-          <label class="form-label form-check-label" for="user_misc_2">
+          <label class="form-check-label" for="user_misc_2">
             Bar
           </label>
         </div>
@@ -267,13 +267,13 @@ class BootstrapCheckboxTest < ActionView::TestCase
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input checked="checked" class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-          <label class="form-label form-check-label" for="user_misc_1">
+          <label class="form-check-label" for="user_misc_1">
             Foo
           </label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
-          <label class="form-label form-check-label" for="user_misc_2">
+          <label class="form-check-label" for="user_misc_2">
             Bar
           </label>
         </div>
@@ -294,11 +294,11 @@ class BootstrapCheckboxTest < ActionView::TestCase
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input checked="checked" class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-          <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
+          <label class="form-check-label" for="user_misc_1"> Foo</label>
         </div>
         <div class="form-check">
           <input checked="checked" class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
-          <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
+          <label class="form-check-label" for="user_misc_2"> Bar</label>
         </div>
       </div>
     HTML
@@ -317,7 +317,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_foo_st" name="user[misc][]" type="checkbox" value="Foo St" />
-          <label class="form-label form-check-label" for="user_misc_foo_st">
+          <label class="form-check-label" for="user_misc_foo_st">
             Foo St
           </label>
         </div>
@@ -334,13 +334,13 @@ class BootstrapCheckboxTest < ActionView::TestCase
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-          <label class="form-label form-check-label" for="user_misc_1">
+          <label class="form-check-label" for="user_misc_1">
             ooF
           </label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
-          <label class="form-label form-check-label" for="user_misc_2">
+          <label class="form-check-label" for="user_misc_2">
             raB
           </label>
         </div>
@@ -358,13 +358,13 @@ class BootstrapCheckboxTest < ActionView::TestCase
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
-          <label class="form-label form-check-label" for="user_misc_address_1">
+          <label class="form-check-label" for="user_misc_address_1">
             Foo
           </label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_2" name="user[misc][]" type="checkbox" value="address_2" />
-          <label class="form-label form-check-label" for="user_misc_address_2">
+          <label class="form-check-label" for="user_misc_address_2">
             Bar
           </label>
         </div>
@@ -382,13 +382,13 @@ class BootstrapCheckboxTest < ActionView::TestCase
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-          <label class="form-label form-check-label" for="user_misc_1">
+          <label class="form-check-label" for="user_misc_1">
             ooF
           </label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
-          <label class="form-label form-check-label" for="user_misc_2">
+          <label class="form-check-label" for="user_misc_2">
             raB
           </label>
         </div>
@@ -406,13 +406,13 @@ class BootstrapCheckboxTest < ActionView::TestCase
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
-          <label class="form-label form-check-label" for="user_misc_address_1">
+          <label class="form-check-label" for="user_misc_address_1">
             Foo
           </label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_2" name="user[misc][]" type="checkbox" value="address_2" />
-          <label class="form-label form-check-label" for="user_misc_address_2">
+          <label class="form-check-label" for="user_misc_address_2">
             Bar
           </label>
         </div>
@@ -431,13 +431,13 @@ class BootstrapCheckboxTest < ActionView::TestCase
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input checked="checked" class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
-          <label class="form-label form-check-label" for="user_misc_address_1">
+          <label class="form-check-label" for="user_misc_address_1">
             Foo
           </label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_2" name="user[misc][]" type="checkbox" value="address_2" />
-          <label class="form-label form-check-label" for="user_misc_address_2">
+          <label class="form-check-label" for="user_misc_address_2">
             Bar
           </label>
         </div>
@@ -458,13 +458,13 @@ class BootstrapCheckboxTest < ActionView::TestCase
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input checked="checked" class="form-check-input" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" />
-          <label class="form-label form-check-label" for="user_misc_address_1">
+          <label class="form-check-label" for="user_misc_address_1">
             Foo
           </label>
         </div>
         <div class="form-check">
           <input checked="checked" class="form-check-input" id="user_misc_address_2" name="user[misc][]" type="checkbox" value="address_2" />
-          <label class="form-label form-check-label" for="user_misc_address_2">
+          <label class="form-check-label" for="user_misc_address_2">
             Bar
           </label>
         </div>
@@ -492,7 +492,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input position-static" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-label form-check-label sr-only" for="user_terms">I agree to the terms</label>
+        <label class="form-check-label sr-only" for="user_terms">I agree to the terms</label>
       </div>
     HTML
     assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", hide_label: true)
@@ -510,11 +510,11 @@ class BootstrapCheckboxTest < ActionView::TestCase
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input is-invalid" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-          <label class="form-label form-check-label" for="user_misc_1">Foo</label>
+          <label class="form-check-label" for="user_misc_1">Foo</label>
         </div>
         <div class="form-check">
           <input class="form-check-input is-invalid" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
-          <label class="form-label form-check-label" for="user_misc_2">Bar</label>
+          <label class="form-check-label" for="user_misc_2">Bar</label>
           <div class="invalid-feedback">a box must be checked</div>
         </div>
       </div>
@@ -539,11 +539,11 @@ class BootstrapCheckboxTest < ActionView::TestCase
           <label class="form-label" for="user_misc">Misc</label>
           <div class="form-check">
             <input checked="checked" class="form-check-input is-invalid" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-            <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
+            <label class="form-check-label" for="user_misc_1"> Foo</label>
           </div>
           <div class="form-check">
             <input checked="checked" class="form-check-input is-invalid" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
-            <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
+            <label class="form-check-label" for="user_misc_2"> Bar</label>
             <div class="invalid-feedback">error for test</div>
           </div>
         </div>
@@ -564,7 +564,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input is-invalid" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-label form-check-label" for="user_terms">
+        <label class="form-check-label" for="user_terms">
           I agree to the terms
         </label>
         <div class="invalid-feedback">You must accept the terms.</div>
@@ -582,7 +582,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check custom-class">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-label form-check-label" for="user_terms">
+        <label class="form-check-label" for="user_terms">
           I agree to the terms
         </label>
       </div>
@@ -595,7 +595,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <div class="form-check form-check-inline custom-class">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-label form-check-label" for="user_terms">
+        <label class="form-check-label" for="user_terms">
           I agree to the terms
         </label>
       </div>

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -477,63 +477,6 @@ class BootstrapCheckboxTest < ActionView::TestCase
                                                                     :street, checked: collection)
   end
 
-  test "check_box is wrapped correctly with custom option set" do
-    expected = <<-HTML.strip_heredoc
-      <div class="custom-control custom-checkbox">
-        <input name="user[terms]" type="hidden" value="0" />
-        <input class="custom-control-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="custom-control-label" for="user_terms">I agree to the terms</label>
-      </div>
-    HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", custom: true)
-  end
-
-  test "check_box is wrapped correctly with id option and custom option set" do
-    expected = <<-HTML.strip_heredoc
-      <div class="custom-control custom-checkbox">
-        <input name="user[terms]" type="hidden" value="0" />
-        <input class="custom-control-input" id="custom_id" name="user[terms]" type="checkbox" value="1" />
-        <label class="custom-control-label" for="custom_id">I agree to the terms</label>
-      </div>
-    HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", id: "custom_id", custom: true)
-  end
-
-  test "check_box is wrapped correctly with custom and inline options set" do
-    expected = <<-HTML.strip_heredoc
-      <div class="custom-control custom-checkbox custom-control-inline">
-        <input name="user[terms]" type="hidden" value="0" />
-        <input class="custom-control-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="custom-control-label" for="user_terms">I agree to the terms</label>
-      </div>
-    HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", inline: true,
-                                                               custom: true)
-  end
-
-  test "check_box is wrapped correctly with custom and disabled options set" do
-    expected = <<-HTML.strip_heredoc
-      <div class="custom-control custom-checkbox">
-        <input name="user[terms]" type="hidden" value="0" disabled="disabled" />
-        <input class="custom-control-input" id="user_terms" name="user[terms]" type="checkbox" value="1" disabled="disabled" />
-        <label class="custom-control-label" for="user_terms">I agree to the terms</label>
-      </div>
-    HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", disabled: true, custom: true)
-  end
-
-  test "check_box is wrapped correctly with custom, inline and disabled options set" do
-    expected = <<-HTML.strip_heredoc
-      <div class="custom-control custom-checkbox custom-control-inline">
-        <input name="user[terms]" type="hidden" value="0" disabled="disabled" />
-        <input class="custom-control-input" id="user_terms" name="user[terms]" type="checkbox" value="1" disabled="disabled" />
-        <label class="custom-control-label" for="user_terms">I agree to the terms</label>
-      </div>
-    HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", inline: true,
-                                                               disabled: true, custom: true)
-  end
-
   test "check_box skip label" do
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
@@ -553,27 +496,6 @@ class BootstrapCheckboxTest < ActionView::TestCase
       </div>
     HTML
     assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", hide_label: true)
-  end
-
-  test "check_box skip label with custom option set" do
-    expected = <<-HTML.strip_heredoc
-      <div class="custom-control custom-checkbox">
-        <input name="user[terms]" type="hidden" value="0" />
-        <input class="custom-control-input position-static" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-      </div>
-    HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", custom: true, skip_label: true)
-  end
-
-  test "check_box hide label with custom option set" do
-    expected = <<-HTML.strip_heredoc
-      <div class="custom-control custom-checkbox">
-        <input name="user[terms]" type="hidden" value="0" />
-        <input class="custom-control-input position-static" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="custom-control-label sr-only" for="user_terms">I agree to the terms</label>
-      </div>
-    HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", custom: true, hide_label: true)
   end
 
   test "collection_check_boxes renders error after last check box" do
@@ -655,25 +577,6 @@ class BootstrapCheckboxTest < ActionView::TestCase
     assert_equivalent_xml expected, actual
   end
 
-  test "check_box with error is wrapped correctly with custom option set" do
-    @user.errors.add(:terms, "You must accept the terms.")
-    expected = <<-HTML.strip_heredoc
-    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
-      #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-      <div class="custom-control custom-checkbox">
-        <input name="user[terms]" type="hidden" value="0" />
-        <input class="custom-control-input is-invalid" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="custom-control-label" for="user_terms">I agree to the terms</label>
-        <div class="invalid-feedback">You must accept the terms.</div>
-      </div>
-    </form>
-    HTML
-    actual = bootstrap_form_for(@user) do |f|
-      f.check_box(:terms, label: "I agree to the terms", custom: true, error_message: true)
-    end
-    assert_equivalent_xml expected, actual
-  end
-
   test "check box with custom wrapper class" do
     expected = <<-HTML.strip_heredoc
       <div class="form-check custom-class">
@@ -699,29 +602,5 @@ class BootstrapCheckboxTest < ActionView::TestCase
     HTML
     assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", inline: true,
                                                                wrapper_class: "custom-class")
-  end
-
-  test "custom check box with custom wrapper class" do
-    expected = <<-HTML.strip_heredoc
-      <div class="custom-control custom-checkbox custom-class">
-        <input name="user[terms]" type="hidden" value="0" />
-        <input class="custom-control-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="custom-control-label" for="user_terms">I agree to the terms</label>
-      </div>
-    HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", custom: true,
-                                                               wrapper_class: "custom-class")
-  end
-
-  test "custom inline check box with custom wrapper class" do
-    expected = <<-HTML.strip_heredoc
-      <div class="custom-control custom-checkbox custom-control-inline custom-class">
-        <input name="user[terms]" type="hidden" value="0" />
-        <input class="custom-control-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="custom-control-label" for="user_terms">I agree to the terms</label>
-      </div>
-    HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", inline: true,
-                                                               custom: true, wrapper_class: "custom-class")
   end
 end

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -123,7 +123,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
 
   test "inline checkboxes from form layout" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user form-inline" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user col-auto g-3" id="new_user" method="post" role="form">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-check form-check-inline">
           <input name="user[terms]" type="hidden" value="0" />

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -7,7 +7,7 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   test "color fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="color" value="#000000" />
       </div>
@@ -17,7 +17,7 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   test "date fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="date" />
       </div>
@@ -27,7 +27,7 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   test "date time fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="datetime" />
       </div>
@@ -37,7 +37,7 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   test "date time local fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="datetime-local" />
       </div>
@@ -47,7 +47,7 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   test "email fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="email" />
       </div>
@@ -57,7 +57,7 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   test "file fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-file">
           <input class="form-file-input" id="user_misc" name="user[misc]" type="file" />
@@ -70,7 +70,7 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   test "file field placeholder can be customized" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-file">
           <input class="form-file-input" id="user_misc" name="user[misc]" type="file" />
@@ -84,7 +84,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   if ::Rails::VERSION::STRING > "5.1"
     test "file field placeholder has appropriate `for` attribute when used in form_with" do
       expected = <<-HTML.strip_heredoc
-        <div class="form-group">
+        <div class="mb-3">
           <label for="custom-id">Misc</label>
           <div class="form-file">
             <input class="form-file-input" id="custom-id" name="user[misc]" type="file" />
@@ -101,7 +101,7 @@ class BootstrapFieldsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
     <form accept-charset="UTF-8" action="/users" class="new_user" enctype="multipart/form-data" id="new_user" method="post" role="form">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-file">
           <input class="form-file-input is-invalid" id="user_misc" name="user[misc]" type="file" />
@@ -121,7 +121,7 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   test "month local fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="month" />
       </div>
@@ -131,7 +131,7 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   test "number fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="number" />
       </div>
@@ -141,7 +141,7 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   test "password fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_password">Password</label>
         <input class="form-control" id="user_password" name="user[password]" type="password" />
         <small class="form-text text-muted">A good password should be at least six characters long</small>
@@ -152,7 +152,7 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   test "phone/telephone fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="tel" />
       </div>
@@ -163,7 +163,7 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   test "range fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="range" />
       </div>
@@ -173,7 +173,7 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   test "search fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="search" />
       </div>
@@ -183,7 +183,7 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   test "text areas are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_comments">Comments</label>
         <textarea class="form-control" id="user_comments" name="user[comments]">\nmy comment</textarea>
       </div>
@@ -194,7 +194,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   if ::Rails::VERSION::STRING > "5.1" && ::Rails::VERSION::STRING < "5.2"
     test "text areas are wrapped correctly form_with Rails 5.1" do
       expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_comments">Comments</label>
         <textarea class="form-control" name="user[comments]">\nmy comment</textarea>
       </div>
@@ -206,7 +206,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   if ::Rails::VERSION::STRING > "5.2"
     test "text areas are wrapped correctly form_with Rails 5.2+" do
       expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_comments">Comments</label>
         <textarea class="form-control" id="user_comments" name="user[comments]">\nmy comment</textarea>
       </div>
@@ -217,7 +217,7 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   test "text fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label class="required" for="user_email">Email</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
@@ -227,7 +227,7 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   test "text fields are wrapped correctly when horizontal and form-row given" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group form-row">
+      <div class="mb-3 form-row">
         <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
           <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
@@ -240,7 +240,7 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   test "field 'id' attribute is used to specify label 'for' attribute" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label class="required" for="custom_id">Email</label>
         <input class="form-control" id="custom_id" name="user[email]" type="text" value="steve@example.com" />
       </div>
@@ -250,7 +250,7 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   test "time fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="time" />
       </div>
@@ -260,7 +260,7 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   test "url fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="url" />
       </div>
@@ -281,7 +281,7 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   test "week fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="week" />
       </div>
@@ -301,7 +301,7 @@ class BootstrapFieldsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group">
+        <div class="mb-3">
           <label for="user_address_attributes_street">Street</label>
           <input class="form-control" id="user_address_attributes_street" name="user[address_attributes][street]" type="text" value="123 Main Street" />
         </div>
@@ -322,7 +322,7 @@ class BootstrapFieldsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group">
+        <div class="mb-3">
           <label for="user_preferences_favorite_color">Favorite color</label>
           <input class="form-control" id="user_preferences_favorite_color" name="user[preferences][favorite_color]" type="text" value="cerulean" />
         </div>
@@ -343,7 +343,7 @@ class BootstrapFieldsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group row">
+        <div class="mb-3 row">
           <label class="col-form-label col-sm-2" for="user_address_attributes_street">Street</label>
           <div class="col-sm-10">
             <input class="form-control" id="user_address_attributes_street" name="user[address_attributes][street]" type="text" value="123 Main Street" />
@@ -367,7 +367,7 @@ class BootstrapFieldsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user form-inline" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group">
+        <div class="mb-3">
           <label class="mr-sm-2" for="user_address_attributes_street">Street</label>
           <input class="form-control" id="user_address_attributes_street" name="user[address_attributes][street]" type="text" value="123 Main Street" />
         </div>

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -59,9 +59,9 @@ class BootstrapFieldsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
         <label for="user_misc">Misc</label>
-        <div class="custom-file">
-          <input class="custom-file-input" id="user_misc" name="user[misc]" type="file" />
-          <label class="custom-file-label" for="user_misc">Choose file</label>
+        <div class="form-file">
+          <input class="form-file-input" id="user_misc" name="user[misc]" type="file" />
+          <label class="form-file-label" for="user_misc">Choose file</label>
         </div>
       </div>
     HTML
@@ -72,9 +72,9 @@ class BootstrapFieldsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
         <label for="user_misc">Misc</label>
-        <div class="custom-file">
-          <input class="custom-file-input" id="user_misc" name="user[misc]" type="file" />
-          <label class="custom-file-label" for="user_misc">Pick a file</label>
+        <div class="form-file">
+          <input class="form-file-input" id="user_misc" name="user[misc]" type="file" />
+          <label class="form-file-label" for="user_misc">Pick a file</label>
         </div>
       </div>
     HTML
@@ -86,9 +86,9 @@ class BootstrapFieldsTest < ActionView::TestCase
       expected = <<-HTML.strip_heredoc
         <div class="form-group">
           <label for="custom-id">Misc</label>
-          <div class="custom-file">
-            <input class="custom-file-input" id="custom-id" name="user[misc]" type="file" />
-            <label class="custom-file-label" for="custom-id">Choose file</label>
+          <div class="form-file">
+            <input class="form-file-input" id="custom-id" name="user[misc]" type="file" />
+            <label class="form-file-label" for="custom-id">Choose file</label>
           </div>
         </div>
       HTML
@@ -103,9 +103,9 @@ class BootstrapFieldsTest < ActionView::TestCase
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       <div class="form-group">
         <label for="user_misc">Misc</label>
-        <div class="custom-file">
-          <input class="custom-file-input is-invalid" id="user_misc" name="user[misc]" type="file" />
-          <label class="custom-file-label" for="user_misc">Choose file</label>
+        <div class="form-file">
+          <input class="form-file-input is-invalid" id="user_misc" name="user[misc]" type="file" />
+          <label class="form-file-label" for="user_misc">Choose file</label>
           <div class="invalid-feedback">error for test</div>
         </div>
       </div>

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -225,17 +225,17 @@ class BootstrapFieldsTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.text_field(:email)
   end
 
-  test "text fields are wrapped correctly when horizontal and form-row given" do
+  test "text fields are wrapped correctly when horizontal and gutter classes are given" do
     expected = <<-HTML.strip_heredoc
-      <div class="mb-3 form-row">
+      <div class="mb-3 g-3">
         <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
           <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, @horizontal_builder.text_field(:email, wrapper_class: "form-row")
-    assert_equivalent_xml expected, @horizontal_builder.text_field(:email, wrapper: { class: "form-row" })
+    assert_equivalent_xml expected, @horizontal_builder.text_field(:email, wrapper_class: "g-3")
+    assert_equivalent_xml expected, @horizontal_builder.text_field(:email, wrapper: { class: "g-3" })
   end
 
   test "field 'id' attribute is used to specify label 'for' attribute" do

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -279,28 +279,6 @@ class BootstrapFieldsTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.check_box(:misc)
   end
 
-  test "custom check_box fields are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
-      <div class="custom-control custom-checkbox">
-        <input name="user[misc]" type="hidden" value="0"/>
-        <input class="custom-control-input" id="user_misc" name="user[misc]" type="checkbox" value="1"/>
-        <label class="custom-control-label" for="user_misc">Misc</label>
-      </div>
-    HTML
-    assert_equivalent_xml expected, @builder.check_box(:misc, custom: true)
-  end
-
-  test "switch-style check_box fields are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
-      <div class="custom-control custom-switch">
-        <input name="user[misc]" type="hidden" value="0"/>
-        <input class="custom-control-input" id="user_misc" name="user[misc]" type="checkbox" value="1"/>
-        <label class="custom-control-label" for="user_misc">Misc</label>
-      </div>
-    HTML
-    assert_equivalent_xml expected, @builder.check_box(:misc, custom: :switch)
-  end
-
   test "week fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -273,7 +273,7 @@ class BootstrapFieldsTest < ActionView::TestCase
       <div class="form-check">
         <input name="user[misc]" type="hidden" value="0"/>
         <input class="form-check-input" id="user_misc" name="user[misc]" type="checkbox" value="1"/>
-        <label class="form-label form-check-label" for="user_misc">Misc</label>
+        <label class="form-check-label" for="user_misc">Misc</label>
       </div>
     HTML
     assert_equivalent_xml expected, @builder.check_box(:misc)
@@ -284,7 +284,7 @@ class BootstrapFieldsTest < ActionView::TestCase
       <div class="form-check form-switch">
         <input name="user[misc]" type="hidden" value="0"/>
         <input class="form-check-input" id="user_misc" name="user[misc]" type="checkbox" value="1"/>
-        <label class="form-label form-check-label" for="user_misc">Misc</label>
+        <label class="form-check-label" for="user_misc">Misc</label>
       </div>
     HTML
     assert_equivalent_xml expected, @builder.check_box(:misc, switch: true)

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -365,7 +365,7 @@ class BootstrapFieldsTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user form-inline" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user col-auto g-3" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
           <label class="mr-sm-2" for="user_address_attributes_street">Street</label>

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -8,7 +8,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "color fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="color" value="#000000" />
       </div>
     HTML
@@ -18,7 +18,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "date fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="date" />
       </div>
     HTML
@@ -28,7 +28,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "date time fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="datetime" />
       </div>
     HTML
@@ -38,7 +38,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "date time local fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="datetime-local" />
       </div>
     HTML
@@ -48,7 +48,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "email fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="email" />
       </div>
     HTML
@@ -58,10 +58,10 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "file fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-file">
           <input class="form-file-input" id="user_misc" name="user[misc]" type="file" />
-          <label class="form-file-label" for="user_misc">Choose file</label>
+          <label class="form-label form-file-label" for="user_misc">Choose file</label>
         </div>
       </div>
     HTML
@@ -71,10 +71,10 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "file field placeholder can be customized" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-file">
           <input class="form-file-input" id="user_misc" name="user[misc]" type="file" />
-          <label class="form-file-label" for="user_misc">Pick a file</label>
+          <label class="form-label form-file-label" for="user_misc">Pick a file</label>
         </div>
       </div>
     HTML
@@ -85,10 +85,10 @@ class BootstrapFieldsTest < ActionView::TestCase
     test "file field placeholder has appropriate `for` attribute when used in form_with" do
       expected = <<-HTML.strip_heredoc
         <div class="mb-3">
-          <label for="custom-id">Misc</label>
+          <label class="form-label" for="custom-id">Misc</label>
           <div class="form-file">
             <input class="form-file-input" id="custom-id" name="user[misc]" type="file" />
-            <label class="form-file-label" for="custom-id">Choose file</label>
+            <label class="form-label form-file-label" for="custom-id">Choose file</label>
           </div>
         </div>
       HTML
@@ -102,10 +102,10 @@ class BootstrapFieldsTest < ActionView::TestCase
     <form accept-charset="UTF-8" action="/users" class="new_user" enctype="multipart/form-data" id="new_user" method="post" role="form">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-file">
           <input class="form-file-input is-invalid" id="user_misc" name="user[misc]" type="file" />
-          <label class="form-file-label" for="user_misc">Choose file</label>
+          <label class="form-label form-file-label" for="user_misc">Choose file</label>
           <div class="invalid-feedback">error for test</div>
         </div>
       </div>
@@ -122,7 +122,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "month local fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="month" />
       </div>
     HTML
@@ -132,7 +132,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "number fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="number" />
       </div>
     HTML
@@ -142,7 +142,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "password fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_password">Password</label>
+        <label class="form-label" for="user_password">Password</label>
         <input class="form-control" id="user_password" name="user[password]" type="password" />
         <small class="form-text text-muted">A good password should be at least six characters long</small>
       </div>
@@ -153,7 +153,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "phone/telephone fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="tel" />
       </div>
     HTML
@@ -164,7 +164,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "range fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="range" />
       </div>
     HTML
@@ -174,7 +174,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "search fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="search" />
       </div>
     HTML
@@ -184,7 +184,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "text areas are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_comments">Comments</label>
+        <label class="form-label" for="user_comments">Comments</label>
         <textarea class="form-control" id="user_comments" name="user[comments]">\nmy comment</textarea>
       </div>
     HTML
@@ -195,7 +195,7 @@ class BootstrapFieldsTest < ActionView::TestCase
     test "text areas are wrapped correctly form_with Rails 5.1" do
       expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_comments">Comments</label>
+        <label class="form-label" for="user_comments">Comments</label>
         <textarea class="form-control" name="user[comments]">\nmy comment</textarea>
       </div>
       HTML
@@ -207,7 +207,7 @@ class BootstrapFieldsTest < ActionView::TestCase
     test "text areas are wrapped correctly form_with Rails 5.2+" do
       expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_comments">Comments</label>
+        <label class="form-label" for="user_comments">Comments</label>
         <textarea class="form-control" id="user_comments" name="user[comments]">\nmy comment</textarea>
       </div>
       HTML
@@ -218,7 +218,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "text fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label class="required" for="user_email">Email</label>
+        <label class="form-label required" for="user_email">Email</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
@@ -228,7 +228,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "text fields are wrapped correctly when horizontal and gutter classes are given" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 g-3">
-        <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
+        <label class="form-label col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
           <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
         </div>
@@ -241,7 +241,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "field 'id' attribute is used to specify label 'for' attribute" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label class="required" for="custom_id">Email</label>
+        <label class="form-label required" for="custom_id">Email</label>
         <input class="form-control" id="custom_id" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
@@ -251,7 +251,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "time fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="time" />
       </div>
     HTML
@@ -261,7 +261,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "url fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="url" />
       </div>
     HTML
@@ -273,7 +273,7 @@ class BootstrapFieldsTest < ActionView::TestCase
       <div class="form-check">
         <input name="user[misc]" type="hidden" value="0"/>
         <input class="form-check-input" id="user_misc" name="user[misc]" type="checkbox" value="1"/>
-        <label class="form-check-label" for="user_misc">Misc</label>
+        <label class="form-label form-check-label" for="user_misc">Misc</label>
       </div>
     HTML
     assert_equivalent_xml expected, @builder.check_box(:misc)
@@ -282,7 +282,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "week fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="week" />
       </div>
     HTML
@@ -302,7 +302,7 @@ class BootstrapFieldsTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label for="user_address_attributes_street">Street</label>
+          <label class="form-label" for="user_address_attributes_street">Street</label>
           <input class="form-control" id="user_address_attributes_street" name="user[address_attributes][street]" type="text" value="123 Main Street" />
         </div>
       </form>
@@ -323,7 +323,7 @@ class BootstrapFieldsTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label for="user_preferences_favorite_color">Favorite color</label>
+          <label class="form-label" for="user_preferences_favorite_color">Favorite color</label>
           <input class="form-control" id="user_preferences_favorite_color" name="user[preferences][favorite_color]" type="text" value="cerulean" />
         </div>
       </form>
@@ -344,7 +344,7 @@ class BootstrapFieldsTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 row">
-          <label class="col-form-label col-sm-2" for="user_address_attributes_street">Street</label>
+          <label class="form-label col-form-label col-sm-2" for="user_address_attributes_street">Street</label>
           <div class="col-sm-10">
             <input class="form-control" id="user_address_attributes_street" name="user[address_attributes][street]" type="text" value="123 Main Street" />
           </div>
@@ -368,7 +368,7 @@ class BootstrapFieldsTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user col-auto g-3" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label class="mr-sm-2" for="user_address_attributes_street">Street</label>
+          <label class="form-label mr-sm-2" for="user_address_attributes_street">Street</label>
           <input class="form-control" id="user_address_attributes_street" name="user[address_attributes][street]" type="text" value="123 Main Street" />
         </div>
       </form>

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -279,6 +279,17 @@ class BootstrapFieldsTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.check_box(:misc)
   end
 
+  test "switch-style check_box fields are wrapped correctly" do
+    expected = <<-HTML.strip_heredoc
+      <div class="form-check form-switch">
+        <input name="user[misc]" type="hidden" value="0"/>
+        <input class="form-check-input" id="user_misc" name="user[misc]" type="checkbox" value="1"/>
+        <label class="form-label form-check-label" for="user_misc">Misc</label>
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.check_box(:misc, switch: true)
+  end
+
   test "week fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -8,7 +8,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "changing the label text via the label option parameter" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label class="required" for="user_email">Email Address</label>
+        <label class="form-label required" for="user_email">Email Address</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
@@ -18,7 +18,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "changing the label text via the html_options label hash" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label class="required" for="user_email">Email Address</label>
+        <label class="form-label required" for="user_email">Email Address</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
@@ -28,7 +28,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "hiding a label" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label class="sr-only required" for="user_email">Email</label>
+        <label class="form-label sr-only required" for="user_email">Email</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
@@ -38,7 +38,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "adding a custom label class via the label_class parameter" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label class="btn required" for="user_email">Email</label>
+        <label class="form-label btn required" for="user_email">Email</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
@@ -48,7 +48,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "adding a custom label class via the html_options label hash" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label class="btn required" for="user_email">Email</label>
+        <label class="form-label btn required" for="user_email">Email</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
@@ -58,7 +58,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "adding a custom label and changing the label text via the html_options label hash" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label class="btn required" for="user_email">Email Address</label>
+        <label class="form-label btn required" for="user_email">Email Address</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
@@ -77,7 +77,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "preventing a label from having the required class with :skip_required" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_email">Email</label>
+        <label class="form-label" for="user_email">Email</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
@@ -89,7 +89,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "preventing a label from having the required class" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_email">Email</label>
+        <label class="form-label" for="user_email">Email</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
@@ -99,7 +99,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "forcing a label to have the required class" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label class="required" for="user_comments">Comments</label>
+        <label class="form-label required" for="user_comments">Comments</label>
         <input class="form-control" id="user_comments" name="user[comments]" type="text" value="my comment" required="required" />
       </div>
     HTML
@@ -109,7 +109,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "label as placeholder" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label class="sr-only required" for="user_email">Email</label>
+        <label class="form-label sr-only required" for="user_email">Email</label>
         <input class="form-control" id="user_email" placeholder="Email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
@@ -119,7 +119,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "adding prepend text" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label class="required" for="user_email">Email</label>
+        <label class="form-label required" for="user_email">Email</label>
         <div class="input-group">
           <span class="input-group-text">@</span>
           <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
@@ -132,7 +132,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "adding append text" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label class="required" for="user_email">Email</label>
+        <label class="form-label required" for="user_email">Email</label>
         <div class="input-group">
           <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
           <span class="input-group-text">.00</span>
@@ -143,7 +143,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "append and prepend button" do
-    prefix = '<div class="mb-3"><label class="required" for="user_email">Email</label><div class="input-group">'
+    prefix = '<div class="mb-3"><label class="form-label required" for="user_email">Email</label><div class="input-group">'
     field = '<input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />'
     button_src = link_to("Click", "#", class: "btn btn-secondary")
     button_prepend = button_src
@@ -162,7 +162,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "adding both prepend and append text" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label class="required" for="user_email">Email</label>
+        <label class="form-label required" for="user_email">Email</label>
         <div class="input-group">
           <span class="input-group-text">$</div>
           <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
@@ -181,7 +181,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label class="required" for="user_email">Email</label>
+          <label class="form-label required" for="user_email">Email</label>
           <div class="input-group">
             <span class="input-group-text">$</div>
             <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
@@ -197,7 +197,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "help messages for default forms" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label class="required" for="user_email">Email</label>
+        <label class="form-label required" for="user_email">Email</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
         <small class="form-text text-muted">This is required</small>
       </div>
@@ -208,7 +208,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "help messages for horizontal forms" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 row">
-        <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
+        <label class="form-label col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
           <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
           <small class="form-text text-muted">This is required</small>
@@ -221,7 +221,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "help messages to look up I18n automatically" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_password">Password</label>
+        <label class="form-label" for="user_password">Password</label>
         <input class="form-control" id="user_password" name="user[password]" type="text" value="secret" />
         <small class="form-text text-muted">A good password should be at least six characters long</small>
       </div>
@@ -242,7 +242,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_password">Password</label>
+        <label class="form-label" for="user_password">Password</label>
         <input class="form-control" id="user_password" name="user[password]" type="text" value="secret" />
         <small class="form-text text-muted">A <strong>good</strong> password should be at least six characters long</small>
       </div>
@@ -271,7 +271,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "help messages to ignore translation when user disables help" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_password">Password</label>
+        <label class="form-label" for="user_password">Password</label>
         <input class="form-control" id="user_password" name="user[password]" type="text" value="secret" />
       </div>
     HTML
@@ -285,7 +285,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 row">
-        <label class="col-form-label col-sm-2" for="user_nil">Foo</label>
+        <label class="form-label col-form-label col-sm-2" for="user_nil">Foo</label>
         <div class="col-sm-10">
           <input class="form-control-plaintext" value="Bar">
         </div>
@@ -316,7 +316,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 row">
-        <label class="col-form-label col-sm-2 required" for="user_email">Custom Control</label>
+        <label class="form-label col-form-label col-sm-2 required" for="user_email">Custom Control</label>
         <div class="col-sm-10">
           <input class="form-control-plaintext" value="Bar">
         </div>
@@ -377,7 +377,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 row">
-        <label class="foo col-form-label col-sm-2" for="bar">Custom Control</label>
+        <label class="form-label foo col-form-label col-sm-2" for="bar">Custom Control</label>
         <div class="col-sm-10">
           <input class="form-control-plaintext" value="Bar">
         </div>
@@ -425,15 +425,15 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <div class="mb-3">
           <div class="form-check">
             <input class="form-check-input is-invalid" id="user_misc_primary_school" name="user[misc]" type="radio" value="primary school"/>
-            <label class="form-check-label" for="user_misc_primary_school">Primary school</label>
+            <label class="form-label form-check-label" for="user_misc_primary_school">Primary school</label>
           </div>
           <div class="form-check">
             <input class="form-check-input is-invalid" id="user_misc_high_school" name="user[misc]" type="radio" value="high school"/>
-            <label class="form-check-label" for="user_misc_high_school">High school</label>
+            <label class="form-label form-check-label" for="user_misc_high_school">High school</label>
           </div>
           <div class="form-check">
             <input class="form-check-input is-invalid" id="user_misc_university" name="user[misc]" type="radio" value="university"/>
-            <label class="form-check-label" for="user_misc_university">University</label>
+            <label class="form-label form-check-label" for="user_misc_university">University</label>
             <div class="invalid-feedback">Must select one.</div>
           </div>
         </div>
@@ -445,7 +445,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "adds class to wrapped form_group by a field" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 none-margin">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="search" />
       </div>
     HTML
@@ -459,7 +459,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 none-margin">
         <div class="field_with_errors">
-          <label class="required" for="user_email">Email</label>
+          <label class="form-label required" for="user_email">Email</label>
         </div>
         <div class="field_with_errors">
           <input class="form-control is-invalid" id="user_email" name="user[email]" type="email" />
@@ -482,7 +482,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 none-margin">
-          <label class="required" for="user_email">Email</label>
+          <label class="form-label required" for="user_email">Email</label>
           <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
         </div>
@@ -534,7 +534,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <div class="col-sm-10 offset-sm-2">Hallo</div>
       </div>
       <div class="mb-3 row">
-        <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
+        <label class="form-label col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
           <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
         </div>
@@ -546,7 +546,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "adds data-attributes (or any other options) to wrapper" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3" data-foo="bar">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="search" />
       </div>
     HTML
@@ -561,7 +561,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "passing options to a form control get passed through" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label class="required" for="user_email">Email</label>
+        <label class="form-label required" for="user_email">Email</label>
         <input autofocus="autofocus" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
@@ -575,7 +575,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_nil">Foo</label>
+        <label class="form-label" for="user_nil">Foo</label>
       </div>
     HTML
     assert_equivalent_xml expected, output
@@ -586,7 +586,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 col-auto g-3">
-          <label class="mr-sm-2 required" for="user_email">Email</label>
+          <label class="form-label mr-sm-2 required" for="user_email">Email</label>
           <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
         </div>
       </form>
@@ -625,7 +625,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test ":input_group_class should apply to input-group" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label class="required" for="user_email">Email</label>
+        <label class="form-label required" for="user_email">Email</label>
         <div class="input-group input-group-lg">
           <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
           <input class="btn btn-primary" name="commit" type="submit" value="Subscribe" />

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -368,12 +368,12 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "form_group horizontal lets caller override .row" do
-    output = @horizontal_builder.form_group class: "form-row" do
+    output = @horizontal_builder.form_group class: "g-3" do
       '<input class="form-control-plaintext" value="Bar">'.html_safe
     end
 
     expected = <<-HTML.strip_heredoc
-      <div class="mb-3 form-row">
+      <div class="mb-3 g-3">
         <div class="col-sm-10 offset-sm-2">
           <input class="form-control-plaintext" value="Bar">
         </div>

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -425,15 +425,15 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <div class="mb-3">
           <div class="form-check">
             <input class="form-check-input is-invalid" id="user_misc_primary_school" name="user[misc]" type="radio" value="primary school"/>
-            <label class="form-label form-check-label" for="user_misc_primary_school">Primary school</label>
+            <label class="form-check-label" for="user_misc_primary_school">Primary school</label>
           </div>
           <div class="form-check">
             <input class="form-check-input is-invalid" id="user_misc_high_school" name="user[misc]" type="radio" value="high school"/>
-            <label class="form-label form-check-label" for="user_misc_high_school">High school</label>
+            <label class="form-check-label" for="user_misc_high_school">High school</label>
           </div>
           <div class="form-check">
             <input class="form-check-input is-invalid" id="user_misc_university" name="user[misc]" type="radio" value="university"/>
-            <label class="form-label form-check-label" for="user_misc_university">University</label>
+            <label class="form-check-label" for="user_misc_university">University</label>
             <div class="invalid-feedback">Must select one.</div>
           </div>
         </div>

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -121,9 +121,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       <div class="mb-3">
         <label class="required" for="user_email">Email</label>
         <div class="input-group">
-          <div class="input-group-prepend">
-            <span class="input-group-text">@</span>
-          </div>
+          <span class="input-group-text">@</span>
           <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
         </div>
       </div>
@@ -137,9 +135,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <label class="required" for="user_email">Email</label>
         <div class="input-group">
           <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
-          <div class="input-group-append">
-            <span class="input-group-text">.00</span>
-          </div>
+          <span class="input-group-text">.00</span>
         </div>
       </div>
     HTML
@@ -150,8 +146,8 @@ class BootstrapFormGroupTest < ActionView::TestCase
     prefix = '<div class="mb-3"><label class="required" for="user_email">Email</label><div class="input-group">'
     field = '<input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />'
     button_src = link_to("Click", "#", class: "btn btn-secondary")
-    button_prepend = "<div class=\"input-group-prepend\">#{button_src}</div>"
-    button_append = "<div class=\"input-group-append\">#{button_src}</div>"
+    button_prepend = button_src
+    button_append = button_src
     suffix = "</div></div>"
     after_button = prefix + field + button_append + suffix
     before_button = prefix + button_prepend + field + suffix
@@ -168,13 +164,9 @@ class BootstrapFormGroupTest < ActionView::TestCase
       <div class="mb-3">
         <label class="required" for="user_email">Email</label>
         <div class="input-group">
-          <div class="input-group-prepend">
-            <span class="input-group-text">$</div>
-          </div>
+          <span class="input-group-text">$</div>
           <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
-          <div class="input-group-append">
-            <span class="input-group-text">.00</span>
-          </div>
+          <span class="input-group-text">.00</span>
         </div>
       </div>
     HTML
@@ -191,13 +183,9 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <div class="mb-3">
           <label class="required" for="user_email">Email</label>
           <div class="input-group">
-            <div class="input-group-prepend">
-              <span class="input-group-text">$</div>
-            </div>
+            <span class="input-group-text">$</div>
             <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
-            <div class="input-group-append">
-              <span class="input-group-text">.00</span>
-            </div>
+            <span class="input-group-text">.00</span>
             <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</span>
           </div>
         </div>
@@ -640,9 +628,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <label class="required" for="user_email">Email</label>
         <div class="input-group input-group-lg">
           <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
-          <div class="input-group-append">
-            <input class="btn btn-primary" name="commit" type="submit" value="Subscribe" />
-          </div>
+          <input class="btn btn-primary" name="commit" type="submit" value="Subscribe" />
         </div>
       </div>
     HTML

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -597,7 +597,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="mb-3 form-inline">
+        <div class="mb-3 col-auto g-3">
           <label class="mr-sm-2 required" for="user_email">Email</label>
           <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
         </div>

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -7,7 +7,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "changing the label text via the label option parameter" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label class="required" for="user_email">Email Address</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
@@ -17,7 +17,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "changing the label text via the html_options label hash" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label class="required" for="user_email">Email Address</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
@@ -27,7 +27,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "hiding a label" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label class="sr-only required" for="user_email">Email</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
@@ -37,7 +37,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "adding a custom label class via the label_class parameter" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label class="btn required" for="user_email">Email</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
@@ -47,7 +47,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "adding a custom label class via the html_options label hash" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label class="btn required" for="user_email">Email</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
@@ -57,7 +57,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "adding a custom label and changing the label text via the html_options label hash" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label class="btn required" for="user_email">Email Address</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
@@ -67,7 +67,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "skipping a label" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
@@ -76,7 +76,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "preventing a label from having the required class with :skip_required" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_email">Email</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
@@ -88,7 +88,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "preventing a label from having the required class" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_email">Email</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
@@ -98,7 +98,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "forcing a label to have the required class" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label class="required" for="user_comments">Comments</label>
         <input class="form-control" id="user_comments" name="user[comments]" type="text" value="my comment" required="required" />
       </div>
@@ -108,7 +108,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "label as placeholder" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label class="sr-only required" for="user_email">Email</label>
         <input class="form-control" id="user_email" placeholder="Email" name="user[email]" type="text" value="steve@example.com" />
       </div>
@@ -118,7 +118,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "adding prepend text" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label class="required" for="user_email">Email</label>
         <div class="input-group">
           <div class="input-group-prepend">
@@ -133,7 +133,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "adding append text" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label class="required" for="user_email">Email</label>
         <div class="input-group">
           <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
@@ -147,7 +147,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "append and prepend button" do
-    prefix = '<div class="form-group"><label class="required" for="user_email">Email</label><div class="input-group">'
+    prefix = '<div class="mb-3"><label class="required" for="user_email">Email</label><div class="input-group">'
     field = '<input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />'
     button_src = link_to("Click", "#", class: "btn btn-secondary")
     button_prepend = "<div class=\"input-group-prepend\">#{button_src}</div>"
@@ -165,7 +165,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "adding both prepend and append text" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label class="required" for="user_email">Email</label>
         <div class="input-group">
           <div class="input-group-prepend">
@@ -188,7 +188,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group">
+        <div class="mb-3">
           <label class="required" for="user_email">Email</label>
           <div class="input-group">
             <div class="input-group-prepend">
@@ -208,7 +208,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "help messages for default forms" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label class="required" for="user_email">Email</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
         <small class="form-text text-muted">This is required</small>
@@ -219,7 +219,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "help messages for horizontal forms" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group row">
+      <div class="mb-3 row">
         <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
           <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
@@ -232,7 +232,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "help messages to look up I18n automatically" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_password">Password</label>
         <input class="form-control" id="user_password" name="user[password]" type="text" value="secret" />
         <small class="form-text text-muted">A good password should be at least six characters long</small>
@@ -253,7 +253,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
                                     })
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_password">Password</label>
         <input class="form-control" id="user_password" name="user[password]" type="text" value="secret" />
         <small class="form-text text-muted">A <strong>good</strong> password should be at least six characters long</small>
@@ -282,7 +282,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "help messages to ignore translation when user disables help" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_password">Password</label>
         <input class="form-control" id="user_password" name="user[password]" type="text" value="secret" />
       </div>
@@ -296,7 +296,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group row">
+      <div class="mb-3 row">
         <label class="col-form-label col-sm-2" for="user_nil">Foo</label>
         <div class="col-sm-10">
           <input class="form-control-plaintext" value="Bar">
@@ -312,7 +312,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group row">
+      <div class="mb-3 row">
         <div class="col-sm-10 offset-sm-2">
           <input class="form-control-plaintext" value="Bar">
         </div>
@@ -327,7 +327,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group row">
+      <div class="mb-3 row">
         <label class="col-form-label col-sm-2 required" for="user_email">Custom Control</label>
         <div class="col-sm-10">
           <input class="form-control-plaintext" value="Bar">
@@ -343,7 +343,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group foo row">
+      <div class="mb-3 foo row">
         <div class="col-sm-10 offset-sm-2">
           <input class="form-control-plaintext" value="Bar">
         </div>
@@ -358,7 +358,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group foo row">
+      <div class="mb-3 foo row">
         <div class="col-sm-10 offset-sm-2">
           <input class="form-control-plaintext" value="Bar">
         </div>
@@ -373,7 +373,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group form-row">
+      <div class="mb-3 form-row">
         <div class="col-sm-10 offset-sm-2">
           <input class="form-control-plaintext" value="Bar">
         </div>
@@ -388,7 +388,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group row">
+      <div class="mb-3 row">
         <label class="foo col-form-label col-sm-2" for="bar">Custom Control</label>
         <div class="col-sm-10">
           <input class="form-control-plaintext" value="Bar">
@@ -412,7 +412,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <p class="form-control-plaintext">Bar</p>
         <div class="invalid-feedback" style="display: block;">can't be blank, is too short (minimum is 5 characters)</div>
       </div>
@@ -434,7 +434,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group">
+        <div class="mb-3">
           <div class="form-check">
             <input class="form-check-input is-invalid" id="user_misc_primary_school" name="user[misc]" type="radio" value="primary school"/>
             <label class="form-check-label" for="user_misc_primary_school">Primary school</label>
@@ -456,7 +456,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "adds class to wrapped form_group by a field" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group none-margin">
+      <div class="mb-3 none-margin">
         <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="search" />
       </div>
@@ -469,7 +469,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert @user.invalid?
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group none-margin">
+      <div class="mb-3 none-margin">
         <div class="field_with_errors">
           <label class="required" for="user_email">Email</label>
         </div>
@@ -493,7 +493,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group none-margin">
+        <div class="mb-3 none-margin">
           <label class="required" for="user_email">Email</label>
           <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
@@ -509,7 +509,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group row">
+      <div class="mb-3 row">
         <div class="col-sm-10 offset-sm-2">
           <input class="btn btn-secondary" name="commit" type="submit" value="Create User" />
         </div>
@@ -524,7 +524,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group row">
+      <div class="mb-3 row">
         <div class="col-sm-8 offset-sm-5">
           <input class="btn btn-secondary" name="commit" type="submit" value="Create User" />
         </div>
@@ -542,10 +542,10 @@ class BootstrapFormGroupTest < ActionView::TestCase
     output += @horizontal_builder.text_field(:email)
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group row">
+      <div class="mb-3 row">
         <div class="col-sm-10 offset-sm-2">Hallo</div>
       </div>
-      <div class="form-group row">
+      <div class="mb-3 row">
         <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
           <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
@@ -557,7 +557,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "adds data-attributes (or any other options) to wrapper" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group" data-foo="bar">
+      <div class="mb-3" data-foo="bar">
         <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="search" />
       </div>
@@ -572,7 +572,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "passing options to a form control get passed through" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label class="required" for="user_email">Email</label>
         <input autofocus="autofocus" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
@@ -586,7 +586,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_nil">Foo</label>
       </div>
     HTML
@@ -597,7 +597,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group form-inline">
+        <div class="mb-3 form-inline">
           <label class="mr-sm-2 required" for="user_email">Email</label>
           <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
         </div>
@@ -615,7 +615,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group row">
+      <div class="mb-3 row">
         <div class="col-sm-9 offset-sm-3">
           <input class="form-control-plaintext" value="Bar">
         </div>
@@ -630,13 +630,13 @@ class BootstrapFormGroupTest < ActionView::TestCase
                                                                                    control_col: "col-sm-9".freeze)
     output = frozen_horizontal_builder.form_group { "test" }
 
-    expected = '<div class="form-group row"><div class="col-sm-9 offset-sm-3">test</div></div>'
+    expected = '<div class="mb-3 row"><div class="col-sm-9 offset-sm-3">test</div></div>'
     assert_equivalent_xml expected, output
   end
 
   test ":input_group_class should apply to input-group" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label class="required" for="user_email">Email</label>
         <div class="input-group input-group-lg">
           <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -18,7 +18,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group row">
+        <div class="mb-3 row">
           <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
           <div class="col-sm-10">
             <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
@@ -29,7 +29,7 @@ class BootstrapFormTest < ActionView::TestCase
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_terms">I agree to the terms</label>
         </div>
-        <div class="form-group row">
+        <div class="mb-3 row">
           <label class="col-form-label col-sm-2" for="user_misc">Misc</label>
           <div class="col-sm-10">
             <div class="form-check">
@@ -42,7 +42,7 @@ class BootstrapFormTest < ActionView::TestCase
             </div>
           </div>
         </div>
-        <div class="form-group row">
+        <div class="mb-3 row">
           <label class="col-form-label col-sm-2" for="user_status">Status</label>
           <div class="col-sm-10">
             <select class="form-control" id="user_status" name="user[status]">
@@ -70,7 +70,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group form-inline">
+        <div class="mb-3 form-inline">
           <label class="mr-sm-2 required" for="user_email">Email</label>
           <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
         </div>
@@ -79,7 +79,7 @@ class BootstrapFormTest < ActionView::TestCase
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_terms">I agree to the terms</label>
         </div>
-        <div class="form-group form-inline">
+        <div class="mb-3 form-inline">
           <label class="mr-sm-2" for="user_misc">Misc</label>
           <div class="form-check form-check-inline">
             <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
@@ -90,7 +90,7 @@ class BootstrapFormTest < ActionView::TestCase
             <label class="form-check-label" for="user_misc_2"> Bar</label>
           </div>
         </div>
-        <div class="form-group form-inline">
+        <div class="mb-3 form-inline">
           <label class="mr-sm-2" for="user_status">Status</label>
           <select class="form-control" id="user_status" name="user[status]">
             <option value="1">activated</option>
@@ -132,7 +132,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user form-inline" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group">
+        <div class="mb-3">
           <label class="mr-sm-2 required" for="user_email">Email</label>
           <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
         </div>
@@ -141,7 +141,7 @@ class BootstrapFormTest < ActionView::TestCase
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_terms">I agree to the terms</label>
         </div>
-        <div class="form-group">
+        <div class="mb-3">
           <label class="mr-sm-2" for="user_misc">Misc</label>
           <div class="form-check form-check-inline">
             <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
@@ -152,7 +152,7 @@ class BootstrapFormTest < ActionView::TestCase
             <label class="form-check-label" for="user_misc_2"> Bar</label>
           </div>
         </div>
-        <div class="form-group">
+        <div class="mb-3">
           <label class="mr-sm-2" for="user_status">Status</label>
           <select class="form-control" id="user_status" name="user[status]">
             <option value="1">activated</option>
@@ -177,7 +177,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group row">
+        <div class="mb-3 row">
           <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
           <div class="col-sm-10">
             <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
@@ -188,7 +188,7 @@ class BootstrapFormTest < ActionView::TestCase
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_terms">I agree to the terms</label>
         </div>
-        <div class="form-group row">
+        <div class="mb-3 row">
           <label class="col-form-label col-sm-2" for="user_misc">Misc</label>
           <div class="col-sm-10">
             <div class="form-check">
@@ -201,7 +201,7 @@ class BootstrapFormTest < ActionView::TestCase
             </div>
           </div>
         </div>
-        <div class="form-group row">
+        <div class="mb-3 row">
           <label class="col-form-label col-sm-2" for="user_status">Status</label>
           <div class="col-sm-10">
             <select class="form-control" id="user_status" name="user[status]">
@@ -228,7 +228,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group">
+        <div class="mb-3">
           <label class="required" for="user_email">Email</label>
           <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
         </div>
@@ -237,7 +237,7 @@ class BootstrapFormTest < ActionView::TestCase
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_terms">I agree to the terms</label>
         </div>
-        <div class="form-group">
+        <div class="mb-3">
           <label for="user_misc">Misc</label>
           <div class="form-check">
             <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
@@ -248,7 +248,7 @@ class BootstrapFormTest < ActionView::TestCase
             <label class="form-check-label" for="user_misc_2"> Bar</label>
           </div>
         </div>
-        <div class="form-group">
+        <div class="mb-3">
           <label for="user_status">Status</label>
           <select class="form-control" id="user_status" name="user[status]">
             <option value="1">activated</option>
@@ -274,7 +274,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group form-inline">
+        <div class="mb-3 form-inline">
           <label class="mr-sm-2 required" for="user_email">Email</label>
           <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
         </div>
@@ -283,7 +283,7 @@ class BootstrapFormTest < ActionView::TestCase
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_terms">I agree to the terms</label>
         </div>
-        <div class="form-group form-inline">
+        <div class="mb-3 form-inline">
           <label class="mr-sm-2" for="user_misc">Misc</label>
           <div class="form-check form-check-inline">
             <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
@@ -294,7 +294,7 @@ class BootstrapFormTest < ActionView::TestCase
             <label class="form-check-label" for="user_misc_2"> Bar</label>
           </div>
         </div>
-        <div class="form-group form-inline">
+        <div class="mb-3 form-inline">
           <label class="mr-sm-2" for="user_status">Status</label>
           <select class="form-control" id="user_status" name="user[status]">
             <option value="1">activated</option>
@@ -320,7 +320,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="my-style" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group row">
+        <div class="mb-3 row">
           <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
           <div class="col-sm-10">
             <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
@@ -365,7 +365,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group">
+        <div class="mb-3">
           <label for="email">Your Email</label>
           <input class="form-control" id="email" name="email" type="text" />
         </div>
@@ -379,7 +379,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group">
+        <div class="mb-3">
           <label class="required" for="ID">Email</label>
           <input class="form-control" id="ID" name="NAME" type="text" value="steve@example.com" />
         </div>
@@ -392,7 +392,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group">
+        <div class="mb-3">
           <label for="ID">Email</label>
           <input class="form-control" id="ID" name="NAME" type="text" />
         </div>
@@ -429,7 +429,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group">
+        <div class="mb-3">
           <label class="required text-danger" for="user_email">Email can't be blank, is too short (minimum is 5 characters)</label>
           <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
         </div>
@@ -445,7 +445,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group">
+        <div class="mb-3">
           <label class="required text-danger" for="user_email">Email can&#39;t be blank, is too short (minimum is 5 characters)</label>
           <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</span>
@@ -464,7 +464,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
         <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
           #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-          <div class="form-group">
+          <div class="mb-3">
             <label class="required text-danger" for="user_email">Your e-mail address can&#39;t be blank, is too short (minimum is 5 characters)</label>
             <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
             <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
@@ -612,7 +612,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group row">
+        <div class="mb-3 row">
           <label class="col-form-label col-sm-1 required" for="user_email">Email</label>
           <div class="col-sm-10">
             <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
@@ -628,7 +628,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group row">
+        <div class="mb-3 row">
           <div class="col-md-10 offset-md-2">
             <input class="btn btn-secondary" name="commit" type="submit" value="Create User" />
           </div>
@@ -644,7 +644,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group row">
+        <div class="mb-3 row">
           <div class="col-sm-8 col-md-10 offset-sm-4 offset-md-2">
             <input class="btn btn-secondary" name="commit" type="submit" value="Create User" />
           </div>
@@ -660,7 +660,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group row">
+        <div class="mb-3 row">
           <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
           <div class="col-sm-5">
             <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
@@ -676,7 +676,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group row">
+        <div class="mb-3 row">
           <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
           <div class="col-sm-10 custom-class">
             <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
@@ -700,7 +700,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group">
+        <div class="mb-3">
           <label class="required" for="user_email">Email</label>
           <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
@@ -721,7 +721,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group">
+        <div class="mb-3">
           <div class="field_with_errors">
             <label class="required" for="user_email">Email</label>
           </div>
@@ -746,7 +746,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group">
+        <div class="mb-3">
           <label class="required" for="user_email">Email</label>
           <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           <small class="form-text text-muted">This is required</small>
@@ -766,7 +766,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
         <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
           #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-          <div class="form-group">
+          <div class="mb-3">
             <label class="required" for="user_email">Email</label>
             <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
             <small class="form-text text-muted">This is <strong>useful</strong> help</small>
@@ -781,7 +781,7 @@ class BootstrapFormTest < ActionView::TestCase
   test "allows the form object to be nil" do
     builder = BootstrapForm::FormBuilder.new :other_model, nil, self, {}
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="other_model_email">Email</label>
         <input class="form-control" id="other_model_email" name="other_model[email]" type="text" />
       </div>

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -27,18 +27,18 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="form-check">
           <input name="user[terms]" type="hidden" value="0" />
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-          <label class="form-label form-check-label" for="user_terms">I agree to the terms</label>
+          <label class="form-check-label" for="user_terms">I agree to the terms</label>
         </div>
         <div class="mb-3 row">
           <label class="form-label col-form-label col-sm-2" for="user_misc">Misc</label>
           <div class="col-sm-10">
             <div class="form-check">
               <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-              <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
+              <label class="form-check-label" for="user_misc_1"> Foo</label>
             </div>
             <div class="form-check">
               <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-              <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
+              <label class="form-check-label" for="user_misc_2"> Bar</label>
             </div>
           </div>
         </div>
@@ -77,17 +77,17 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="form-check form-check-inline">
           <input name="user[terms]" type="hidden" value="0" />
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-          <label class="form-label form-check-label" for="user_terms">I agree to the terms</label>
+          <label class="form-check-label" for="user_terms">I agree to the terms</label>
         </div>
         <div class="mb-3 col-auto g-3">
           <label class="form-label mr-sm-2" for="user_misc">Misc</label>
           <div class="form-check form-check-inline">
             <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-            <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
+            <label class="form-check-label" for="user_misc_1"> Foo</label>
           </div>
           <div class="form-check form-check-inline">
             <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-            <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
+            <label class="form-check-label" for="user_misc_2"> Bar</label>
           </div>
         </div>
         <div class="mb-3 col-auto g-3">
@@ -139,17 +139,17 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="form-check form-check-inline">
           <input name="user[terms]" type="hidden" value="0" />
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-          <label class="form-label form-check-label" for="user_terms">I agree to the terms</label>
+          <label class="form-check-label" for="user_terms">I agree to the terms</label>
         </div>
         <div class="mb-3">
           <label class="form-label mr-sm-2" for="user_misc">Misc</label>
           <div class="form-check form-check-inline">
             <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-            <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
+            <label class="form-check-label" for="user_misc_1"> Foo</label>
           </div>
           <div class="form-check form-check-inline">
             <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-            <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
+            <label class="form-check-label" for="user_misc_2"> Bar</label>
           </div>
         </div>
         <div class="mb-3">
@@ -186,18 +186,18 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="form-check">
           <input name="user[terms]" type="hidden" value="0" />
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-          <label class="form-label form-check-label" for="user_terms">I agree to the terms</label>
+          <label class="form-check-label" for="user_terms">I agree to the terms</label>
         </div>
         <div class="mb-3 row">
           <label class="form-label col-form-label col-sm-2" for="user_misc">Misc</label>
           <div class="col-sm-10">
             <div class="form-check">
               <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-              <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
+              <label class="form-check-label" for="user_misc_1"> Foo</label>
             </div>
             <div class="form-check">
               <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-              <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
+              <label class="form-check-label" for="user_misc_2"> Bar</label>
             </div>
           </div>
         </div>
@@ -235,17 +235,17 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="form-check">
           <input name="user[terms]" type="hidden" value="0" />
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-          <label class="form-label form-check-label" for="user_terms">I agree to the terms</label>
+          <label class="form-check-label" for="user_terms">I agree to the terms</label>
         </div>
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="form-check">
             <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-            <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
+            <label class="form-check-label" for="user_misc_1"> Foo</label>
           </div>
           <div class="form-check">
             <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-            <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
+            <label class="form-check-label" for="user_misc_2"> Bar</label>
           </div>
         </div>
         <div class="mb-3">
@@ -281,17 +281,17 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="form-check form-check-inline">
           <input name="user[terms]" type="hidden" value="0" />
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-          <label class="form-label form-check-label" for="user_terms">I agree to the terms</label>
+          <label class="form-check-label" for="user_terms">I agree to the terms</label>
         </div>
         <div class="mb-3 col-auto g-3">
           <label class="form-label mr-sm-2" for="user_misc">Misc</label>
           <div class="form-check form-check-inline">
             <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-            <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
+            <label class="form-check-label" for="user_misc_1"> Foo</label>
           </div>
           <div class="form-check form-check-inline">
             <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-            <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
+            <label class="form-check-label" for="user_misc_2"> Bar</label>
           </div>
         </div>
         <div class="mb-3 col-auto g-3">
@@ -415,7 +415,7 @@ class BootstrapFormTest < ActionView::TestCase
       <div class="form-check">
         <input class="form-check-input" id="#{id}" name="#{name}" type="checkbox" value="1" />
         <input name="#{name}" type="hidden" value="0" />
-        <label class="form-label form-check-label" for="#{id}"> Misc</label>
+        <label class="form-check-label" for="#{id}"> Misc</label>
       </div>
     </form>
     HTML

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -45,7 +45,7 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="mb-3 row">
           <label class="form-label col-form-label col-sm-2" for="user_status">Status</label>
           <div class="col-sm-10">
-            <select class="form-control" id="user_status" name="user[status]">
+            <select class="form-select" id="user_status" name="user[status]">
               <option value="1">activated</option>
               <option value="2">blocked</option>
             </select>
@@ -92,7 +92,7 @@ class BootstrapFormTest < ActionView::TestCase
         </div>
         <div class="mb-3 col-auto g-3">
           <label class="form-label mr-sm-2" for="user_status">Status</label>
-          <select class="form-control" id="user_status" name="user[status]">
+          <select class="form-select" id="user_status" name="user[status]">
             <option value="1">activated</option>
             <option value="2">blocked</option>
           </select>
@@ -154,7 +154,7 @@ class BootstrapFormTest < ActionView::TestCase
         </div>
         <div class="mb-3">
           <label class="form-label mr-sm-2" for="user_status">Status</label>
-          <select class="form-control" id="user_status" name="user[status]">
+          <select class="form-select" id="user_status" name="user[status]">
             <option value="1">activated</option>
             <option value="2">blocked</option>
           </select>
@@ -204,7 +204,7 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="mb-3 row">
           <label class="form-label col-form-label col-sm-2" for="user_status">Status</label>
           <div class="col-sm-10">
-            <select class="form-control" id="user_status" name="user[status]">
+            <select class="form-select" id="user_status" name="user[status]">
               <option value="1">activated</option>
               <option value="2">blocked</option>
             </select>
@@ -250,7 +250,7 @@ class BootstrapFormTest < ActionView::TestCase
         </div>
         <div class="mb-3">
           <label class="form-label" for="user_status">Status</label>
-          <select class="form-control" id="user_status" name="user[status]">
+          <select class="form-select" id="user_status" name="user[status]">
             <option value="1">activated</option>
             <option value="2">blocked</option>
           </select>
@@ -296,7 +296,7 @@ class BootstrapFormTest < ActionView::TestCase
         </div>
         <div class="mb-3 col-auto g-3">
           <label class="form-label mr-sm-2" for="user_status">Status</label>
-          <select class="form-control" id="user_status" name="user[status]">
+          <select class="form-select" id="user_status" name="user[status]">
             <option value="1">activated</option>
             <option value="2">blocked</option>
           </select>

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -70,7 +70,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="mb-3 form-inline">
+        <div class="mb-3 col-auto g-3">
           <label class="mr-sm-2 required" for="user_email">Email</label>
           <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
         </div>
@@ -79,7 +79,7 @@ class BootstrapFormTest < ActionView::TestCase
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_terms">I agree to the terms</label>
         </div>
-        <div class="mb-3 form-inline">
+        <div class="mb-3 col-auto g-3">
           <label class="mr-sm-2" for="user_misc">Misc</label>
           <div class="form-check form-check-inline">
             <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
@@ -90,7 +90,7 @@ class BootstrapFormTest < ActionView::TestCase
             <label class="form-check-label" for="user_misc_2"> Bar</label>
           </div>
         </div>
-        <div class="mb-3 form-inline">
+        <div class="mb-3 col-auto g-3">
           <label class="mr-sm-2" for="user_status">Status</label>
           <select class="form-control" id="user_status" name="user[status]">
             <option value="1">activated</option>
@@ -130,7 +130,7 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "inline-style forms" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user form-inline" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user col-auto g-3" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
           <label class="mr-sm-2 required" for="user_email">Email</label>
@@ -274,7 +274,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="mb-3 form-inline">
+        <div class="mb-3 col-auto g-3">
           <label class="mr-sm-2 required" for="user_email">Email</label>
           <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
         </div>
@@ -283,7 +283,7 @@ class BootstrapFormTest < ActionView::TestCase
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_terms">I agree to the terms</label>
         </div>
-        <div class="mb-3 form-inline">
+        <div class="mb-3 col-auto g-3">
           <label class="mr-sm-2" for="user_misc">Misc</label>
           <div class="form-check form-check-inline">
             <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
@@ -294,7 +294,7 @@ class BootstrapFormTest < ActionView::TestCase
             <label class="form-check-label" for="user_misc_2"> Bar</label>
           </div>
         </div>
-        <div class="mb-3 form-inline">
+        <div class="mb-3 col-auto g-3">
           <label class="mr-sm-2" for="user_status">Status</label>
           <select class="form-control" id="user_status" name="user[status]">
             <option value="1">activated</option>

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -19,7 +19,7 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 row">
-          <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
+          <label class="form-label col-form-label col-sm-2 required" for="user_email">Email</label>
           <div class="col-sm-10">
             <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
           </div>
@@ -27,23 +27,23 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="form-check">
           <input name="user[terms]" type="hidden" value="0" />
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-          <label class="form-check-label" for="user_terms">I agree to the terms</label>
+          <label class="form-label form-check-label" for="user_terms">I agree to the terms</label>
         </div>
         <div class="mb-3 row">
-          <label class="col-form-label col-sm-2" for="user_misc">Misc</label>
+          <label class="form-label col-form-label col-sm-2" for="user_misc">Misc</label>
           <div class="col-sm-10">
             <div class="form-check">
               <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-              <label class="form-check-label" for="user_misc_1"> Foo</label>
+              <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
             </div>
             <div class="form-check">
               <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-              <label class="form-check-label" for="user_misc_2"> Bar</label>
+              <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
             </div>
           </div>
         </div>
         <div class="mb-3 row">
-          <label class="col-form-label col-sm-2" for="user_status">Status</label>
+          <label class="form-label col-form-label col-sm-2" for="user_status">Status</label>
           <div class="col-sm-10">
             <select class="form-control" id="user_status" name="user[status]">
               <option value="1">activated</option>
@@ -71,27 +71,27 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 col-auto g-3">
-          <label class="mr-sm-2 required" for="user_email">Email</label>
+          <label class="form-label mr-sm-2 required" for="user_email">Email</label>
           <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
         </div>
         <div class="form-check form-check-inline">
           <input name="user[terms]" type="hidden" value="0" />
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-          <label class="form-check-label" for="user_terms">I agree to the terms</label>
+          <label class="form-label form-check-label" for="user_terms">I agree to the terms</label>
         </div>
         <div class="mb-3 col-auto g-3">
-          <label class="mr-sm-2" for="user_misc">Misc</label>
+          <label class="form-label mr-sm-2" for="user_misc">Misc</label>
           <div class="form-check form-check-inline">
             <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-            <label class="form-check-label" for="user_misc_1"> Foo</label>
+            <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
           </div>
           <div class="form-check form-check-inline">
             <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-            <label class="form-check-label" for="user_misc_2"> Bar</label>
+            <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
           </div>
         </div>
         <div class="mb-3 col-auto g-3">
-          <label class="mr-sm-2" for="user_status">Status</label>
+          <label class="form-label mr-sm-2" for="user_status">Status</label>
           <select class="form-control" id="user_status" name="user[status]">
             <option value="1">activated</option>
             <option value="2">blocked</option>
@@ -133,27 +133,27 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user col-auto g-3" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label class="mr-sm-2 required" for="user_email">Email</label>
+          <label class="form-label mr-sm-2 required" for="user_email">Email</label>
           <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
         </div>
         <div class="form-check form-check-inline">
           <input name="user[terms]" type="hidden" value="0" />
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-          <label class="form-check-label" for="user_terms">I agree to the terms</label>
+          <label class="form-label form-check-label" for="user_terms">I agree to the terms</label>
         </div>
         <div class="mb-3">
-          <label class="mr-sm-2" for="user_misc">Misc</label>
+          <label class="form-label mr-sm-2" for="user_misc">Misc</label>
           <div class="form-check form-check-inline">
             <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-            <label class="form-check-label" for="user_misc_1"> Foo</label>
+            <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
           </div>
           <div class="form-check form-check-inline">
             <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-            <label class="form-check-label" for="user_misc_2"> Bar</label>
+            <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
           </div>
         </div>
         <div class="mb-3">
-          <label class="mr-sm-2" for="user_status">Status</label>
+          <label class="form-label mr-sm-2" for="user_status">Status</label>
           <select class="form-control" id="user_status" name="user[status]">
             <option value="1">activated</option>
             <option value="2">blocked</option>
@@ -178,7 +178,7 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 row">
-          <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
+          <label class="form-label col-form-label col-sm-2 required" for="user_email">Email</label>
           <div class="col-sm-10">
             <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
           </div>
@@ -186,23 +186,23 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="form-check">
           <input name="user[terms]" type="hidden" value="0" />
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-          <label class="form-check-label" for="user_terms">I agree to the terms</label>
+          <label class="form-label form-check-label" for="user_terms">I agree to the terms</label>
         </div>
         <div class="mb-3 row">
-          <label class="col-form-label col-sm-2" for="user_misc">Misc</label>
+          <label class="form-label col-form-label col-sm-2" for="user_misc">Misc</label>
           <div class="col-sm-10">
             <div class="form-check">
               <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-              <label class="form-check-label" for="user_misc_1"> Foo</label>
+              <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
             </div>
             <div class="form-check">
               <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-              <label class="form-check-label" for="user_misc_2"> Bar</label>
+              <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
             </div>
           </div>
         </div>
         <div class="mb-3 row">
-          <label class="col-form-label col-sm-2" for="user_status">Status</label>
+          <label class="form-label col-form-label col-sm-2" for="user_status">Status</label>
           <div class="col-sm-10">
             <select class="form-control" id="user_status" name="user[status]">
               <option value="1">activated</option>
@@ -229,27 +229,27 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label class="required" for="user_email">Email</label>
+          <label class="form-label required" for="user_email">Email</label>
           <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
         </div>
         <div class="form-check">
           <input name="user[terms]" type="hidden" value="0" />
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-          <label class="form-check-label" for="user_terms">I agree to the terms</label>
+          <label class="form-label form-check-label" for="user_terms">I agree to the terms</label>
         </div>
         <div class="mb-3">
-          <label for="user_misc">Misc</label>
+          <label class="form-label" for="user_misc">Misc</label>
           <div class="form-check">
             <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-            <label class="form-check-label" for="user_misc_1"> Foo</label>
+            <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
           </div>
           <div class="form-check">
             <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-            <label class="form-check-label" for="user_misc_2"> Bar</label>
+            <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
           </div>
         </div>
         <div class="mb-3">
-          <label for="user_status">Status</label>
+          <label class="form-label" for="user_status">Status</label>
           <select class="form-control" id="user_status" name="user[status]">
             <option value="1">activated</option>
             <option value="2">blocked</option>
@@ -275,27 +275,27 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 col-auto g-3">
-          <label class="mr-sm-2 required" for="user_email">Email</label>
+          <label class="form-label mr-sm-2 required" for="user_email">Email</label>
           <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
         </div>
         <div class="form-check form-check-inline">
           <input name="user[terms]" type="hidden" value="0" />
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-          <label class="form-check-label" for="user_terms">I agree to the terms</label>
+          <label class="form-label form-check-label" for="user_terms">I agree to the terms</label>
         </div>
         <div class="mb-3 col-auto g-3">
-          <label class="mr-sm-2" for="user_misc">Misc</label>
+          <label class="form-label mr-sm-2" for="user_misc">Misc</label>
           <div class="form-check form-check-inline">
             <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-            <label class="form-check-label" for="user_misc_1"> Foo</label>
+            <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
           </div>
           <div class="form-check form-check-inline">
             <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-            <label class="form-check-label" for="user_misc_2"> Bar</label>
+            <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
           </div>
         </div>
         <div class="mb-3 col-auto g-3">
-          <label class="mr-sm-2" for="user_status">Status</label>
+          <label class="form-label mr-sm-2" for="user_status">Status</label>
           <select class="form-control" id="user_status" name="user[status]">
             <option value="1">activated</option>
             <option value="2">blocked</option>
@@ -321,7 +321,7 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="my-style" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 row">
-          <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
+          <label class="form-label col-form-label col-sm-2 required" for="user_email">Email</label>
           <div class="col-sm-10">
             <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
           </div>
@@ -366,7 +366,7 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label for="email">Your Email</label>
+          <label class="form-label" for="email">Your Email</label>
           <input class="form-control" id="email" name="email" type="text" />
         </div>
       </form>
@@ -380,7 +380,7 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label class="required" for="ID">Email</label>
+          <label class="form-label required" for="ID">Email</label>
           <input class="form-control" id="ID" name="NAME" type="text" value="steve@example.com" />
         </div>
       </form>
@@ -393,7 +393,7 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label for="ID">Email</label>
+          <label class="form-label" for="ID">Email</label>
           <input class="form-control" id="ID" name="NAME" type="text" />
         </div>
       </form>
@@ -415,7 +415,7 @@ class BootstrapFormTest < ActionView::TestCase
       <div class="form-check">
         <input class="form-check-input" id="#{id}" name="#{name}" type="checkbox" value="1" />
         <input name="#{name}" type="hidden" value="0" />
-        <label class="form-check-label" for="#{id}"> Misc</label>
+        <label class="form-label form-check-label" for="#{id}"> Misc</label>
       </div>
     </form>
     HTML
@@ -430,7 +430,7 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label class="required text-danger" for="user_email">Email can't be blank, is too short (minimum is 5 characters)</label>
+          <label class="form-label required text-danger" for="user_email">Email can't be blank, is too short (minimum is 5 characters)</label>
           <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
         </div>
       </form>
@@ -446,7 +446,7 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label class="required text-danger" for="user_email">Email can&#39;t be blank, is too short (minimum is 5 characters)</label>
+          <label class="form-label required text-danger" for="user_email">Email can&#39;t be blank, is too short (minimum is 5 characters)</label>
           <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</span>
         </div>
@@ -465,7 +465,7 @@ class BootstrapFormTest < ActionView::TestCase
         <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
           #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
           <div class="mb-3">
-            <label class="required text-danger" for="user_email">Your e-mail address can&#39;t be blank, is too short (minimum is 5 characters)</label>
+            <label class="form-label required text-danger" for="user_email">Your e-mail address can&#39;t be blank, is too short (minimum is 5 characters)</label>
             <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
             <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
           </div>
@@ -613,7 +613,7 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 row">
-          <label class="col-form-label col-sm-1 required" for="user_email">Email</label>
+          <label class="form-label col-form-label col-sm-1 required" for="user_email">Email</label>
           <div class="col-sm-10">
             <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
           </div>
@@ -661,7 +661,7 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 row">
-          <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
+          <label class="form-label col-form-label col-sm-2 required" for="user_email">Email</label>
           <div class="col-sm-5">
             <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
           </div>
@@ -677,7 +677,7 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 row">
-          <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
+          <label class="form-label col-form-label col-sm-2 required" for="user_email">Email</label>
           <div class="col-sm-10 custom-class">
             <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
           </div>
@@ -701,7 +701,7 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label class="required" for="user_email">Email</label>
+          <label class="form-label required" for="user_email">Email</label>
           <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
         </div>
@@ -723,7 +723,7 @@ class BootstrapFormTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
           <div class="field_with_errors">
-            <label class="required" for="user_email">Email</label>
+            <label class="form-label required" for="user_email">Email</label>
           </div>
           <div class="field_with_errors">
             <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
@@ -747,7 +747,7 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label class="required" for="user_email">Email</label>
+          <label class="form-label required" for="user_email">Email</label>
           <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           <small class="form-text text-muted">This is required</small>
         </div>
@@ -767,7 +767,7 @@ class BootstrapFormTest < ActionView::TestCase
         <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
           #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
           <div class="mb-3">
-            <label class="required" for="user_email">Email</label>
+            <label class="form-label required" for="user_email">Email</label>
             <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
             <small class="form-text text-muted">This is <strong>useful</strong> help</small>
           </div>
@@ -782,7 +782,7 @@ class BootstrapFormTest < ActionView::TestCase
     builder = BootstrapForm::FormBuilder.new :other_model, nil, self, {}
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="other_model_email">Email</label>
+        <label class="form-label" for="other_model_email">Email</label>
         <input class="form-control" id="other_model_email" name="other_model[email]" type="text" />
       </div>
     HTML

--- a/test/bootstrap_other_components_test.rb
+++ b/test/bootstrap_other_components_test.rb
@@ -9,7 +9,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
     output = @horizontal_builder.static_control :email
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group row">
+      <div class="mb-3 row">
         <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
           <input class="form-control-plaintext" id="user_email" name="user[email]" readonly="readonly" type="text" value="steve@example.com"/>
@@ -23,7 +23,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
     output = @horizontal_builder.static_control :email, id: "custom_id"
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group row">
+      <div class="mb-3 row">
         <label class="col-form-label col-sm-2 required" for="custom_id">Email</label>
         <div class="col-sm-10">
           <input class="form-control-plaintext" id="custom_id" name="user[email]" readonly="readonly" type="text" value="steve@example.com"/>
@@ -37,7 +37,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
     output = @horizontal_builder.static_control nil, label: "My Label", value: "this is a test"
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group row">
+      <div class="mb-3 row">
         <label class="col-form-label col-sm-2" for="user_">My Label</label>
         <div class="col-sm-10">
           <input class="form-control-plaintext" id="user_" name="user[]" readonly="readonly" type="text" value="this is a test"/>
@@ -51,7 +51,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
     output = @horizontal_builder.static_control label: "Custom Label", value: "Custom Control"
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group row">
+      <div class="mb-3 row">
         <label class="col-form-label col-sm-2" for="user_">Custom Label</label>
         <div class="col-sm-10">
           <input class="form-control-plaintext" id="user_" name="user[]" readonly="readonly" type="text" value="Custom Control"/>
@@ -65,7 +65,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
     output = @horizontal_builder.static_control label: "Custom Label", value: nil
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group row">
+      <div class="mb-3 row">
         <label class="col-form-label col-sm-2" for="user_">Custom Label</label>
         <div class="col-sm-10">
           <input class="form-control-plaintext" id="user_" name="user[]" readonly="readonly" type="text"/>
@@ -79,7 +79,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
     output = @horizontal_builder.static_control :email, control_class: "test_class"
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group row">
+      <div class="mb-3 row">
         <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
           <input class="test_class form-control-plaintext" id="user_email" name="user[email]" readonly="readonly" type="text" value="steve@example.com"/>
@@ -95,7 +95,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group row">
+      <div class="mb-3 row">
         <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">this is a test</div>
       </div>
@@ -109,7 +109,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group row">
+      <div class="mb-3 row">
         <label class="col-form-label col-sm-2" for="user_">My Label</label>
         <div class="col-sm-10">this is a test</div>
       </div>
@@ -123,7 +123,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
     end
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group row">
+      <div class="mb-3 row">
         <label class="col-form-label col-sm-2" for="user_">Custom Label</label>
         <div class="col-sm-10">Custom Control</div>
       </div>

--- a/test/bootstrap_other_components_test.rb
+++ b/test/bootstrap_other_components_test.rb
@@ -10,7 +10,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 row">
-        <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
+        <label class="form-label col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
           <input class="form-control-plaintext" id="user_email" name="user[email]" readonly="readonly" type="text" value="steve@example.com"/>
         </div>
@@ -24,7 +24,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 row">
-        <label class="col-form-label col-sm-2 required" for="custom_id">Email</label>
+        <label class="form-label col-form-label col-sm-2 required" for="custom_id">Email</label>
         <div class="col-sm-10">
           <input class="form-control-plaintext" id="custom_id" name="user[email]" readonly="readonly" type="text" value="steve@example.com"/>
         </div>
@@ -38,7 +38,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 row">
-        <label class="col-form-label col-sm-2" for="user_">My Label</label>
+        <label class="form-label col-form-label col-sm-2" for="user_">My Label</label>
         <div class="col-sm-10">
           <input class="form-control-plaintext" id="user_" name="user[]" readonly="readonly" type="text" value="this is a test"/>
         </div>
@@ -52,7 +52,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 row">
-        <label class="col-form-label col-sm-2" for="user_">Custom Label</label>
+        <label class="form-label col-form-label col-sm-2" for="user_">Custom Label</label>
         <div class="col-sm-10">
           <input class="form-control-plaintext" id="user_" name="user[]" readonly="readonly" type="text" value="Custom Control"/>
         </div>
@@ -66,7 +66,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 row">
-        <label class="col-form-label col-sm-2" for="user_">Custom Label</label>
+        <label class="form-label col-form-label col-sm-2" for="user_">Custom Label</label>
         <div class="col-sm-10">
           <input class="form-control-plaintext" id="user_" name="user[]" readonly="readonly" type="text"/>
         </div>
@@ -80,7 +80,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 row">
-        <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
+        <label class="form-label col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
           <input class="test_class form-control-plaintext" id="user_email" name="user[email]" readonly="readonly" type="text" value="steve@example.com"/>
         </div>
@@ -96,7 +96,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 row">
-        <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
+        <label class="form-label col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">this is a test</div>
       </div>
     HTML
@@ -110,7 +110,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 row">
-        <label class="col-form-label col-sm-2" for="user_">My Label</label>
+        <label class="form-label col-form-label col-sm-2" for="user_">My Label</label>
         <div class="col-sm-10">this is a test</div>
       </div>
     HTML
@@ -124,7 +124,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 row">
-        <label class="col-form-label col-sm-2" for="user_">Custom Label</label>
+        <label class="form-label col-form-label col-sm-2" for="user_">Custom Label</label>
         <div class="col-sm-10">Custom Control</div>
       </div>
     HTML

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -9,7 +9,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
         <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-label form-check-label" for="user_misc_1">
+        <label class="form-check-label" for="user_misc_1">
           This is a radio button
         </label>
       </div>
@@ -21,7 +21,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
         <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-label form-check-label" for="user_misc_1">&#8203;</label>
+        <label class="form-check-label" for="user_misc_1">&#8203;</label>
       </div>
     HTML
     # &#8203; is a zero-width space.
@@ -35,7 +35,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       <div class="form-check">
         <input class="form-check-input is-invalid" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-label form-check-label" for="user_misc_1">
+        <label class="form-check-label" for="user_misc_1">
           This is a radio button
         </label>
         <div class="invalid-feedback">error for test</div>
@@ -52,7 +52,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check disabled">
         <input class="form-check-input" disabled="disabled" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-label form-check-label" for="user_misc_1">
+        <label class="form-check-label" for="user_misc_1">
           This is a radio button
         </label>
       </div>
@@ -64,7 +64,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
         <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-label form-check-label btn" for="user_misc_1">
+        <label class="form-check-label btn" for="user_misc_1">
           This is a radio button
         </label>
       </div>
@@ -76,7 +76,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
         <input class="form-check-input" id="custom_id" name="user[misc]" type="radio" value="1" />
-        <label class="form-label form-check-label" for="custom_id">
+        <label class="form-check-label" for="custom_id">
           This is a radio button
         </label>
       </div>
@@ -88,7 +88,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check form-check-inline">
         <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-label form-check-label" for="user_misc_1">
+        <label class="form-check-label" for="user_misc_1">
           This is a radio button
         </label>
       </div>
@@ -102,7 +102,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-check form-check-inline">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-          <label class="form-label form-check-label" for="user_misc_1">
+          <label class="form-check-label" for="user_misc_1">
             This is a radio button
           </label>
         </div>
@@ -118,7 +118,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check form-check-inline disabled">
         <input class="form-check-input" disabled="disabled" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-label form-check-label" for="user_misc_1">
+        <label class="form-check-label" for="user_misc_1">
           This is a radio button
         </label>
       </div>
@@ -130,7 +130,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check form-check-inline">
         <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-label form-check-label btn" for="user_misc_1">
+        <label class="form-check-label btn" for="user_misc_1">
           This is a radio button
         </label>
       </div>
@@ -146,7 +146,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         <label class="form-label" for="user_misc">This is a radio button collection</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-          <label class="form-label form-check-label" for="user_misc_1">
+          <label class="form-check-label" for="user_misc_1">
             Foobar
           </label>
         </div>
@@ -166,11 +166,11 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-          <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
+          <label class="form-check-label" for="user_misc_1"> Foo</label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-          <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
+          <label class="form-check-label" for="user_misc_2"> Bar</label>
         </div>
       </div>
     HTML
@@ -188,11 +188,11 @@ class BootstrapRadioButtonTest < ActionView::TestCase
           <label class="form-label" for="user_misc">Misc</label>
           <div class="form-check">
             <input class="form-check-input is-invalid" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-            <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
+            <label class="form-check-label" for="user_misc_1"> Foo</label>
           </div>
           <div class="form-check">
             <input class="form-check-input is-invalid" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-            <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
+            <label class="form-check-label" for="user_misc_2"> Bar</label>
             <div class="invalid-feedback">error for test</div>
           </div>
         </div>
@@ -212,11 +212,11 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check form-check-inline">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-          <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
+          <label class="form-check-label" for="user_misc_1"> Foo</label>
         </div>
         <div class="form-check form-check-inline">
           <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-          <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
+          <label class="form-check-label" for="user_misc_2"> Bar</label>
         </div>
       </div>
     HTML
@@ -231,11 +231,11 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" checked="checked" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-          <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
+          <label class="form-check-label" for="user_misc_1"> Foo</label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-          <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
+          <label class="form-check-label" for="user_misc_2"> Bar</label>
         </div>
       </div>
     HTML
@@ -250,7 +250,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         <label class="form-label" for="user_misc">This is a radio button collection</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-          <label class="form-label form-check-label" for="user_misc_1"> rabooF</label>
+          <label class="form-check-label" for="user_misc_1"> rabooF</label>
         </div>
         <small class="form-text text-muted">With a help!</small>
       </div>
@@ -268,7 +268,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         <label class="form-label" for="user_misc">This is a radio button collection</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
-          <label class="form-label form-check-label" for="user_misc_address_1"> Foobar</label>
+          <label class="form-check-label" for="user_misc_address_1"> Foobar</label>
         </div>
         <small class="form-text text-muted">With a help!</small>
       </div>
@@ -287,11 +287,11 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-          <label class="form-label form-check-label" for="user_misc_1"> ooF</label>
+          <label class="form-check-label" for="user_misc_1"> ooF</label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-          <label class="form-label form-check-label" for="user_misc_2"> raB</label>
+          <label class="form-check-label" for="user_misc_2"> raB</label>
         </div>
       </div>
     HTML
@@ -306,11 +306,11 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
-          <label class="form-label form-check-label" for="user_misc_address_1"> Foo</label>
+          <label class="form-check-label" for="user_misc_address_1"> Foo</label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_2" name="user[misc]" type="radio" value="address_2" />
-          <label class="form-label form-check-label" for="user_misc_address_2"> Bar</label>
+          <label class="form-check-label" for="user_misc_address_2"> Bar</label>
         </div>
       </div>
     HTML
@@ -325,7 +325,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         <label class="form-label" for="user_misc">This is a radio button collection</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-          <label class="form-label form-check-label" for="user_misc_1"> rabooF</label>
+          <label class="form-check-label" for="user_misc_1"> rabooF</label>
         </div>
         <small class="form-text text-muted">With a help!</small>
       </div>
@@ -343,7 +343,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         <label class="form-label" for="user_misc">This is a radio button collection</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
-          <label class="form-label form-check-label" for="user_misc_address_1"> Foobar</label>
+          <label class="form-check-label" for="user_misc_address_1"> Foobar</label>
         </div>
         <small class="form-text text-muted">With a help!</small>
       </div>
@@ -362,11 +362,11 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-          <label class="form-label form-check-label" for="user_misc_1"> ooF</label>
+          <label class="form-check-label" for="user_misc_1"> ooF</label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-          <label class="form-label form-check-label" for="user_misc_2"> raB</label>
+          <label class="form-check-label" for="user_misc_2"> raB</label>
         </div>
       </div>
     HTML
@@ -381,11 +381,11 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
-          <label class="form-label form-check-label" for="user_misc_address_1"> Foo</label>
+          <label class="form-check-label" for="user_misc_address_1"> Foo</label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_2" name="user[misc]" type="radio" value="address_2" />
-          <label class="form-label form-check-label" for="user_misc_address_2"> Bar</label>
+          <label class="form-check-label" for="user_misc_address_2"> Bar</label>
         </div>
       </div>
     HTML
@@ -406,7 +406,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
         <input class="form-check-input position-static" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-label form-check-label sr-only" for="user_misc_1">This is a radio button</label>
+        <label class="form-check-label sr-only" for="user_misc_1">This is a radio button</label>
       </div>
     HTML
     assert_equivalent_xml expected, @builder.radio_button(:misc, "1", label: "This is a radio button", hide_label: true)
@@ -416,7 +416,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check custom-class">
         <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-label form-check-label" for="user_misc_1">
+        <label class="form-check-label" for="user_misc_1">
           This is a radio button
         </label>
       </div>
@@ -429,7 +429,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check form-check-inline custom-class">
         <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-label form-check-label" for="user_misc_1">
+        <label class="form-check-label" for="user_misc_1">
           This is a radio button
         </label>
       </div>

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -9,7 +9,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
         <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-check-label" for="user_misc_1">
+        <label class="form-label form-check-label" for="user_misc_1">
           This is a radio button
         </label>
       </div>
@@ -21,7 +21,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
         <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-check-label" for="user_misc_1">&#8203;</label>
+        <label class="form-label form-check-label" for="user_misc_1">&#8203;</label>
       </div>
     HTML
     # &#8203; is a zero-width space.
@@ -35,7 +35,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       <div class="form-check">
         <input class="form-check-input is-invalid" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-check-label" for="user_misc_1">
+        <label class="form-label form-check-label" for="user_misc_1">
           This is a radio button
         </label>
         <div class="invalid-feedback">error for test</div>
@@ -52,7 +52,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check disabled">
         <input class="form-check-input" disabled="disabled" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-check-label" for="user_misc_1">
+        <label class="form-label form-check-label" for="user_misc_1">
           This is a radio button
         </label>
       </div>
@@ -64,7 +64,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
         <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-check-label btn" for="user_misc_1">
+        <label class="form-label form-check-label btn" for="user_misc_1">
           This is a radio button
         </label>
       </div>
@@ -76,7 +76,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
         <input class="form-check-input" id="custom_id" name="user[misc]" type="radio" value="1" />
-        <label class="form-check-label" for="custom_id">
+        <label class="form-label form-check-label" for="custom_id">
           This is a radio button
         </label>
       </div>
@@ -88,7 +88,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check form-check-inline">
         <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-check-label" for="user_misc_1">
+        <label class="form-label form-check-label" for="user_misc_1">
           This is a radio button
         </label>
       </div>
@@ -102,7 +102,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-check form-check-inline">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-          <label class="form-check-label" for="user_misc_1">
+          <label class="form-label form-check-label" for="user_misc_1">
             This is a radio button
           </label>
         </div>
@@ -118,7 +118,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check form-check-inline disabled">
         <input class="form-check-input" disabled="disabled" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-check-label" for="user_misc_1">
+        <label class="form-label form-check-label" for="user_misc_1">
           This is a radio button
         </label>
       </div>
@@ -130,7 +130,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check form-check-inline">
         <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-check-label btn" for="user_misc_1">
+        <label class="form-label form-check-label btn" for="user_misc_1">
           This is a radio button
         </label>
       </div>
@@ -143,10 +143,10 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foobar")]
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">This is a radio button collection</label>
+        <label class="form-label" for="user_misc">This is a radio button collection</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-          <label class="form-check-label" for="user_misc_1">
+          <label class="form-label form-check-label" for="user_misc_1">
             Foobar
           </label>
         </div>
@@ -163,14 +163,14 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-          <label class="form-check-label" for="user_misc_1"> Foo</label>
+          <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-          <label class="form-check-label" for="user_misc_2"> Bar</label>
+          <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
         </div>
       </div>
     HTML
@@ -185,14 +185,14 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label for="user_misc">Misc</label>
+          <label class="form-label" for="user_misc">Misc</label>
           <div class="form-check">
             <input class="form-check-input is-invalid" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-            <label class="form-check-label" for="user_misc_1"> Foo</label>
+            <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
           </div>
           <div class="form-check">
             <input class="form-check-input is-invalid" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-            <label class="form-check-label" for="user_misc_2"> Bar</label>
+            <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
             <div class="invalid-feedback">error for test</div>
           </div>
         </div>
@@ -209,14 +209,14 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check form-check-inline">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-          <label class="form-check-label" for="user_misc_1"> Foo</label>
+          <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
         </div>
         <div class="form-check form-check-inline">
           <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-          <label class="form-check-label" for="user_misc_2"> Bar</label>
+          <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
         </div>
       </div>
     HTML
@@ -228,14 +228,14 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" checked="checked" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-          <label class="form-check-label" for="user_misc_1"> Foo</label>
+          <label class="form-label form-check-label" for="user_misc_1"> Foo</label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-          <label class="form-check-label" for="user_misc_2"> Bar</label>
+          <label class="form-label form-check-label" for="user_misc_2"> Bar</label>
         </div>
       </div>
     HTML
@@ -247,10 +247,10 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foobar")]
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">This is a radio button collection</label>
+        <label class="form-label" for="user_misc">This is a radio button collection</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-          <label class="form-check-label" for="user_misc_1"> rabooF</label>
+          <label class="form-label form-check-label" for="user_misc_1"> rabooF</label>
         </div>
         <small class="form-text text-muted">With a help!</small>
       </div>
@@ -265,10 +265,10 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foobar")]
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">This is a radio button collection</label>
+        <label class="form-label" for="user_misc">This is a radio button collection</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
-          <label class="form-check-label" for="user_misc_address_1"> Foobar</label>
+          <label class="form-label form-check-label" for="user_misc_address_1"> Foobar</label>
         </div>
         <small class="form-text text-muted">With a help!</small>
       </div>
@@ -284,14 +284,14 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-          <label class="form-check-label" for="user_misc_1"> ooF</label>
+          <label class="form-label form-check-label" for="user_misc_1"> ooF</label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-          <label class="form-check-label" for="user_misc_2"> raB</label>
+          <label class="form-label form-check-label" for="user_misc_2"> raB</label>
         </div>
       </div>
     HTML
@@ -303,14 +303,14 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
-          <label class="form-check-label" for="user_misc_address_1"> Foo</label>
+          <label class="form-label form-check-label" for="user_misc_address_1"> Foo</label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_2" name="user[misc]" type="radio" value="address_2" />
-          <label class="form-check-label" for="user_misc_address_2"> Bar</label>
+          <label class="form-label form-check-label" for="user_misc_address_2"> Bar</label>
         </div>
       </div>
     HTML
@@ -322,10 +322,10 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foobar")]
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">This is a radio button collection</label>
+        <label class="form-label" for="user_misc">This is a radio button collection</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-          <label class="form-check-label" for="user_misc_1"> rabooF</label>
+          <label class="form-label form-check-label" for="user_misc_1"> rabooF</label>
         </div>
         <small class="form-text text-muted">With a help!</small>
       </div>
@@ -340,10 +340,10 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foobar")]
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">This is a radio button collection</label>
+        <label class="form-label" for="user_misc">This is a radio button collection</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
-          <label class="form-check-label" for="user_misc_address_1"> Foobar</label>
+          <label class="form-label form-check-label" for="user_misc_address_1"> Foobar</label>
         </div>
         <small class="form-text text-muted">With a help!</small>
       </div>
@@ -359,14 +359,14 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-          <label class="form-check-label" for="user_misc_1"> ooF</label>
+          <label class="form-label form-check-label" for="user_misc_1"> ooF</label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_2" name="user[misc]" type="radio" value="2" />
-          <label class="form-check-label" for="user_misc_2"> raB</label>
+          <label class="form-label form-check-label" for="user_misc_2"> raB</label>
         </div>
       </div>
     HTML
@@ -378,14 +378,14 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
-          <label class="form-check-label" for="user_misc_address_1"> Foo</label>
+          <label class="form-label form-check-label" for="user_misc_address_1"> Foo</label>
         </div>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_2" name="user[misc]" type="radio" value="address_2" />
-          <label class="form-check-label" for="user_misc_address_2"> Bar</label>
+          <label class="form-label form-check-label" for="user_misc_address_2"> Bar</label>
         </div>
       </div>
     HTML
@@ -406,7 +406,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
         <input class="form-check-input position-static" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-check-label sr-only" for="user_misc_1">This is a radio button</label>
+        <label class="form-label form-check-label sr-only" for="user_misc_1">This is a radio button</label>
       </div>
     HTML
     assert_equivalent_xml expected, @builder.radio_button(:misc, "1", label: "This is a radio button", hide_label: true)
@@ -416,7 +416,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check custom-class">
         <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-check-label" for="user_misc_1">
+        <label class="form-label form-check-label" for="user_misc_1">
           This is a radio button
         </label>
       </div>
@@ -429,7 +429,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-check form-check-inline custom-class">
         <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-check-label" for="user_misc_1">
+        <label class="form-label form-check-label" for="user_misc_1">
           This is a radio button
         </label>
       </div>

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -393,76 +393,6 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.collection_radio_buttons(:misc, collection, ->(a) { "address_#{a.id}" }, :street)
   end
 
-  test "radio_button is wrapped correctly with custom option set" do
-    expected = <<-HTML.strip_heredoc
-      <div class="custom-control custom-radio">
-        <input class="custom-control-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="custom-control-label" for="user_misc_1">This is a radio button</label>
-      </div>
-    HTML
-    assert_equivalent_xml expected, @builder.radio_button(:misc, "1", label: "This is a radio button", custom: true)
-  end
-
-  test "radio_button is wrapped correctly with id option and custom option set" do
-    expected = <<-HTML.strip_heredoc
-      <div class="custom-control custom-radio">
-        <input class="custom-control-input" id="custom_id" name="user[misc]" type="radio" value="1" />
-        <label class="custom-control-label" for="custom_id">This is a radio button</label>
-      </div>
-    HTML
-    assert_equivalent_xml expected,
-                          @builder.radio_button(:misc, "1", label: "This is a radio button", id: "custom_id", custom: true)
-  end
-
-  test "radio_button with error is wrapped correctly with custom option set" do
-    @user.errors.add(:misc, "error for test")
-    expected = <<-HTML.strip_heredoc
-    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
-      #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-      <div class="custom-control custom-radio">
-        <input class="custom-control-input is-invalid" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="custom-control-label" for="user_misc_1">This is a radio button</label>
-        <div class="invalid-feedback">error for test</div>
-      </div>
-    </form>
-    HTML
-    actual = bootstrap_form_for(@user) do |f|
-      f.radio_button(:misc, "1", label: "This is a radio button", custom: true, error_message: true)
-    end
-    assert_equivalent_xml expected, actual
-  end
-
-  test "radio_button is wrapped correctly with custom and inline options set" do
-    expected = <<-HTML.strip_heredoc
-      <div class="custom-control custom-radio custom-control-inline">
-        <input class="custom-control-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="custom-control-label" for="user_misc_1">This is a radio button</label>
-      </div>
-    HTML
-    assert_equivalent_xml expected, @builder.radio_button(:misc, "1", label: "This is a radio button", inline: true, custom: true)
-  end
-
-  test "radio_button is wrapped correctly with custom and disabled options set" do
-    expected = <<-HTML.strip_heredoc
-      <div class="custom-control custom-radio">
-        <input class="custom-control-input" id="user_misc_1" name="user[misc]" type="radio" value="1" disabled="disabled"/>
-        <label class="custom-control-label" for="user_misc_1">This is a radio button</label>
-      </div>
-    HTML
-    assert_equivalent_xml expected, @builder.radio_button(:misc, "1", label: "This is a radio button", disabled: true, custom: true)
-  end
-  test "radio_button is wrapped correctly with custom, inline and disabled options set" do
-    expected = <<-HTML.strip_heredoc
-      <div class="custom-control custom-radio custom-control-inline">
-        <input class="custom-control-input" id="user_misc_1" name="user[misc]" type="radio" value="1" disabled="disabled"/>
-        <label class="custom-control-label" for="user_misc_1">This is a radio button</label>
-      </div>
-    HTML
-    assert_equivalent_xml expected,
-                          @builder.radio_button(:misc, "1", label: "This is a radio button", inline: true,
-                                                            disabled: true, custom: true)
-  end
-
   test "radio button skip label" do
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
@@ -471,6 +401,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     HTML
     assert_equivalent_xml expected, @builder.radio_button(:misc, "1", label: "This is a radio button", skip_label: true)
   end
+
   test "radio button hide label" do
     expected = <<-HTML.strip_heredoc
       <div class="form-check">
@@ -479,27 +410,6 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       </div>
     HTML
     assert_equivalent_xml expected, @builder.radio_button(:misc, "1", label: "This is a radio button", hide_label: true)
-  end
-
-  test "radio button skip label with custom option set" do
-    expected = <<-HTML.strip_heredoc
-    <div class="custom-control custom-radio">
-      <input class="custom-control-input position-static" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-    </div>
-    HTML
-    assert_equivalent_xml expected,
-                          @builder.radio_button(:misc, "1", label: "This is a radio button", custom: true, skip_label: true)
-  end
-
-  test "radio button hide label with custom option set" do
-    expected = <<-HTML.strip_heredoc
-      <div class="custom-control custom-radio">
-        <input class="custom-control-input position-static" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="custom-control-label sr-only" for="user_misc_1">This is a radio button</label>
-      </div>
-    HTML
-    assert_equivalent_xml expected,
-                          @builder.radio_button(:misc, "1", label: "This is a radio button", custom: true, hide_label: true)
   end
 
   test "radio button with custom wrapper class" do
@@ -527,29 +437,5 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     assert_equivalent_xml expected,
                           @builder.radio_button(:misc, "1", label: "This is a radio button", inline: true,
                                                             wrapper_class: "custom-class")
-  end
-
-  test "custom radio button with custom wrapper class" do
-    expected = <<-HTML.strip_heredoc
-      <div class="custom-control custom-radio custom-class">
-        <input class="custom-control-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="custom-control-label" for="user_misc_1">This is a radio button</label>
-      </div>
-    HTML
-    assert_equivalent_xml expected,
-                          @builder.radio_button(:misc, "1", label: "This is a radio button", custom: true,
-                                                            wrapper_class: "custom-class")
-  end
-
-  test "custom inline radio button with custom wrapper class" do
-    expected = <<-HTML.strip_heredoc
-      <div class="custom-control custom-radio custom-control-inline custom-class">
-        <input class="custom-control-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="custom-control-label" for="user_misc_1">This is a radio button</label>
-      </div>
-    HTML
-    assert_equivalent_xml expected,
-                          @builder.radio_button(:misc, "1", label: "This is a radio button", inline: true,
-                                                            custom: true, wrapper_class: "custom-class")
   end
 end

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -98,7 +98,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "radio_button inline label is set correctly from form level" do
     expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user form-inline" id="new_user" method="post" role="form">
+      <form accept-charset="UTF-8" action="/users" class="new_user col-auto g-3" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-check form-check-inline">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -142,7 +142,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "collection_radio_buttons renders the form_group correctly" do
     collection = [Address.new(id: 1, street: "Foobar")]
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">This is a radio button collection</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
@@ -162,7 +162,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "collection_radio_buttons renders multiple radios correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
@@ -184,7 +184,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group">
+        <div class="mb-3">
           <label for="user_misc">Misc</label>
           <div class="form-check">
             <input class="form-check-input is-invalid" id="user_misc_1" name="user[misc]" type="radio" value="1" />
@@ -208,7 +208,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "collection_radio_buttons renders inline radios correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-check form-check-inline">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
@@ -227,7 +227,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "collection_radio_buttons renders with checked option correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" checked="checked" id="user_misc_1" name="user[misc]" type="radio" value="1" />
@@ -246,7 +246,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "collection_radio_buttons renders label defined by Proc correctly" do
     collection = [Address.new(id: 1, street: "Foobar")]
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">This is a radio button collection</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
@@ -264,7 +264,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "collection_radio_buttons renders value defined by Proc correctly" do
     collection = [Address.new(id: 1, street: "Foobar")]
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">This is a radio button collection</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
@@ -283,7 +283,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "collection_radio_buttons renders multiple radios with label defined by Proc correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
@@ -302,7 +302,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "collection_radio_buttons renders multiple radios with value defined by Proc correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
@@ -321,7 +321,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "collection_radio_buttons renders label defined by lambda correctly" do
     collection = [Address.new(id: 1, street: "Foobar")]
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">This is a radio button collection</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
@@ -339,7 +339,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "collection_radio_buttons renders value defined by lambda correctly" do
     collection = [Address.new(id: 1, street: "Foobar")]
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">This is a radio button collection</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
@@ -358,7 +358,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "collection_radio_buttons renders multiple radios with label defined by lambda correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
@@ -377,7 +377,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "collection_radio_buttons renders multiple radios with value defined by lambda correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <div class="form-check">
           <input class="form-check-input" id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />

--- a/test/bootstrap_rich_text_area_test.rb
+++ b/test/bootstrap_rich_text_area_test.rb
@@ -10,7 +10,7 @@ if ::Rails::VERSION::STRING > "6"
     test "rich text areas are wrapped correctly" do
       expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_life_story">Life story</label>
+        <label class="form-label" for="user_life_story">Life story</label>
         <input type="hidden" name="user[life_story]" id="user_life_story_trix_input_user"/>
         <trix-editor id="user_life_story" data-blob-url-template="http://test.host/rails/active_storage/blobs/:signed_id/:filename" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" input="user_life_story_trix_input_user" class="trix-content form-control"/>
         </trix-editor>

--- a/test/bootstrap_rich_text_area_test.rb
+++ b/test/bootstrap_rich_text_area_test.rb
@@ -9,7 +9,7 @@ if ::Rails::VERSION::STRING > "6"
 
     test "rich text areas are wrapped correctly" do
       expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_life_story">Life story</label>
         <input type="hidden" name="user[life_story]" id="user_life_story_trix_input_user"/>
         <trix-editor id="user_life_story" data-blob-url-template="http://test.host/rails/active_storage/blobs/:signed_id/:filename" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" input="user_life_story_trix_input_user" class="trix-content form-control"/>

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -127,12 +127,12 @@ class BootstrapSelectsTest < ActionView::TestCase
       <div class="mb-3">
         <label for="user_status">Status</label>
         <div class="input-group">
-          <div class="input-group-prepend"><span class="input-group-text">Before</span></div>
+          <span class="input-group-text">Before</span>
           <select class="form-control" id="user_status" name="user[status]">
             <option value="1">activated</option>
             <option value="2">blocked</option>
           </select>
-          <div class="input-group-append"><span class="input-group-text">After</span></div>
+          <span class="input-group-text">After</span>
         </div>
       </div>
     HTML

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -17,7 +17,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "time zone selects are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <select class="form-control" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
       </div>
     HTML
@@ -27,7 +27,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "time zone selects are wrapped correctly with wrapper" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 none-margin">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <select class="form-control" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
       </div>
     HTML
@@ -40,7 +40,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <select class="form-control is-invalid" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
         <div class="invalid-feedback">error for test</div>
       </div>
@@ -52,7 +52,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "selects are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_status">Status</label>
+        <label class="form-label" for="user_status">Status</label>
         <select class="form-control" id="user_status" name="user[status]">
           <option value="1">activated</option>
           <option value="2">blocked</option>
@@ -65,7 +65,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "bootstrap_specific options are handled correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_status">My Status Label</label>
+        <label class="form-label" for="user_status">My Status Label</label>
         <select class="form-control" id="user_status" name="user[status]">
           <option value="1">activated</option>
           <option value="2">blocked</option>
@@ -80,7 +80,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "selects with options are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_status">Status</label>
+        <label class="form-label" for="user_status">Status</label>
         <select class="form-control" id="user_status" name="user[status]">
           <option value="">Please Select</option>
           <option value="1">activated</option>
@@ -94,7 +94,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "selects with both options and html_options are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_status">Status</label>
+        <label class="form-label" for="user_status">Status</label>
         <select class="form-control my-select" id="user_status" name="user[status]">
           <option value="">Please Select</option>
           <option value="1">activated</option>
@@ -110,7 +110,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "select 'id' attribute is used to specify label 'for' attribute" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="custom_id">Status</label>
+        <label class="form-label" for="custom_id">Status</label>
         <select class="form-control" id="custom_id" name="user[status]">
           <option value="">Please Select</option>
           <option value="1">activated</option>
@@ -125,7 +125,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "selects with addons are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_status">Status</label>
+        <label class="form-label" for="user_status">Status</label>
         <div class="input-group">
           <span class="input-group-text">Before</span>
           <select class="form-control" id="user_status" name="user[status]">
@@ -142,7 +142,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "selects with block use block as content" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_status">Status</label>
+        <label class="form-label" for="user_status">Status</label>
         <select class="form-control" name="user[status]" id="user_status">
           <option>Option 1</option>
           <option>Option 2</option>
@@ -159,7 +159,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "selects render labels properly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_status">User Status</label>
+        <label class="form-label" for="user_status">User Status</label>
         <select class="form-control" id="user_status" name="user[status]">
           <option value="1">activated</option>
           <option value="2">blocked</option>
@@ -172,7 +172,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "collection_selects are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_status">Status</label>
+        <label class="form-label" for="user_status">Status</label>
         <select class="form-control" id="user_status" name="user[status]"></select>
       </div>
     HTML
@@ -182,7 +182,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "collection_selects are wrapped correctly with wrapper" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 none-margin">
-        <label for="user_status">Status</label>
+        <label class="form-label" for="user_status">Status</label>
         <select class="form-control" id="user_status" name="user[status]"></select>
       </div>
     HTML
@@ -195,7 +195,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       <div class="mb-3">
-        <label for="user_status">Status</label>
+        <label class="form-label" for="user_status">Status</label>
         <select class="form-control is-invalid" id="user_status" name="user[status]"></select>
         <div class="invalid-feedback">error for test</div>
       </div>
@@ -207,7 +207,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "collection_selects with options are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_status">Status</label>
+        <label class="form-label" for="user_status">Status</label>
         <select class="form-control" id="user_status" name="user[status]">
           <option value="">Please Select</option>
         </select>
@@ -219,7 +219,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "collection_selects with options and html_options are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_status">Status</label>
+        <label class="form-label" for="user_status">Status</label>
         <select class="form-control my-select" id="user_status" name="user[status]">
           <option value="">Please Select</option>
         </select>
@@ -232,7 +232,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "grouped_collection_selects are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_status">Status</label>
+        <label class="form-label" for="user_status">Status</label>
         <select class="form-control" id="user_status" name="user[status]"></select>
       </div>
     HTML
@@ -242,7 +242,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "grouped_collection_selects are wrapped correctly with wrapper" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 none-margin">
-        <label for="user_status">Status</label>
+        <label class="form-label" for="user_status">Status</label>
         <select class="form-control" id="user_status" name="user[status]"></select>
       </div>
     HTML
@@ -256,7 +256,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       <div class="mb-3">
-        <label for="user_status">Status</label>
+        <label class="form-label" for="user_status">Status</label>
         <select class="form-control is-invalid" id="user_status" name="user[status]"></select>
         <div class="invalid-feedback">error for test</div>
       </div>
@@ -269,7 +269,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "grouped_collection_selects with options are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_status">Status</label>
+        <label class="form-label" for="user_status">Status</label>
         <select class="form-control" id="user_status" name="user[status]">
           <option value="">Please Select</option>
         </select>
@@ -282,7 +282,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "grouped_collection_selects with options and html_options are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_status">Status</label>
+        <label class="form-label" for="user_status">Status</label>
         <select class="form-control my-select" id="user_status" name="user[status]">
           <option value="">Please Select</option>
         </select>
@@ -297,7 +297,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     travel_to(Time.utc(2012, 2, 3)) do
       expected = <<-HTML.strip_heredoc
         <div class="mb-3">
-          <label for="user_misc">Misc</label>
+          <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
             <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
               #{options_range(start: 2007, stop: 2017, selected: 2012)}
@@ -319,7 +319,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     travel_to(Time.utc(2012, 2, 3)) do
       expected = <<-HTML.strip_heredoc
         <div class="mb-3 none-margin">
-          <label for="user_misc">Misc</label>
+          <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
             <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
               #{options_range(start: 2007, stop: 2017, selected: 2012)}
@@ -343,7 +343,7 @@ class BootstrapSelectsTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 row">
-          <label class="col-form-label col-sm-2" for="user_misc">Misc</label>
+          <label class="form-label col-form-label col-sm-2" for="user_misc">Misc</label>
           <div class="col-sm-10">
             <div class="rails-bootstrap-forms-date-select col-auto g-3">
               <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
@@ -371,7 +371,7 @@ class BootstrapSelectsTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label for="user_misc">Misc</label>
+          <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
             <select class="form-control is-invalid" id="user_misc_1i" name="user[misc(1i)]">
               #{options_range(start: 2007, stop: 2017, selected: 2012)}
@@ -395,7 +395,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     travel_to(Time.utc(2012, 2, 3)) do
       expected = <<-HTML.strip_heredoc
         <div class="mb-3">
-          <label for="user_misc">Misc</label>
+          <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
             <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
               <option value=""></option>
@@ -421,7 +421,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     travel_to(Time.utc(2012, 2, 3)) do
       expected = <<-HTML.strip_heredoc
         <div class="mb-3">
-          <label for="user_misc">Misc</label>
+          <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
             <select class="form-control my-date-select" id="user_misc_1i" name="user[misc(1i)]">
               <option value=""></option>
@@ -446,7 +446,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     travel_to(Time.utc(2012, 2, 3, 12, 0, 0)) do
       expected = <<-HTML.strip_heredoc
         <div class="mb-3">
-          <label for="user_misc">Misc</label>
+          <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-time-select">
             <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="2012" />
             <input id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="2" />
@@ -472,7 +472,7 @@ class BootstrapSelectsTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label for="user_misc">Misc</label>
+          <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-time-select">
             <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="2012" />
             <input id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="2" />
@@ -497,7 +497,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     travel_to(Time.utc(2012, 2, 3, 12, 0, 0)) do
       expected = <<-HTML.strip_heredoc
         <div class="mb-3">
-          <label for="user_misc">Misc</label>
+          <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-time-select">
             <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="1" />
             <input id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="1" />
@@ -522,7 +522,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     travel_to(Time.utc(2012, 2, 3, 12, 0, 0)) do
       expected = <<-HTML.strip_heredoc
         <div class="mb-3">
-          <label for="user_misc">Misc</label>
+          <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-time-select">
             <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="1" />
             <input id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="1" />
@@ -547,7 +547,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     travel_to(Time.utc(2012, 2, 3, 12, 0, 0)) do
       expected = <<-HTML.strip_heredoc
         <div class="mb-3">
-          <label for="user_misc">Misc</label>
+          <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-datetime-select">
             <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
               #{options_range(start: 2007, stop: 2017, selected: 2012)}
@@ -580,7 +580,7 @@ class BootstrapSelectsTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label for="user_misc">Misc</label>
+          <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-datetime-select">
             <select class="form-control is-invalid" id="user_misc_1i" name="user[misc(1i)]">
               #{options_range(start: 2007, stop: 2017, selected: 2012)}
@@ -612,7 +612,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     travel_to(Time.utc(2012, 2, 3, 12, 0, 0)) do
       expected = <<-HTML.strip_heredoc
         <div class="mb-3">
-          <label for="user_misc">Misc</label>
+          <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-datetime-select">
             <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
               <option value=""></option>
@@ -647,7 +647,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     travel_to(Time.utc(2012, 2, 3, 12, 0, 0)) do
       expected = <<-HTML.strip_heredoc
         <div class="mb-3">
-          <label for="user_misc">Misc</label>
+          <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-datetime-select">
             <select class="form-control my-datetime-select" id="user_misc_1i" name="user[misc(1i)]">
               <option value=""></option>
@@ -681,7 +681,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "confirm documentation example for HTML options" do
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 has-warning" data-foo="bar">
-        <label for="user_misc">Choose your favorite fruit:</label>
+        <label class="form-label" for="user_misc">Choose your favorite fruit:</label>
         <select class="form-control selectpicker" id="user_misc" name="user[misc]">
           <option value="1">Apple</option>
           <option value="2">Grape</option>

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -345,7 +345,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         <div class="mb-3 row">
           <label class="col-form-label col-sm-2" for="user_misc">Misc</label>
           <div class="col-sm-10">
-            <div class="rails-bootstrap-forms-date-select form-inline">
+            <div class="rails-bootstrap-forms-date-select col-auto g-3">
               <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
                 #{options_range(start: 2007, stop: 2017, selected: 2012)}
               </select>

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -16,7 +16,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "time zone selects are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <select class="form-control" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
       </div>
@@ -26,7 +26,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "time zone selects are wrapped correctly with wrapper" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group none-margin">
+      <div class="mb-3 none-margin">
         <label for="user_misc">Misc</label>
         <select class="form-control" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
       </div>
@@ -39,7 +39,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
     <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <select class="form-control is-invalid" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
         <div class="invalid-feedback">error for test</div>
@@ -51,7 +51,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "selects are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_status">Status</label>
         <select class="form-control" id="user_status" name="user[status]">
           <option value="1">activated</option>
@@ -64,7 +64,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "bootstrap_specific options are handled correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_status">My Status Label</label>
         <select class="form-control" id="user_status" name="user[status]">
           <option value="1">activated</option>
@@ -79,7 +79,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "selects with options are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_status">Status</label>
         <select class="form-control" id="user_status" name="user[status]">
           <option value="">Please Select</option>
@@ -93,7 +93,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "selects with both options and html_options are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_status">Status</label>
         <select class="form-control my-select" id="user_status" name="user[status]">
           <option value="">Please Select</option>
@@ -109,7 +109,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "select 'id' attribute is used to specify label 'for' attribute" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="custom_id">Status</label>
         <select class="form-control" id="custom_id" name="user[status]">
           <option value="">Please Select</option>
@@ -124,7 +124,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "selects with addons are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_status">Status</label>
         <div class="input-group">
           <div class="input-group-prepend"><span class="input-group-text">Before</span></div>
@@ -141,7 +141,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "selects with block use block as content" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_status">Status</label>
         <select class="form-control" name="user[status]" id="user_status">
           <option>Option 1</option>
@@ -158,7 +158,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "selects render labels properly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_status">User Status</label>
         <select class="form-control" id="user_status" name="user[status]">
           <option value="1">activated</option>
@@ -171,7 +171,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "collection_selects are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_status">Status</label>
         <select class="form-control" id="user_status" name="user[status]"></select>
       </div>
@@ -181,7 +181,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "collection_selects are wrapped correctly with wrapper" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group none-margin">
+      <div class="mb-3 none-margin">
         <label for="user_status">Status</label>
         <select class="form-control" id="user_status" name="user[status]"></select>
       </div>
@@ -194,7 +194,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
     <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_status">Status</label>
         <select class="form-control is-invalid" id="user_status" name="user[status]"></select>
         <div class="invalid-feedback">error for test</div>
@@ -206,7 +206,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "collection_selects with options are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_status">Status</label>
         <select class="form-control" id="user_status" name="user[status]">
           <option value="">Please Select</option>
@@ -218,7 +218,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "collection_selects with options and html_options are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_status">Status</label>
         <select class="form-control my-select" id="user_status" name="user[status]">
           <option value="">Please Select</option>
@@ -231,7 +231,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "grouped_collection_selects are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_status">Status</label>
         <select class="form-control" id="user_status" name="user[status]"></select>
       </div>
@@ -241,7 +241,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "grouped_collection_selects are wrapped correctly with wrapper" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group none-margin">
+      <div class="mb-3 none-margin">
         <label for="user_status">Status</label>
         <select class="form-control" id="user_status" name="user[status]"></select>
       </div>
@@ -255,7 +255,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
     <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_status">Status</label>
         <select class="form-control is-invalid" id="user_status" name="user[status]"></select>
         <div class="invalid-feedback">error for test</div>
@@ -268,7 +268,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "grouped_collection_selects with options are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_status">Status</label>
         <select class="form-control" id="user_status" name="user[status]">
           <option value="">Please Select</option>
@@ -281,7 +281,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "grouped_collection_selects with options and html_options are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_status">Status</label>
         <select class="form-control my-select" id="user_status" name="user[status]">
           <option value="">Please Select</option>
@@ -296,7 +296,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "date selects are wrapped correctly" do
     travel_to(Time.utc(2012, 2, 3)) do
       expected = <<-HTML.strip_heredoc
-        <div class="form-group">
+        <div class="mb-3">
           <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
             <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
@@ -318,7 +318,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "date selects are wrapped correctly with wrapper class" do
     travel_to(Time.utc(2012, 2, 3)) do
       expected = <<-HTML.strip_heredoc
-        <div class="form-group none-margin">
+        <div class="mb-3 none-margin">
           <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
             <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
@@ -342,7 +342,7 @@ class BootstrapSelectsTest < ActionView::TestCase
       expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group row">
+        <div class="mb-3 row">
           <label class="col-form-label col-sm-2" for="user_misc">Misc</label>
           <div class="col-sm-10">
             <div class="rails-bootstrap-forms-date-select form-inline">
@@ -370,7 +370,7 @@ class BootstrapSelectsTest < ActionView::TestCase
       expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group">
+        <div class="mb-3">
           <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
             <select class="form-control is-invalid" id="user_misc_1i" name="user[misc(1i)]">
@@ -394,7 +394,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "date selects with options are wrapped correctly" do
     travel_to(Time.utc(2012, 2, 3)) do
       expected = <<-HTML.strip_heredoc
-        <div class="form-group">
+        <div class="mb-3">
           <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
             <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
@@ -420,7 +420,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "date selects with options and html_options are wrapped correctly" do
     travel_to(Time.utc(2012, 2, 3)) do
       expected = <<-HTML.strip_heredoc
-        <div class="form-group">
+        <div class="mb-3">
           <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
             <select class="form-control my-date-select" id="user_misc_1i" name="user[misc(1i)]">
@@ -445,7 +445,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "time selects are wrapped correctly" do
     travel_to(Time.utc(2012, 2, 3, 12, 0, 0)) do
       expected = <<-HTML.strip_heredoc
-        <div class="form-group">
+        <div class="mb-3">
           <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-time-select">
             <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="2012" />
@@ -471,7 +471,7 @@ class BootstrapSelectsTest < ActionView::TestCase
       expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group">
+        <div class="mb-3">
           <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-time-select">
             <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="2012" />
@@ -496,7 +496,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "time selects with options are wrapped correctly" do
     travel_to(Time.utc(2012, 2, 3, 12, 0, 0)) do
       expected = <<-HTML.strip_heredoc
-        <div class="form-group">
+        <div class="mb-3">
           <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-time-select">
             <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="1" />
@@ -521,7 +521,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "time selects with options and html_options are wrapped correctly" do
     travel_to(Time.utc(2012, 2, 3, 12, 0, 0)) do
       expected = <<-HTML.strip_heredoc
-        <div class="form-group">
+        <div class="mb-3">
           <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-time-select">
             <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="1" />
@@ -546,7 +546,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "datetime selects are wrapped correctly" do
     travel_to(Time.utc(2012, 2, 3, 12, 0, 0)) do
       expected = <<-HTML.strip_heredoc
-        <div class="form-group">
+        <div class="mb-3">
           <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-datetime-select">
             <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
@@ -579,7 +579,7 @@ class BootstrapSelectsTest < ActionView::TestCase
       expected = <<-HTML.strip_heredoc
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="form-group">
+        <div class="mb-3">
           <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-datetime-select">
             <select class="form-control is-invalid" id="user_misc_1i" name="user[misc(1i)]">
@@ -611,7 +611,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "datetime selects with options are wrapped correctly" do
     travel_to(Time.utc(2012, 2, 3, 12, 0, 0)) do
       expected = <<-HTML.strip_heredoc
-        <div class="form-group">
+        <div class="mb-3">
           <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-datetime-select">
             <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
@@ -646,7 +646,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "datetime selects with options and html_options are wrapped correctly" do
     travel_to(Time.utc(2012, 2, 3, 12, 0, 0)) do
       expected = <<-HTML.strip_heredoc
-        <div class="form-group">
+        <div class="mb-3">
           <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-datetime-select">
             <select class="form-control my-datetime-select" id="user_misc_1i" name="user[misc(1i)]">
@@ -680,7 +680,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "confirm documentation example for HTML options" do
     expected = <<-HTML.strip_heredoc
-      <div class="form-group has-warning" data-foo="bar">
+      <div class="mb-3 has-warning" data-foo="bar">
         <label for="user_misc">Choose your favorite fruit:</label>
         <select class="form-control selectpicker" id="user_misc" name="user[misc]">
           <option value="1">Apple</option>

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -18,7 +18,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
-        <select class="form-control" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
+        <select class="form-select" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
       </div>
     HTML
     assert_equivalent_xml expected, @builder.time_zone_select(:misc)
@@ -28,7 +28,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 none-margin">
         <label class="form-label" for="user_misc">Misc</label>
-        <select class="form-control" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
+        <select class="form-select" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
       </div>
     HTML
     assert_equivalent_xml expected, @builder.time_zone_select(:misc, nil, wrapper: { class: "none-margin" })
@@ -41,7 +41,7 @@ class BootstrapSelectsTest < ActionView::TestCase
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
-        <select class="form-control is-invalid" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
+        <select class="form-select is-invalid" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
         <div class="invalid-feedback">error for test</div>
       </div>
     </form>
@@ -53,7 +53,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
-        <select class="form-control" id="user_status" name="user[status]">
+        <select class="form-select" id="user_status" name="user[status]">
           <option value="1">activated</option>
           <option value="2">blocked</option>
         </select>
@@ -66,7 +66,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
         <label class="form-label" for="user_status">My Status Label</label>
-        <select class="form-control" id="user_status" name="user[status]">
+        <select class="form-select" id="user_status" name="user[status]">
           <option value="1">activated</option>
           <option value="2">blocked</option>
         </select>
@@ -81,7 +81,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
-        <select class="form-control" id="user_status" name="user[status]">
+        <select class="form-select" id="user_status" name="user[status]">
           <option value="">Please Select</option>
           <option value="1">activated</option>
           <option value="2">blocked</option>
@@ -95,7 +95,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
-        <select class="form-control my-select" id="user_status" name="user[status]">
+        <select class="form-select my-select" id="user_status" name="user[status]">
           <option value="">Please Select</option>
           <option value="1">activated</option>
           <option value="2">blocked</option>
@@ -111,7 +111,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
         <label class="form-label" for="custom_id">Status</label>
-        <select class="form-control" id="custom_id" name="user[status]">
+        <select class="form-select" id="custom_id" name="user[status]">
           <option value="">Please Select</option>
           <option value="1">activated</option>
           <option value="2">blocked</option>
@@ -128,7 +128,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         <label class="form-label" for="user_status">Status</label>
         <div class="input-group">
           <span class="input-group-text">Before</span>
-          <select class="form-control" id="user_status" name="user[status]">
+          <select class="form-select" id="user_status" name="user[status]">
             <option value="1">activated</option>
             <option value="2">blocked</option>
           </select>
@@ -143,7 +143,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
-        <select class="form-control" name="user[status]" id="user_status">
+        <select class="form-select" name="user[status]" id="user_status">
           <option>Option 1</option>
           <option>Option 2</option>
         </select>
@@ -160,7 +160,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
         <label class="form-label" for="user_status">User Status</label>
-        <select class="form-control" id="user_status" name="user[status]">
+        <select class="form-select" id="user_status" name="user[status]">
           <option value="1">activated</option>
           <option value="2">blocked</option>
         </select>
@@ -173,7 +173,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
-        <select class="form-control" id="user_status" name="user[status]"></select>
+        <select class="form-select" id="user_status" name="user[status]"></select>
       </div>
     HTML
     assert_equivalent_xml expected, @builder.collection_select(:status, [], :id, :name)
@@ -183,7 +183,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 none-margin">
         <label class="form-label" for="user_status">Status</label>
-        <select class="form-control" id="user_status" name="user[status]"></select>
+        <select class="form-select" id="user_status" name="user[status]"></select>
       </div>
     HTML
     assert_equivalent_xml expected, @builder.collection_select(:status, [], :id, :name, wrapper: { class: "none-margin" })
@@ -196,7 +196,7 @@ class BootstrapSelectsTest < ActionView::TestCase
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
-        <select class="form-control is-invalid" id="user_status" name="user[status]"></select>
+        <select class="form-select is-invalid" id="user_status" name="user[status]"></select>
         <div class="invalid-feedback">error for test</div>
       </div>
     </form>
@@ -208,7 +208,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
-        <select class="form-control" id="user_status" name="user[status]">
+        <select class="form-select" id="user_status" name="user[status]">
           <option value="">Please Select</option>
         </select>
       </div>
@@ -220,7 +220,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
-        <select class="form-control my-select" id="user_status" name="user[status]">
+        <select class="form-select my-select" id="user_status" name="user[status]">
           <option value="">Please Select</option>
         </select>
       </div>
@@ -233,7 +233,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
-        <select class="form-control" id="user_status" name="user[status]"></select>
+        <select class="form-select" id="user_status" name="user[status]"></select>
       </div>
     HTML
     assert_equivalent_xml expected, @builder.grouped_collection_select(:status, [], :last, :first, :to_s, :to_s)
@@ -243,7 +243,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 none-margin">
         <label class="form-label" for="user_status">Status</label>
-        <select class="form-control" id="user_status" name="user[status]"></select>
+        <select class="form-select" id="user_status" name="user[status]"></select>
       </div>
     HTML
     assert_equivalent_xml expected,
@@ -257,7 +257,7 @@ class BootstrapSelectsTest < ActionView::TestCase
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
-        <select class="form-control is-invalid" id="user_status" name="user[status]"></select>
+        <select class="form-select is-invalid" id="user_status" name="user[status]"></select>
         <div class="invalid-feedback">error for test</div>
       </div>
     </form>
@@ -270,7 +270,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
-        <select class="form-control" id="user_status" name="user[status]">
+        <select class="form-select" id="user_status" name="user[status]">
           <option value="">Please Select</option>
         </select>
       </div>
@@ -283,7 +283,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
-        <select class="form-control my-select" id="user_status" name="user[status]">
+        <select class="form-select my-select" id="user_status" name="user[status]">
           <option value="">Please Select</option>
         </select>
       </div>
@@ -299,13 +299,13 @@ class BootstrapSelectsTest < ActionView::TestCase
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
-            <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
+            <select class="form-select" id="user_misc_1i" name="user[misc(1i)]">
               #{options_range(start: 2007, stop: 2017, selected: 2012)}
             </select>
-            <select class="form-control" id="user_misc_2i" name="user[misc(2i)]">
+            <select class="form-select" id="user_misc_2i" name="user[misc(2i)]">
               #{options_range(start: 1, stop: 12, selected: 2, months: true)}
             </select>
-            <select class="form-control" id="user_misc_3i" name="user[misc(3i)]">
+            <select class="form-select" id="user_misc_3i" name="user[misc(3i)]">
               #{options_range(start: 1, stop: 31, selected: 3)}
             </select>
           </div>
@@ -321,13 +321,13 @@ class BootstrapSelectsTest < ActionView::TestCase
         <div class="mb-3 none-margin">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
-            <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
+            <select class="form-select" id="user_misc_1i" name="user[misc(1i)]">
               #{options_range(start: 2007, stop: 2017, selected: 2012)}
             </select>
-            <select class="form-control" id="user_misc_2i" name="user[misc(2i)]">
+            <select class="form-select" id="user_misc_2i" name="user[misc(2i)]">
               #{options_range(start: 1, stop: 12, selected: 2, months: true)}
             </select>
-            <select class="form-control" id="user_misc_3i" name="user[misc(3i)]">
+            <select class="form-select" id="user_misc_3i" name="user[misc(3i)]">
               #{options_range(start: 1, stop: 31, selected: 3)}
             </select>
           </div>
@@ -346,13 +346,13 @@ class BootstrapSelectsTest < ActionView::TestCase
           <label class="form-label col-form-label col-sm-2" for="user_misc">Misc</label>
           <div class="col-sm-10">
             <div class="rails-bootstrap-forms-date-select col-auto g-3">
-              <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
+              <select class="form-select" id="user_misc_1i" name="user[misc(1i)]">
                 #{options_range(start: 2007, stop: 2017, selected: 2012)}
               </select>
-              <select class="form-control" id="user_misc_2i" name="user[misc(2i)]">
+              <select class="form-select" id="user_misc_2i" name="user[misc(2i)]">
                 #{options_range(start: 1, stop: 12, selected: 2, months: true)}
               </select>
-              <select class="form-control" id="user_misc_3i" name="user[misc(3i)]">
+              <select class="form-select" id="user_misc_3i" name="user[misc(3i)]">
                 #{options_range(start: 1, stop: 31, selected: 3)}
               </select>
             </div>
@@ -373,13 +373,13 @@ class BootstrapSelectsTest < ActionView::TestCase
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
-            <select class="form-control is-invalid" id="user_misc_1i" name="user[misc(1i)]">
+            <select class="form-select is-invalid" id="user_misc_1i" name="user[misc(1i)]">
               #{options_range(start: 2007, stop: 2017, selected: 2012)}
             </select>
-            <select class="form-control is-invalid" id="user_misc_2i" name="user[misc(2i)]">
+            <select class="form-select is-invalid" id="user_misc_2i" name="user[misc(2i)]">
               #{options_range(start: 1, stop: 12, selected: 2, months: true)}
             </select>
-            <select class="form-control is-invalid" id="user_misc_3i" name="user[misc(3i)]">
+            <select class="form-select is-invalid" id="user_misc_3i" name="user[misc(3i)]">
               #{options_range(start: 1, stop: 31, selected: 3)}
             </select>
             <div class="invalid-feedback">error for test</div>
@@ -397,15 +397,15 @@ class BootstrapSelectsTest < ActionView::TestCase
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
-            <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
+            <select class="form-select" id="user_misc_1i" name="user[misc(1i)]">
               <option value=""></option>
               #{options_range(start: 2007, stop: 2017)}
             </select>
-            <select class="form-control" id="user_misc_2i" name="user[misc(2i)]">
+            <select class="form-select" id="user_misc_2i" name="user[misc(2i)]">
               <option value=""></option>
               #{options_range(start: 1, stop: 12, months: true)}
             </select>
-            <select class="form-control" id="user_misc_3i" name="user[misc(3i)]">
+            <select class="form-select" id="user_misc_3i" name="user[misc(3i)]">
               <option value=""></option>
               #{options_range(start: 1, stop: 31)}
             </select>
@@ -423,15 +423,15 @@ class BootstrapSelectsTest < ActionView::TestCase
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
-            <select class="form-control my-date-select" id="user_misc_1i" name="user[misc(1i)]">
+            <select class="form-select my-date-select" id="user_misc_1i" name="user[misc(1i)]">
               <option value=""></option>
               #{options_range(start: 2007, stop: 2017)}
             </select>
-            <select class="form-control my-date-select" id="user_misc_2i" name="user[misc(2i)]">
+            <select class="form-select my-date-select" id="user_misc_2i" name="user[misc(2i)]">
               <option value=""></option>
               #{options_range(start: 1, stop: 12, months: true)}
             </select>
-            <select class="form-control my-date-select" id="user_misc_3i" name="user[misc(3i)]">
+            <select class="form-select my-date-select" id="user_misc_3i" name="user[misc(3i)]">
               <option value=""></option>
               #{options_range(start: 1, stop: 31)}
             </select>
@@ -451,11 +451,11 @@ class BootstrapSelectsTest < ActionView::TestCase
             <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="2012" />
             <input id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="2" />
             <input id="user_misc_3i" name="user[misc(3i)]" type="hidden" value="3" />
-            <select class="form-control" id="user_misc_4i" name="user[misc(4i)]">
+            <select class="form-select" id="user_misc_4i" name="user[misc(4i)]">
               #{options_range(start: '00', stop: '23', selected: '12')}
             </select>
             :
-            <select class="form-control" id="user_misc_5i" name="user[misc(5i)]">
+            <select class="form-select" id="user_misc_5i" name="user[misc(5i)]">
               #{options_range(start: '00', stop: '59', selected: '00')}
             </select>
           </div>
@@ -477,11 +477,11 @@ class BootstrapSelectsTest < ActionView::TestCase
             <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="2012" />
             <input id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="2" />
             <input id="user_misc_3i" name="user[misc(3i)]" type="hidden" value="3" />
-            <select class="form-control is-invalid" id="user_misc_4i" name="user[misc(4i)]">
+            <select class="form-select is-invalid" id="user_misc_4i" name="user[misc(4i)]">
               #{options_range(start: '00', stop: '23', selected: '12')}
             </select>
             :
-            <select class="form-control is-invalid" id="user_misc_5i" name="user[misc(5i)]">
+            <select class="form-select is-invalid" id="user_misc_5i" name="user[misc(5i)]">
               #{options_range(start: '00', stop: '59', selected: '00')}
             </select>
             <div class="invalid-feedback">error for test</div>
@@ -502,12 +502,12 @@ class BootstrapSelectsTest < ActionView::TestCase
             <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="1" />
             <input id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="1" />
             <input id="user_misc_3i" name="user[misc(3i)]" type="hidden" value="1" />
-            <select class="form-control" id="user_misc_4i" name="user[misc(4i)]">
+            <select class="form-select" id="user_misc_4i" name="user[misc(4i)]">
               <option value=""></option>
               #{options_range(start: '00', stop: '23')}
             </select>
             :
-            <select class="form-control" id="user_misc_5i" name="user[misc(5i)]">
+            <select class="form-select" id="user_misc_5i" name="user[misc(5i)]">
               <option value=""></option>
               #{options_range(start: '00', stop: '59')}
             </select>
@@ -527,12 +527,12 @@ class BootstrapSelectsTest < ActionView::TestCase
             <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="1" />
             <input id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="1" />
             <input id="user_misc_3i" name="user[misc(3i)]" type="hidden" value="1" />
-            <select class="form-control my-time-select" id="user_misc_4i" name="user[misc(4i)]">
+            <select class="form-select my-time-select" id="user_misc_4i" name="user[misc(4i)]">
               <option value=""></option>
               #{options_range(start: '00', stop: '23')}
             </select>
             :
-            <select class="form-control my-time-select" id="user_misc_5i" name="user[misc(5i)]">
+            <select class="form-select my-time-select" id="user_misc_5i" name="user[misc(5i)]">
               <option value=""></option>
               #{options_range(start: '00', stop: '59')}
             </select>
@@ -549,21 +549,21 @@ class BootstrapSelectsTest < ActionView::TestCase
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-datetime-select">
-            <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
+            <select class="form-select" id="user_misc_1i" name="user[misc(1i)]">
               #{options_range(start: 2007, stop: 2017, selected: 2012)}
             </select>
-            <select class="form-control" id="user_misc_2i" name="user[misc(2i)]">
+            <select class="form-select" id="user_misc_2i" name="user[misc(2i)]">
               #{options_range(start: 1, stop: 12, selected: 2, months: true)}
             </select>
-            <select class="form-control" id="user_misc_3i" name="user[misc(3i)]">
+            <select class="form-select" id="user_misc_3i" name="user[misc(3i)]">
               #{options_range(start: 1, stop: 31, selected: 3)}
             </select>
             &mdash;
-            <select class="form-control" id="user_misc_4i" name="user[misc(4i)]">
+            <select class="form-select" id="user_misc_4i" name="user[misc(4i)]">
               #{options_range(start: '00', stop: '23', selected: '12')}
             </select>
             :
-            <select class="form-control" id="user_misc_5i" name="user[misc(5i)]">
+            <select class="form-select" id="user_misc_5i" name="user[misc(5i)]">
               #{options_range(start: '00', stop: '59', selected: '00')}
             </select>
           </div>
@@ -582,21 +582,21 @@ class BootstrapSelectsTest < ActionView::TestCase
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-datetime-select">
-            <select class="form-control is-invalid" id="user_misc_1i" name="user[misc(1i)]">
+            <select class="form-select is-invalid" id="user_misc_1i" name="user[misc(1i)]">
               #{options_range(start: 2007, stop: 2017, selected: 2012)}
             </select>
-            <select class="form-control is-invalid" id="user_misc_2i" name="user[misc(2i)]">
+            <select class="form-select is-invalid" id="user_misc_2i" name="user[misc(2i)]">
               #{options_range(start: 1, stop: 12, selected: 2, months: true)}
             </select>
-            <select class="form-control is-invalid" id="user_misc_3i" name="user[misc(3i)]">
+            <select class="form-select is-invalid" id="user_misc_3i" name="user[misc(3i)]">
               #{options_range(start: 1, stop: 31, selected: 3)}
             </select>
             &mdash;
-            <select class="form-control is-invalid" id="user_misc_4i" name="user[misc(4i)]">
+            <select class="form-select is-invalid" id="user_misc_4i" name="user[misc(4i)]">
               #{options_range(start: '00', stop: '23', selected: '12')}
             </select>
             :
-            <select class="form-control is-invalid" id="user_misc_5i" name="user[misc(5i)]">
+            <select class="form-select is-invalid" id="user_misc_5i" name="user[misc(5i)]">
               #{options_range(start: '00', stop: '59', selected: '00')}
             </select>
             <div class="invalid-feedback">error for test</div>
@@ -614,25 +614,25 @@ class BootstrapSelectsTest < ActionView::TestCase
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-datetime-select">
-            <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
+            <select class="form-select" id="user_misc_1i" name="user[misc(1i)]">
               <option value=""></option>
               #{options_range(start: 2007, stop: 2017)}
             </select>
-            <select class="form-control" id="user_misc_2i" name="user[misc(2i)]">
+            <select class="form-select" id="user_misc_2i" name="user[misc(2i)]">
               <option value=""></option>
               #{options_range(start: 1, stop: 12, months: true)}
             </select>
-            <select class="form-control" id="user_misc_3i" name="user[misc(3i)]">
+            <select class="form-select" id="user_misc_3i" name="user[misc(3i)]">
               <option value=""></option>
               #{options_range(start: 1, stop: 31)}
             </select>
             &mdash;
-            <select class="form-control" id="user_misc_4i" name="user[misc(4i)]">
+            <select class="form-select" id="user_misc_4i" name="user[misc(4i)]">
               <option value=""></option>
               #{options_range(start: '00', stop: '23')}
             </select>
             :
-            <select class="form-control" id="user_misc_5i" name="user[misc(5i)]">
+            <select class="form-select" id="user_misc_5i" name="user[misc(5i)]">
               <option value=""></option>
               #{options_range(start: '00', stop: '59')}
             </select>
@@ -649,25 +649,25 @@ class BootstrapSelectsTest < ActionView::TestCase
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-datetime-select">
-            <select class="form-control my-datetime-select" id="user_misc_1i" name="user[misc(1i)]">
+            <select class="form-select my-datetime-select" id="user_misc_1i" name="user[misc(1i)]">
               <option value=""></option>
               #{options_range(start: 2007, stop: 2017)}
             </select>
-            <select class="form-control my-datetime-select" id="user_misc_2i" name="user[misc(2i)]">
+            <select class="form-select my-datetime-select" id="user_misc_2i" name="user[misc(2i)]">
               <option value=""></option>
               #{options_range(start: 1, stop: 12, months: true)}
             </select>
-            <select class="form-control my-datetime-select" id="user_misc_3i" name="user[misc(3i)]">
+            <select class="form-select my-datetime-select" id="user_misc_3i" name="user[misc(3i)]">
               <option value=""></option>
               #{options_range(start: 1, stop: 31)}
             </select>
             &mdash;
-            <select class="form-control my-datetime-select" id="user_misc_4i" name="user[misc(4i)]">
+            <select class="form-select my-datetime-select" id="user_misc_4i" name="user[misc(4i)]">
               <option value=""></option>
               #{options_range(start: '00', stop: '23')}
             </select>
             :
-            <select class="form-control my-datetime-select" id="user_misc_5i" name="user[misc(5i)]">
+            <select class="form-select my-datetime-select" id="user_misc_5i" name="user[misc(5i)]">
               <option value=""></option>
               #{options_range(start: '00', stop: '59')}
             </select>
@@ -682,7 +682,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="mb-3 has-warning" data-foo="bar">
         <label class="form-label" for="user_misc">Choose your favorite fruit:</label>
-        <select class="form-control selectpicker" id="user_misc" name="user[misc]">
+        <select class="form-select selectpicker" id="user_misc" name="user[misc]">
           <option value="1">Apple</option>
           <option value="2">Grape</option>
         </select>

--- a/test/special_form_class_models_test.rb
+++ b/test/special_form_class_models_test.rb
@@ -21,7 +21,7 @@ class SpecialFormClassModelsTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="date" />
       </div>
     HTML
@@ -41,7 +41,7 @@ class SpecialFormClassModelsTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="date" />
       </div>
     HTML
@@ -63,7 +63,7 @@ class SpecialFormClassModelsTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="mb-3">
-        <label for="user_misc">Misc</label>
+        <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="date" />
       </div>
     HTML

--- a/test/special_form_class_models_test.rb
+++ b/test/special_form_class_models_test.rb
@@ -20,7 +20,7 @@ class SpecialFormClassModelsTest < ActionView::TestCase
                                     })
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="date" />
       </div>
@@ -40,7 +40,7 @@ class SpecialFormClassModelsTest < ActionView::TestCase
                                     })
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="date" />
       </div>
@@ -62,7 +62,7 @@ class SpecialFormClassModelsTest < ActionView::TestCase
                                     })
 
     expected = <<-HTML.strip_heredoc
-      <div class="form-group">
+      <div class="mb-3">
         <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="date" />
       </div>


### PR DESCRIPTION
With the Bootstrap 5 alpha out today, I thought I'd see how hard it would be to update the gem to support the latest alpha release.

This is a work-in-progress PR, but it does seem to be working, at least with the demo application forms. More work needs to be put into updating parts of the README.

I've also questionably removed some tests that I should probably look into figuring out if they're actually tests that should be removed, or slightly reworked.

One thing that might be worth discussing is Bootstrap 5's removal of the `.form-group` class. The concept is pretty hard-wired into the gem. Even though the class is gone, the "concept" of the form group wrapper is still there, just replaced with the `.mb-3` class to maintain the margin on the div. I don't think it would necessarily be a bad thing to keep using the form group terminology within the code base.

I haven't contributed here before, but any existing maintainers should feel free to push to this branch with changes you feel are necessary. If you'd like to go for a more methodical, less "shotgun search and replace" methodology, I wouldn't be offended if my efforts here were scrapped.