### PR TITLE
Fixed: Append and Prepend

### DIFF
--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -108,7 +108,7 @@ module BootstrapForm
 
       def attach_input(options, key)
         tags = [*options[key]].map do |item|
-          tag.div(input_group_content(item), class: "input-group-#{key}")
+          input_group_content(item)
         end
         ActiveSupport::SafeBuffer.new(tags.join)
       end

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -121,9 +121,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       <div class="form-group">
         <label class="required" for="user_email">Email</label>
         <div class="input-group">
-          <div class="input-group-prepend">
-            <span class="input-group-text">@</span>
-          </div>
+          <span class="input-group-text">@</span>
           <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
         </div>
       </div>
@@ -137,9 +135,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <label class="required" for="user_email">Email</label>
         <div class="input-group">
           <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
-          <div class="input-group-append">
-            <span class="input-group-text">.00</span>
-          </div>
+          <span class="input-group-text">.00</span>
         </div>
       </div>
     HTML
@@ -168,13 +164,9 @@ class BootstrapFormGroupTest < ActionView::TestCase
       <div class="form-group">
         <label class="required" for="user_email">Email</label>
         <div class="input-group">
-          <div class="input-group-prepend">
-            <span class="input-group-text">$</div>
-          </div>
+          <span class="input-group-text">$</div>
           <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
-          <div class="input-group-append">
-            <span class="input-group-text">.00</span>
-          </div>
+          <span class="input-group-text">.00</span>
         </div>
       </div>
     HTML
@@ -191,13 +183,9 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <div class="form-group">
           <label class="required" for="user_email">Email</label>
           <div class="input-group">
-            <div class="input-group-prepend">
-              <span class="input-group-text">$</div>
-            </div>
+            <span class="input-group-text">$</div>
             <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
-            <div class="input-group-append">
-              <span class="input-group-text">.00</span>
-            </div>
+            <span class="input-group-text">.00</span>
             <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</span>
           </div>
         </div>


### PR DESCRIPTION
This PR removes the div element with class "input-group-*pend" to comply with the specs here
https://getbootstrap.com/docs/5.0/forms/input-group/

