### PR TITLE
Support Bootstrap 5 floating labels. Fixes #573

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### New features
 
-* Your contribution here!
+* [#573](https://github.com/bootstrap-ruby/bootstrap_form/issues/573): Add support for Bootstrap 5's floating labels
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -693,6 +693,21 @@ The `custom` option can be used to replace the browser default styles for check 
 <% end %>
 ```
 
+### Floating labels
+
+The `floating` option can be used to enable Bootstrap 5's floating labels. This option is supported on text fields
+and dropdowns. Here's an example:
+
+```erb
+<%= bootstrap_form_for(@user) do |f| %>
+  <%= f.email_field :email, floating: true %>
+  <%= f.password_field :password, floating: true %>
+  <%= f.password_field :password, floating: true %>
+  <%= f.select :status, [["Active", 1], ["Inactive", 2]], include_blank: "Select a value", floating: true %>
+  <%= f.submit "Log In" %>
+<% end %>
+```
+
 ## Validation and Errors
 
 Rails normally wraps fields with validation errors in a `div.field_with_errors`, but this behaviour isn't consistent with Bootstrap 4 styling. By default, `bootstrap_form` generations in-line errors which appear below the field. But it can also generate errors on the label, or not display any errors, leaving it up to you.

--- a/README.md
+++ b/README.md
@@ -693,7 +693,7 @@ The `custom` option can be used to replace the browser default styles for check 
 <% end %>
 ```
 
-### Floating labels
+### Floating Labels
 
 The `floating` option can be used to enable Bootstrap 5's floating labels. This option is supported on text fields
 and dropdowns. Here's an example:

--- a/demo/app/views/bootstrap/form.html.erb
+++ b/demo/app/views/bootstrap/form.html.erb
@@ -52,3 +52,16 @@
     <%= form.submit %>
   <% end %>
 <% end %>
+
+<h3>Floating Labels</h3>
+
+<%= form_with_source do %>
+  <%= bootstrap_form_for @user do |form| %>
+    <%= form.email_field :email, placeholder: "Enter Email", label: "Email address", help: "We'll never share your email with anyone else", floating: true %>
+    <%= form.password_field :password, placeholder: "Password", floating: true %>
+    <%= form.text_field :misc, floating: true %>
+    <%= form.text_area :comments, floating: true %>
+    <%= form.select :status, [["Active", 1], ["Inactive", 2]], include_blank: "Select a value", floating: true %>
+    <%= form.submit %>
+  <% end %>
+<% end %>

--- a/lib/bootstrap_form/form_group.rb
+++ b/lib/bootstrap_form/form_group.rb
@@ -12,7 +12,7 @@ module BootstrapForm
 
       tag.div(options.except(:append, :id, :label, :help, :icon,
                              :input_group_class, :label_col, :control_col,
-                             :add_control_col_class, :layout, :prepend)) do
+                             :add_control_col_class, :layout, :prepend, :floating)) do
         form_group_content(
           generate_label(options[:id], name, options[:label], options[:label_col], options[:layout]),
           generate_help(name, options[:help]), options, &block
@@ -36,8 +36,10 @@ module BootstrapForm
       if group_layout_horizontal?(options[:layout])
         concat(label).concat(tag.div(capture(&block) + help_text, class: form_group_control_class(options)))
       else
-        concat(label)
+        # Floating labels need to be rendered after the field
+        concat(label) unless options[:floating]
         concat(capture(&block))
+        concat(label) if options[:floating]
         concat(help_text) if help_text
       end
     end
@@ -54,6 +56,7 @@ module BootstrapForm
       classes << "row" if horizontal_group_with_gutters?(options[:layout], classes)
       classes << "col-auto g-3" if field_inline_override?(options[:layout])
       classes << feedback_class if options[:icon]
+      classes << "form-floating" if options[:floating]
       classes
     end
 

--- a/lib/bootstrap_form/form_group_builder.rb
+++ b/lib/bootstrap_form/form_group_builder.rb
@@ -46,7 +46,8 @@ module BootstrapForm
         id: options[:id], help: options[:help], icon: options[:icon],
         label_col: options[:label_col], control_col: options[:control_col],
         add_control_col_class: options[:add_control_col_class],
-        layout: get_group_layout(options[:layout]), class: options[:wrapper_class]
+        layout: get_group_layout(options[:layout]), class: options[:wrapper_class],
+        floating: options[:floating]
       }
 
       form_group_options.merge!(wrapper_options) if wrapper_options.is_a?(Hash)

--- a/lib/bootstrap_form/inputs/base.rb
+++ b/lib/bootstrap_form/inputs/base.rb
@@ -10,7 +10,8 @@ module BootstrapForm
           define_method "#{field_name}_with_bootstrap" do |name, options={}|
             form_group_builder(name, options) do
               prepend_and_append_input(name, options) do
-                send("#{field_name}_without_bootstrap".to_sym, name, options)
+                options[:placeholder] ||= name if options[:floating]
+                send("#{field_name}_without_bootstrap".to_sym, name, options.except(:floating))
               end
             end
           end

--- a/lib/bootstrap_form/inputs/base.rb
+++ b/lib/bootstrap_form/inputs/base.rb
@@ -20,12 +20,10 @@ module BootstrapForm
         end
 
         def bootstrap_select_group(field_name)
-          with_field_name = "#{field_name}_with_bootstrap"
-          without_field_name = "#{field_name}_without_bootstrap"
-          define_method(with_field_name) do |name, options={}, html_options={}|
+          define_method("#{field_name}_with_bootstrap") do |name, options={}, html_options={}|
             html_options = html_options.reverse_merge(control_class: "form-select")
             form_group_builder(name, options, html_options) do
-              form_group_content_tag(name, field_name, without_field_name, options, html_options)
+              form_group_content_tag(name, field_name, "#{field_name}_without_bootstrap", options, html_options)
             end
           end
 

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -430,7 +430,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "can have a floating label" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 form-floating">
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" placeholder="Email" />
         <label class="form-label required" for="user_email">Email</label>

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -428,4 +428,14 @@ class BootstrapFieldsTest < ActionView::TestCase
       end
     end
   end
+
+  test "can have a floating label" do
+    expected = <<-HTML.strip_heredoc
+      <div class="mb-3 form-floating">
+        <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" placeholder="Email" />
+        <label class="form-label required" for="user_email">Email</label>
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.text_field(:email, floating: true)
+  end
 end

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -698,6 +698,19 @@ class BootstrapSelectsTest < ActionView::TestCase
                                           class: "selectpicker")
   end
 
+  test "can have a floating label" do
+    expected = <<-HTML.strip_heredoc
+      <div class="mb-3 form-floating">
+        <select class="form-select" id="user_misc" name="user[misc]">
+          <option value="1">Apple</option>
+          <option value="2">Grape</option>
+        </select>
+        <label class="form-label" for="user_misc">Misc</label>
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.select(:misc, [["Apple", 1], ["Grape", 2]], floating: true)
+  end
+
   def blank_option
     if ::Rails::VERSION::STRING < "6.1"
       '<option value=""></option>'


### PR DESCRIPTION
Add support for Bootstrap 5 floating labels. See https://github.com/bootstrap-ruby/bootstrap_form/issues/573.

<img width="1182" alt="CleanShot 2021-04-07 at 10 20 48@2x" src="https://user-images.githubusercontent.com/781488/113834273-f2387780-978a-11eb-9512-ab447988c962.png">
