### PR TITLE
Simplify Dockerfile and add documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ demo/node_modules
 demo/yarn-error.log
 demo/yarn-debug.log*
 demo/.yarn-integrity
+
+# For stuff that gets created if using the Dockerfile image
+.bundle/
+.cache/
+vendor/bundle

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,12 @@ demo/.yarn-integrity
 .bundle/
 .cache/
 vendor/bundle
+
+# or .local/share/pry/pry_history if you need to be more exact
+.local/
+.irb_history
+.byebug_history
+# For Debian images with Bash
+.bash_history
+# For Alpine images
+.ash_history

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ There are a number of ways you can contribute to `bootstrap_form`:
 *Note:* If you want to work on preparing `bootstrap_form` for Bootstrap 5,
 please start from the `bootstrap-5` branch.
 If you're submitting a pull request with code or documentation,
-say that you want to merge your branch to the `bootstrap-5` branch.
+target the pull request to the `bootstrap-5` branch.
 
 ## Code Contributions
 
@@ -81,6 +81,33 @@ Note that most editors have plugins to run RuboCop as you type, or when you save
 The goal of `bootstrap_form` is to support all versions of Rails currently supported for bug fixes and security issues. We do not test against versions supported for severe security issues. We test against the minimum [version of Ruby required](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#ruby-versions) for those versions of Rails.
 
 The Ruby on Rails support policy is [here](https://guides.rubyonrails.org/maintenance_policy.html).
+
+### Developing with Docker
+
+This repository includes a `Dockerfile` to build an image with the minimum `bootstrap_form`-supported Ruby environment. To build the image:
+
+```bash
+docker build --tag bootstrap_form .
+```
+
+This builds an image called `bootstrap_form`. You can change that to any tag you wish. Just make sure you use the same tag name in the `docker run` command.
+
+If you want to use a different Ruby version, or a smaller Linux distribution (although the distro may be missing tools you need):
+
+```bash
+docker build --build-arg "RUBY_VERSION=2.7" --build-arg "DISTRO=slim-buster" --tag bootstrap_form .
+```
+
+Then run whichever container you built with the shell to create the bundle:
+
+```bash
+docker run --volume "$PWD:/app" --user $UID:`grep ^$USERNAME /etc/passwd | cut -d: -f4` -it bootstrap_form /bin/bash
+bundle install
+```
+
+You can run tests in the container as normal, with `rake test`.
+
+(Some of that command line is need for Linux hosts, to run the container as the current user.)
 
 ## Documentation Contributions
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,59 +1,26 @@
-# From: https://evilmartians.com/chronicles/ruby-on-whales-docker-for-ruby-rails-development
-ARG RUBY_VERSION
-# See explanation below
-FROM ruby:$RUBY_VERSION-slim-buster
+ARG DISTRO=buster
+ARG RUBY_VERSION=2.6
 
-ARG NODE_MAJOR
-ARG BUNDLER_VERSION
-ARG YARN_VERSION
+FROM ruby:$RUBY_VERSION-$DISTRO
 
-# Common dependencies
-RUN apt-get update -qq \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-    build-essential \
-    gnupg2 \
-    curl \
-    less \
-    git \
-    sqlite3 \
-    libsqlite3-dev \
-  && apt-get clean \
-  && rm -rf /var/cache/apt/archives/* \
-  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-  && truncate -s 0 /var/log/*log
-
-# Add NodeJS to sources list
-RUN curl -sL https://deb.nodesource.com/setup_$NODE_MAJOR.x | bash -
-
-# Add Yarn to the sources list
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-  && echo 'deb http://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list
-
-# Application dependencies
-RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrade && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-    nodejs \
-    yarn=$YARN_VERSION-1 && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-    truncate -s 0 /var/log/*log
-
-# Configure bundler
-ENV LANG=C.UTF-8 \
-  BUNDLE_JOBS=4 \
-  BUNDLE_RETRY=3
-
-# Uncomment this line if you store Bundler settings in the project's root
-# ENV BUNDLE_APP_CONFIG=.bundle
-
-# Uncomment this line if you want to run binstubs without prefixing with `bin/` or `bundle exec`
-# ENV PATH /app/bin:$PATH
-
-# Upgrade RubyGems and install required Bundler version
-RUN gem update --system && \
-    gem install bundler:$BUNDLER_VERSION
-
-# Create a directory for the app code
 RUN mkdir -p /app
-
+ENV HOME /app
 WORKDIR /app
+
+ENV GEM_HOME $HOME/vendor/bundle
+ENV BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH ./bin:$GEM_HOME/bin:$PATH
+RUN (echo 'docker'; echo 'docker') | passwd root
+
+# Yarn installs nodejs.
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt update -y -q && \
+    apt install -y -q yarn
+
+# Ruby now comes with bundler, but we're not using the default version yet, because we were using
+# a newer version of bundler already. Ruby 3 comes with Bundler 2.2.3. Ruby 2.7 has Bundler 2.1.2,
+# which is still behind what we were using.
+RUN gem install bundler -v 2.1.4
+
+EXPOSE 3000


### PR DESCRIPTION
This PR makes the container generated by the `Dockerfile` meet the current version requirements for the minimum supported version of Ruby, and the version of Bundler than we've been using lately.

It also simplifies the `Dockerfile` and keeps everything under the directory in which you're developing. If your host is Linux, run the container as the current user, rather than the superuser. Instructions are in the `CONTRIBUTING.md` document.