### PR TITLE
Get rid of `heredoc` on `bootstrap-5` branch

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,45 @@
+name: Ruby
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  Lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.2
+          bundler-cache: true
+      - name: Danger
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          gem install danger
+          danger
+      - name: Rubocop
+        run: bundle exec rubocop --auto-correct
+  Test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: [ '3.0', '2.7', '2.6' ]
+        gemfile: [ '6.1', '6.0', '5.2', 'edge' ]
+        exclude:
+          - { ruby-version: '3.0', gemfile: "5.2" }
+          - { ruby-version: '2.6', gemfile: "edge" }
+    env:
+      BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rake test

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .bundle/
+.idea
 log/*.log
 pkg/
 demo/db/*.sqlite3
@@ -13,7 +14,7 @@ test/gemfiles/*.lock
 Vagrantfile
 .vagrant
 
-// For the demo app.
+# For the demo app.
 
 # Ignore uploaded files in development.
 demo/storage/*
@@ -30,3 +31,17 @@ demo/node_modules
 demo/yarn-error.log
 demo/yarn-debug.log*
 demo/.yarn-integrity
+
+# For stuff that gets created if using the Dockerfile image
+.bundle/
+.cache/
+vendor/bundle
+
+# or .local/share/pry/pry_history if you need to be more exact
+.local/
+.irb_history
+.byebug_history
+# For Debian images with Bash
+.bash_history
+# For Alpine images
+.ash_history

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,7 @@ AllCops:
     - "demo/vendor/**/*"
     - Gemfile
     - gemfiles/vendor/bundle/**/*
+    - vendor/bundle/**/*
     - Guardfile
     - Rakefile
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,3 @@
-# Taken from: https://github.com/mattbrictson/rails-template/blob/master/rubocop.yml.tt
-# Modified for demo app in `demo/` directory.
 require:
   - rubocop-performance
   - rubocop-rails
@@ -8,24 +6,32 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
   TargetRubyVersion: 2.5
+  NewCops: enable
   Exclude:
-    - "bin/*"
+    - bin/*
     - Capfile
     - demo/bin/*
-    - "demo/bower_components/**/*"
+    - demo/bower_components/**/*
     - demo/config/boot.rb
     - demo/config/environment.rb
     - demo/config/initializers/version.rb
     - demo/db/schema.rb
-    - "demo/node_modules/**/*"
+    - demo/node_modules/**/*
     - demo/Rakefile
-    - "demo/tmp/**/*"
-    - "demo/vendor/**/*"
+    - demo/tmp/**/*
+    - demo/vendor/**/*
     - Gemfile
     - gemfiles/vendor/bundle/**/*
     - vendor/bundle/**/*
     - Guardfile
     - Rakefile
+    - vendor/**/*
+
+Layout/LineLength:
+  Max: 132
+  Exclude:
+    - "demo/config/**/*"
+    - "demo/db/**/*"
 
 Layout/SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: no_space
@@ -45,12 +51,6 @@ Metrics/ClassLength:
   Exclude:
     - "demo/test/**/*"
     - "test/**/*"
-
-Metrics/LineLength:
-  Max: 132
-  Exclude:
-    - "demo/config/**/*"
-    - "demo/db/**/*"
 
 Metrics/MethodLength:
   Max: 12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@
 
 ### Bugfixes
 
-* Your contribution here!
+* [#586](https://github.com/bootstrap-ruby/bootstrap_form/pull/586): Fix Rails 6.1 tests on master - [@thimo](https://github.com/thimo).
+* [#587](https://github.com/bootstrap-ruby/bootstrap_form/pull/587): Replace `strip_heredoc` with `<<~` - [@thimo](https://github.com/thimo).
 
 ## [4.5.0][] (2020-04-29)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ There are a number of ways you can contribute to `bootstrap_form`:
 *Note:* If you want to work on preparing `bootstrap_form` for Bootstrap 5,
 please start from the `bootstrap-5` branch.
 If you're submitting a pull request with code or documentation,
-say that you want to merge your branch to the `bootstrap-5` branch.
+target the pull request to the `bootstrap-5` branch.
 
 ## Code Contributions
 
@@ -81,6 +81,33 @@ Note that most editors have plugins to run RuboCop as you type, or when you save
 The goal of `bootstrap_form` is to support all versions of Rails currently supported for bug fixes and security issues. We do not test against versions supported for severe security issues. We test against the minimum [version of Ruby required](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#ruby-versions) for those versions of Rails.
 
 The Ruby on Rails support policy is [here](https://guides.rubyonrails.org/maintenance_policy.html).
+
+### Developing with Docker
+
+This repository includes a `Dockerfile` to build an image with the minimum `bootstrap_form`-supported Ruby environment. To build the image:
+
+```bash
+docker build --tag bootstrap_form .
+```
+
+This builds an image called `bootstrap_form`. You can change that to any tag you wish. Just make sure you use the same tag name in the `docker run` command.
+
+If you want to use a different Ruby version, or a smaller Linux distribution (although the distro may be missing tools you need):
+
+```bash
+docker build --build-arg "RUBY_VERSION=2.7" --build-arg "DISTRO=slim-buster" --tag bootstrap_form .
+```
+
+Then run whichever container you built with the shell to create the bundle:
+
+```bash
+docker run --volume "$PWD:/app" --user $UID:`grep ^$USERNAME /etc/passwd | cut -d: -f4` -it bootstrap_form /bin/bash
+bundle install
+```
+
+You can run tests in the container as normal, with `rake test`.
+
+(Some of that command line is need for Linux hosts, to run the container as the current user.)
 
 ## Documentation Contributions
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -45,7 +45,6 @@ end
 # Did you remove the CHANGELOG's "Your contribution here!" line?
 # ------------------------------------------------------------------------------
 if has_changelog_changes && IO.read("CHANGELOG.md").scan(/^\s*[-*] Your contribution here/i).count < 3
-if has_changelog_changes && (IO.read("CHANGELOG.md").scan(/^\s*[-*] Your contribution here/i).count < 3)
   raise(
     "Please put the `- Your contribution here!` line back into CHANGELOG.md.",
     sticky: false

--- a/Dangerfile
+++ b/Dangerfile
@@ -45,6 +45,7 @@ end
 # Did you remove the CHANGELOG's "Your contribution here!" line?
 # ------------------------------------------------------------------------------
 if has_changelog_changes && IO.read("CHANGELOG.md").scan(/^\s*[-*] Your contribution here/i).count < 3
+if has_changelog_changes && (IO.read("CHANGELOG.md").scan(/^\s*[-*] Your contribution here/i).count < 3)
   raise(
     "Please put the `- Your contribution here!` line back into CHANGELOG.md.",
     sticky: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,59 +1,26 @@
-# From: https://evilmartians.com/chronicles/ruby-on-whales-docker-for-ruby-rails-development
-ARG RUBY_VERSION
-# See explanation below
-FROM ruby:$RUBY_VERSION-slim-buster
+ARG DISTRO=buster
+ARG RUBY_VERSION=2.6
 
-ARG NODE_MAJOR
-ARG BUNDLER_VERSION
-ARG YARN_VERSION
+FROM ruby:$RUBY_VERSION-$DISTRO
 
-# Common dependencies
-RUN apt-get update -qq \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-    build-essential \
-    gnupg2 \
-    curl \
-    less \
-    git \
-    sqlite3 \
-    libsqlite3-dev \
-  && apt-get clean \
-  && rm -rf /var/cache/apt/archives/* \
-  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-  && truncate -s 0 /var/log/*log
-
-# Add NodeJS to sources list
-RUN curl -sL https://deb.nodesource.com/setup_$NODE_MAJOR.x | bash -
-
-# Add Yarn to the sources list
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-  && echo 'deb http://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list
-
-# Application dependencies
-RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrade && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-    nodejs \
-    yarn=$YARN_VERSION-1 && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-    truncate -s 0 /var/log/*log
-
-# Configure bundler
-ENV LANG=C.UTF-8 \
-  BUNDLE_JOBS=4 \
-  BUNDLE_RETRY=3
-
-# Uncomment this line if you store Bundler settings in the project's root
-# ENV BUNDLE_APP_CONFIG=.bundle
-
-# Uncomment this line if you want to run binstubs without prefixing with `bin/` or `bundle exec`
-# ENV PATH /app/bin:$PATH
-
-# Upgrade RubyGems and install required Bundler version
-RUN gem update --system && \
-    gem install bundler:$BUNDLER_VERSION
-
-# Create a directory for the app code
 RUN mkdir -p /app
-
+ENV HOME /app
 WORKDIR /app
+
+ENV GEM_HOME $HOME/vendor/bundle
+ENV BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH ./bin:$GEM_HOME/bin:$PATH
+RUN (echo 'docker'; echo 'docker') | passwd root
+
+# Yarn installs nodejs.
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt update -y -q && \
+    apt install -y -q yarn
+
+# Ruby now comes with bundler, but we're not using the default version yet, because we were using
+# a newer version of bundler already. Ruby 3 comes with Bundler 2.2.3. Ruby 2.7 has Bundler 2.1.2,
+# which is still behind what we were using.
+RUN gem install bundler -v 2.1.4
+
+EXPOSE 3000

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -14,7 +14,7 @@ module BootstrapForm
       def primary(name=nil, options={}, &block)
         setup_css_class "btn btn-primary", options
 
-        if options[:render_as_button] || block_given?
+        if options[:render_as_button] || block
           options.except! :render_as_button
           button(name, options, &block)
         else

--- a/lib/bootstrap_form/inputs/check_box.rb
+++ b/lib/bootstrap_form/inputs/check_box.rb
@@ -38,7 +38,7 @@ module BootstrapForm
       end
 
       def check_box_description(name, options, &block)
-        content = block_given? ? capture(&block) : options[:label]
+        content = block ? capture(&block) : options[:label]
         content || object&.class&.human_attribute_name(name) || name.to_s.humanize
       end
 

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -6,7 +6,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   setup :setup_test_fixture
 
   test "check_box is wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
@@ -19,7 +19,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   end
 
   test "check_box empty label" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
@@ -31,7 +31,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   end
 
   test "disabled check_box has proper wrapper classes" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" disabled="disabled" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" disabled="disabled" />
@@ -44,7 +44,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   end
 
   test "check_box label allows html" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
@@ -57,7 +57,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   end
 
   test "check_box accepts a block to define the label" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
@@ -70,7 +70,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   end
 
   test "check_box accepts a custom label class" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
@@ -83,7 +83,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   end
 
   test "check_box 'id' attribute is used to specify label 'for' attribute" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="custom_id" name="user[terms]" type="checkbox" value="1" />
@@ -96,7 +96,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   end
 
   test "check_box responds to checked_value and unchecked_value arguments" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="no" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="yes" />
@@ -109,7 +109,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   end
 
   test "inline checkboxes" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check form-check-inline">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
@@ -122,7 +122,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   end
 
   test "inline checkboxes from form layout" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user col-auto g-3" id="new_user" method="post">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-check form-check-inline">
@@ -141,7 +141,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   end
 
   test "disabled inline check_box" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check form-check-inline">
         <input name="user[terms]" type="hidden" value="0" disabled="disabled" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" disabled="disabled" />
@@ -155,21 +155,21 @@ class BootstrapCheckboxTest < ActionView::TestCase
   end
 
   test "inline checkboxes with custom label class" do
-    expected = <<-HTML.strip_heredoc
-    <div class="form-check form-check-inline">
-      <input name="user[terms]" type="hidden" value="0" />
-      <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-      <label class="form-check-label btn" for="user_terms">
-        Terms
-      </label>
-    </div>
+    expected = <<~HTML
+      <div class="form-check form-check-inline">
+        <input name="user[terms]" type="hidden" value="0" />
+        <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
+        <label class="form-check-label btn" for="user_terms">
+          Terms
+        </label>
+      </div>
     HTML
     assert_equivalent_xml expected, @builder.check_box(:terms, inline: true, label_class: "btn")
   end
 
   test "collection_check_boxes renders the form_group correctly" do
     collection = [Address.new(id: 1, street: "Foobar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">This is a checkbox collection</label>
@@ -187,7 +187,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
 
   test "collection_check_boxes renders multiple checkboxes correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
@@ -212,7 +212,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders multiple checkboxes contains unicode characters in IDs correctly" do
     struct = Struct.new(:id, :name)
     collection = [struct.new(1, "Foo"), struct.new("二", "Bar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
@@ -236,7 +236,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
 
   test "collection_check_boxes renders inline checkboxes correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
@@ -261,7 +261,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
 
   test "collection_check_boxes renders with checked option correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
@@ -288,7 +288,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
 
   test "collection_check_boxes renders with multiple checked options correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
@@ -311,7 +311,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
 
   test "collection_check_boxes sanitizes values when generating label `for`" do
     collection = [Address.new(id: 1, street: "Foo St")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
@@ -328,7 +328,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
 
   test "collection_check_boxes renders multiple checkboxes with labels defined by Proc :text_method correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
@@ -352,7 +352,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
 
   test "collection_check_boxes renders multiple checkboxes with values defined by Proc :value_method correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
@@ -376,7 +376,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
 
   test "collection_check_boxes renders multiple checkboxes with labels defined by lambda :text_method correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
@@ -400,7 +400,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
 
   test "collection_check_boxes renders multiple checkboxes with values defined by lambda :value_method correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
@@ -425,7 +425,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
 
   test "collection_check_boxes renders with checked option correctly with Proc :value_method" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
@@ -452,7 +452,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
 
   test "collection_check_boxes renders with multiple checked options correctly with lambda :value_method" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
@@ -478,7 +478,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   end
 
   test "check_box skip label" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input position-static" id="user_terms" name="user[terms]" type="checkbox" value="1" />
@@ -488,7 +488,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   end
 
   test "check_box hide label" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input position-static" id="user_terms" name="user[terms]" type="checkbox" value="1" />
@@ -502,23 +502,23 @@ class BootstrapCheckboxTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     @user.errors.add(:misc, "a box must be checked")
 
-    expected = <<-HTML.strip_heredoc
-    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
-      #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-      <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
-      <div class="mb-3">
-        <label class="form-label" for="user_misc">Misc</label>
-        <div class="form-check">
-          <input class="form-check-input is-invalid" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
-          <label class="form-check-label" for="user_misc_1">Foo</label>
+    expected = <<~HTML
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
+        #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
+        <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+        <div class="mb-3">
+          <label class="form-label" for="user_misc">Misc</label>
+          <div class="form-check">
+            <input class="form-check-input is-invalid" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
+            <label class="form-check-label" for="user_misc_1">Foo</label>
+          </div>
+          <div class="form-check">
+            <input class="form-check-input is-invalid" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
+            <label class="form-check-label" for="user_misc_2">Bar</label>
+            <div class="invalid-feedback">a box must be checked</div>
+          </div>
         </div>
-        <div class="form-check">
-          <input class="form-check-input is-invalid" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
-          <label class="form-check-label" for="user_misc_2">Bar</label>
-          <div class="invalid-feedback">a box must be checked</div>
-        </div>
-      </div>
-    </form>
+      </form>
     HTML
 
     actual = bootstrap_form_for(@user) do |f|
@@ -531,7 +531,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders multiple check boxes with error correctly" do
     @user.errors.add(:misc, "error for test")
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
@@ -558,18 +558,18 @@ class BootstrapCheckboxTest < ActionView::TestCase
 
   test "check_box renders error when asked" do
     @user.errors.add(:terms, "You must accept the terms.")
-    expected = <<-HTML.strip_heredoc
-    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
-      #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-      <div class="form-check">
-        <input name="user[terms]" type="hidden" value="0" />
-        <input class="form-check-input is-invalid" id="user_terms" name="user[terms]" type="checkbox" value="1" />
-        <label class="form-check-label" for="user_terms">
-          I agree to the terms
-        </label>
-        <div class="invalid-feedback">You must accept the terms.</div>
-      </div>
-    </form>
+    expected = <<~HTML
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
+        #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
+        <div class="form-check">
+          <input name="user[terms]" type="hidden" value="0" />
+          <input class="form-check-input is-invalid" id="user_terms" name="user[terms]" type="checkbox" value="1" />
+          <label class="form-check-label" for="user_terms">
+            I agree to the terms
+          </label>
+          <div class="invalid-feedback">You must accept the terms.</div>
+        </div>
+      </form>
     HTML
     actual = bootstrap_form_for(@user) do |f|
       f.check_box(:terms, label: "I agree to the terms", error_message: true)
@@ -578,7 +578,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   end
 
   test "check box with custom wrapper class" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check custom-class">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
@@ -591,7 +591,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   end
 
   test "inline check box with custom wrapper class" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check form-check-inline custom-class">
         <input name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -6,7 +6,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   setup :setup_test_fixture
 
   test "color fields are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="color" value="#000000" />
@@ -16,7 +16,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "date fields are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="date" />
@@ -26,7 +26,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "date time fields are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="datetime" />
@@ -36,7 +36,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "date time local fields are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="datetime-local" />
@@ -46,7 +46,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "email fields are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="email" />
@@ -56,7 +56,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "file fields are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="file"/>
@@ -66,7 +66,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "file field placeholder can be customized" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" placeholder="Pick a file" type="file"/>
@@ -77,7 +77,7 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   if ::Rails::VERSION::STRING > "5.1"
     test "file field placeholder has appropriate `for` attribute when used in form_with" do
-      expected = <<-HTML.strip_heredoc
+      expected = <<~HTML
         <div class="mb-3">
           <label class="form-label" for="custom-id">Misc</label>
           <input class="form-control" id="custom-id" name="user[misc]" type="file"/>
@@ -89,15 +89,15 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   test "file fields are wrapped correctly with error" do
     @user.errors.add(:misc, "error for test")
-    expected = <<-HTML.strip_heredoc
-    <form accept-charset="UTF-8" action="/users" class="new_user" enctype="multipart/form-data" id="new_user" method="post">
-      #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-      <div class="mb-3">
-        <label class="form-label" for="user_misc">Misc</label>
-        <input class="form-control is-invalid" id="user_misc" name="user[misc]" type="file"/>
-        <div class="invalid-feedback">error for test</div>
-      </div>
-    </form>
+    expected = <<~HTML
+      <form accept-charset="UTF-8" action="/users" class="new_user" enctype="multipart/form-data" id="new_user" method="post">
+        #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
+        <div class="mb-3">
+          <label class="form-label" for="user_misc">Misc</label>
+          <input class="form-control is-invalid" id="user_misc" name="user[misc]" type="file"/>
+          <div class="invalid-feedback">error for test</div>
+        </div>
+      </form>
     HTML
     assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.file_field(:misc) }
   end
@@ -108,7 +108,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "month local fields are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="month" />
@@ -118,7 +118,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "number fields are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="number" />
@@ -128,7 +128,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "password fields are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_password">Password</label>
         <input class="form-control" id="user_password" name="user[password]" type="password" />
@@ -139,7 +139,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "phone/telephone fields are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="tel" />
@@ -150,7 +150,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "range fields are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="range" />
@@ -160,7 +160,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "search fields are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="search" />
@@ -170,7 +170,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "text areas are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_comments">Comments</label>
         <textarea class="form-control" id="user_comments" name="user[comments]">\nmy comment</textarea>
@@ -181,11 +181,11 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   if ::Rails::VERSION::STRING > "5.1" && ::Rails::VERSION::STRING < "5.2"
     test "text areas are wrapped correctly form_with Rails 5.1" do
-      expected = <<-HTML.strip_heredoc
-      <div class="mb-3">
-        <label class="form-label" for="user_comments">Comments</label>
-        <textarea class="form-control" name="user[comments]">\nmy comment</textarea>
-      </div>
+      expected = <<~HTML
+        <div class="mb-3">
+          <label class="form-label" for="user_comments">Comments</label>
+          <textarea class="form-control" name="user[comments]">\nmy comment</textarea>
+        </div>
       HTML
       assert_equivalent_xml expected, form_with_builder.text_area(:comments)
     end
@@ -193,18 +193,18 @@ class BootstrapFieldsTest < ActionView::TestCase
 
   if ::Rails::VERSION::STRING > "5.2"
     test "text areas are wrapped correctly form_with Rails 5.2+" do
-      expected = <<-HTML.strip_heredoc
-      <div class="mb-3">
-        <label class="form-label" for="user_comments">Comments</label>
-        <textarea class="form-control" id="user_comments" name="user[comments]">\nmy comment</textarea>
-      </div>
+      expected = <<~HTML
+        <div class="mb-3">
+          <label class="form-label" for="user_comments">Comments</label>
+          <textarea class="form-control" id="user_comments" name="user[comments]">\nmy comment</textarea>
+        </div>
       HTML
       assert_equivalent_xml expected, form_with_builder.text_area(:comments)
     end
   end
 
   test "text fields are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label required" for="user_email">Email</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
@@ -214,7 +214,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "text fields are wrapped correctly when horizontal and gutter classes are given" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 g-3">
         <label class="form-label col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
@@ -227,7 +227,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "field 'id' attribute is used to specify label 'for' attribute" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label required" for="custom_id">Email</label>
         <input class="form-control" id="custom_id" name="user[email]" type="text" value="steve@example.com" />
@@ -237,7 +237,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "time fields are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="time" />
@@ -247,7 +247,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "url fields are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="url" />
@@ -257,7 +257,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "check_box fields are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check">
         <input name="user[misc]" type="hidden" value="0"/>
         <input class="form-check-input" id="user_misc" name="user[misc]" type="checkbox" value="1"/>
@@ -268,7 +268,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "switch-style check_box fields are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check form-switch">
         <input name="user[misc]" type="hidden" value="0"/>
         <input class="form-check-input" id="user_misc" name="user[misc]" type="checkbox" value="1"/>
@@ -279,7 +279,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "week fields are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="week" />
@@ -297,7 +297,7 @@ class BootstrapFieldsTest < ActionView::TestCase
       end
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
@@ -318,7 +318,7 @@ class BootstrapFieldsTest < ActionView::TestCase
       end
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
@@ -339,7 +339,7 @@ class BootstrapFieldsTest < ActionView::TestCase
       end
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 row">
@@ -363,7 +363,7 @@ class BootstrapFieldsTest < ActionView::TestCase
       end
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user col-auto g-3" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -6,7 +6,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   setup :setup_test_fixture
 
   test "changing the label text via the label option parameter" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label required" for="user_email">Email Address</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
@@ -16,7 +16,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "changing the label text via the html_options label hash" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label required" for="user_email">Email Address</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
@@ -26,7 +26,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "hiding a label" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label sr-only required" for="user_email">Email</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
@@ -36,7 +36,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "adding a custom label class via the label_class parameter" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label btn required" for="user_email">Email</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
@@ -46,7 +46,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "adding a custom label class via the html_options label hash" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label btn required" for="user_email">Email</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
@@ -56,7 +56,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "adding a custom label and changing the label text via the html_options label hash" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label btn required" for="user_email">Email Address</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
@@ -66,7 +66,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "skipping a label" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
@@ -75,7 +75,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "preventing a label from having the required class with :skip_required" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_email">Email</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
@@ -87,7 +87,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "preventing a label from having the required class" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_email">Email</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
@@ -97,7 +97,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "forcing a label to have the required class" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label required" for="user_comments">Comments</label>
         <input class="form-control" id="user_comments" name="user[comments]" type="text" value="my comment" required="required" />
@@ -107,7 +107,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "label as placeholder" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label sr-only required" for="user_email">Email</label>
         <input class="form-control" id="user_email" placeholder="Email" name="user[email]" type="text" value="steve@example.com" />
@@ -117,7 +117,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "adding prepend text" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label required" for="user_email">Email</label>
         <div class="input-group">
@@ -130,7 +130,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "adding append text" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label required" for="user_email">Email</label>
         <div class="input-group">
@@ -160,7 +160,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "adding both prepend and append text" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label required" for="user_email">Email</label>
         <div class="input-group">
@@ -177,7 +177,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     @user.email = nil
     assert @user.invalid?
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
@@ -195,7 +195,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "help messages for default forms" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label required" for="user_email">Email</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
@@ -206,7 +206,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "help messages for horizontal forms" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 row">
         <label class="form-label col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
@@ -219,7 +219,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "help messages to look up I18n automatically" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_password">Password</label>
         <input class="form-control" id="user_password" name="user[password]" type="text" value="secret" />
@@ -240,7 +240,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
                                       }
                                     })
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_password">Password</label>
         <input class="form-control" id="user_password" name="user[password]" type="text" value="secret" />
@@ -269,7 +269,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "help messages to ignore translation when user disables help" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_password">Password</label>
         <input class="form-control" id="user_password" name="user[password]" type="text" value="secret" />
@@ -283,7 +283,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       '<input class="form-control-plaintext" value="Bar">'.html_safe
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 row">
         <label class="form-label col-form-label col-sm-2" for="user_nil">Foo</label>
         <div class="col-sm-10">
@@ -299,7 +299,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       '<input class="form-control-plaintext" value="Bar">'.html_safe
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 row">
         <div class="col-sm-10 offset-sm-2">
           <input class="form-control-plaintext" value="Bar">
@@ -314,7 +314,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       '<input class="form-control-plaintext" value="Bar">'.html_safe
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 row">
         <label class="form-label col-form-label col-sm-2 required" for="user_email">Custom Control</label>
         <div class="col-sm-10">
@@ -330,7 +330,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       '<input class="form-control-plaintext" value="Bar">'.html_safe
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 foo row">
         <div class="col-sm-10 offset-sm-2">
           <input class="form-control-plaintext" value="Bar">
@@ -345,7 +345,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       '<input class="form-control-plaintext" value="Bar">'.html_safe
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 foo row">
         <div class="col-sm-10 offset-sm-2">
           <input class="form-control-plaintext" value="Bar">
@@ -360,7 +360,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       '<input class="form-control-plaintext" value="Bar">'.html_safe
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 g-3">
         <div class="col-sm-10 offset-sm-2">
           <input class="form-control-plaintext" value="Bar">
@@ -375,7 +375,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       '<input class="form-control-plaintext" value="Bar">'.html_safe
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 row">
         <label class="form-label foo col-form-label col-sm-2" for="bar">Custom Control</label>
         <div class="col-sm-10">
@@ -399,7 +399,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       html
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <p class="form-control-plaintext">Bar</p>
         <div class="invalid-feedback" style="display: block;">can't be blank, is too short (minimum is 5 characters)</div>
@@ -419,7 +419,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       end
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
@@ -443,7 +443,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "adds class to wrapped form_group by a field" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 none-margin">
         <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="search" />
@@ -456,7 +456,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     @user.email = nil
     assert @user.invalid?
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 none-margin">
         <div class="field_with_errors">
           <label class="form-label required" for="user_email">Email</label>
@@ -478,7 +478,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       f.text_field(:email, help: "This is required", wrapper_class: "none-margin")
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 none-margin">
@@ -496,7 +496,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       @horizontal_builder.submit
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 row">
         <div class="col-sm-10 offset-sm-2">
           <input class="btn btn-secondary" name="commit" type="submit" value="Create User" />
@@ -511,7 +511,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       @horizontal_builder.submit
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 row">
         <div class="col-sm-8 offset-sm-5">
           <input class="btn btn-secondary" name="commit" type="submit" value="Create User" />
@@ -529,7 +529,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
     output += @horizontal_builder.text_field(:email)
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 row">
         <div class="col-sm-10 offset-sm-2">Hallo</div>
       </div>
@@ -544,7 +544,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "adds data-attributes (or any other options) to wrapper" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3" data-foo="bar">
         <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="search" />
@@ -559,7 +559,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "passing options to a form control get passed through" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label required" for="user_email">Email</label>
         <input autofocus="autofocus" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
@@ -573,7 +573,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       nil
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_nil">Foo</label>
       </div>
@@ -582,7 +582,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "custom form group layout option" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 col-auto g-3">
@@ -602,7 +602,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       '<input class="form-control-plaintext" value="Bar">'.html_safe
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 row">
         <div class="col-sm-9 offset-sm-3">
           <input class="form-control-plaintext" value="Bar">
@@ -623,7 +623,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test ":input_group_class should apply to input-group" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label required" for="user_email">Email</label>
         <div class="input-group input-group-lg">

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -6,7 +6,7 @@ class BootstrapFormTest < ActionView::TestCase
   setup :setup_test_fixture
 
   test "default-style forms" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       </form>
@@ -15,7 +15,7 @@ class BootstrapFormTest < ActionView::TestCase
   end
 
   test "default-style form fields layout horizontal" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 row">
@@ -67,7 +67,7 @@ class BootstrapFormTest < ActionView::TestCase
   end
 
   test "default-style form fields layout inline" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 col-auto g-3">
@@ -119,7 +119,7 @@ class BootstrapFormTest < ActionView::TestCase
     # No need to test 5.2 separately for this case, since 5.2 does *not*
     # generate a default ID for the form element.
     test "default-style forms bootstrap_form_with Rails 5.1+" do
-      expected = <<-HTML.strip_heredoc
+      expected = <<~HTML
         <form accept-charset="UTF-8" action="/users" method="post" #{'data-remote="true"' if ::Rails::VERSION::STRING < '6.1'}>
           #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         </form>
@@ -129,7 +129,7 @@ class BootstrapFormTest < ActionView::TestCase
   end
 
   test "inline-style forms" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user col-auto g-3" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
@@ -174,7 +174,7 @@ class BootstrapFormTest < ActionView::TestCase
   end
 
   test "horizontal-style forms" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 row">
@@ -225,7 +225,7 @@ class BootstrapFormTest < ActionView::TestCase
   end
 
   test "horizontal-style form fields layout default" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
@@ -271,7 +271,7 @@ class BootstrapFormTest < ActionView::TestCase
   end
 
   test "horizontal-style form fields layout inline" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 col-auto g-3">
@@ -317,7 +317,7 @@ class BootstrapFormTest < ActionView::TestCase
   end
 
   test "existing styles aren't clobbered when specifying a form style" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="my-style" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 row">
@@ -333,7 +333,7 @@ class BootstrapFormTest < ActionView::TestCase
   end
 
   test "given role attribute should not be covered by default role attribute" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="not-a-form">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       </form>
@@ -343,7 +343,7 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "allows to set blank default form attributes via configuration" do
     BootstrapForm.config.stubs(:default_form_attributes).returns({})
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       </form>
@@ -353,7 +353,7 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "allows to set custom default form attributes via configuration" do
     BootstrapForm.config.stubs(:default_form_attributes).returns(foo: "bar")
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" foo="bar" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       </form>
@@ -362,7 +362,7 @@ class BootstrapFormTest < ActionView::TestCase
   end
 
   test "bootstrap_form_tag acts like a form tag" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
@@ -376,7 +376,7 @@ class BootstrapFormTest < ActionView::TestCase
   end
 
   test "bootstrap_form_for does not clobber custom options" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
@@ -389,7 +389,7 @@ class BootstrapFormTest < ActionView::TestCase
   end
 
   test "bootstrap_form_tag does not clobber custom options" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
@@ -409,15 +409,15 @@ class BootstrapFormTest < ActionView::TestCase
       id = "_misc"
       name = "[misc]"
     end
-    expected = <<-HTML.strip_heredoc
-    <form accept-charset="UTF-8" action="/users" method="post">
-      #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-      <div class="form-check">
-        <input class="form-check-input" id="#{id}" name="#{name}" type="checkbox" value="1" />
-        <input name="#{name}" type="hidden" value="0" />
-        <label class="form-check-label" for="#{id}"> Misc</label>
-      </div>
-    </form>
+    expected = <<~HTML
+      <form accept-charset="UTF-8" action="/users" method="post">
+        #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
+        <div class="form-check">
+          <input class="form-check-input" id="#{id}" name="#{name}" type="checkbox" value="1" />
+          <input name="#{name}" type="hidden" value="0" />
+          <label class="form-check-label" for="#{id}"> Misc</label>
+        </div>
+      </form>
     HTML
     assert_equivalent_xml expected, bootstrap_form_tag(url: "/users") { |f| f.check_box :misc }
   end
@@ -426,7 +426,7 @@ class BootstrapFormTest < ActionView::TestCase
     @user.email = nil
     assert @user.invalid?
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
@@ -442,7 +442,7 @@ class BootstrapFormTest < ActionView::TestCase
     @user.email = nil
     assert @user.invalid?
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
@@ -461,15 +461,15 @@ class BootstrapFormTest < ActionView::TestCase
     @user.email = nil
     assert @user.invalid?
 
-    expected = <<-HTML.strip_heredoc
-        <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
-          #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-          <div class="mb-3">
-            <label class="form-label required text-danger" for="user_email">Your e-mail address can&#39;t be blank, is too short (minimum is 5 characters)</label>
-            <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
-            <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
-          </div>
-        </form>
+    expected = <<~HTML
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
+        #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
+        <div class="mb-3">
+          <label class="form-label required text-danger" for="user_email">Your e-mail address can&#39;t be blank, is too short (minimum is 5 characters)</label>
+          <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
+          <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
+        </div>
+      </form>
     HTML
     assert_equivalent_xml expected, bootstrap_form_for(@user, label_errors: true, inline_errors: true) { |f| f.text_field :email }
   ensure
@@ -480,7 +480,7 @@ class BootstrapFormTest < ActionView::TestCase
     @user.email = nil
     assert @user.invalid?
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="alert alert-danger">
         <p>Please fix the following errors:</p>
         <ul class="rails-bootstrap-forms-error-summary">
@@ -497,7 +497,7 @@ class BootstrapFormTest < ActionView::TestCase
     @user.email = nil
     assert @user.invalid?
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="my-css-class">
         <p>Please fix the following errors:</p>
         <ul class="rails-bootstrap-forms-error-summary">
@@ -518,7 +518,7 @@ class BootstrapFormTest < ActionView::TestCase
       f.alert_message("Please fix the following errors:")
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="alert alert-danger">
@@ -542,7 +542,7 @@ class BootstrapFormTest < ActionView::TestCase
       f.alert_message("Please fix the following errors:", error_summary: false)
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="alert alert-danger">
@@ -561,7 +561,7 @@ class BootstrapFormTest < ActionView::TestCase
       f.alert_message("Please fix the following errors:", error_summary: true)
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="alert alert-danger">
@@ -581,7 +581,7 @@ class BootstrapFormTest < ActionView::TestCase
     @user.email = nil
     assert @user.invalid?
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <ul class="rails-bootstrap-forms-error-summary">
         <li>Email can&#39;t be blank</li>
         <li>Email is too short (minimum is 5 characters)</li>
@@ -602,14 +602,14 @@ class BootstrapFormTest < ActionView::TestCase
     @user.email = nil
     assert @user.invalid?
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="alert alert-danger">Email can&#39;t be blank, Email is too short (minimum is 5 characters)</div>
     HTML
     assert_equivalent_xml expected, @builder.errors_on(:email)
   end
 
   test "custom label width for horizontal forms" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 row">
@@ -625,7 +625,7 @@ class BootstrapFormTest < ActionView::TestCase
   end
 
   test "offset for form group without label respects label width for horizontal forms" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 row">
@@ -641,7 +641,7 @@ class BootstrapFormTest < ActionView::TestCase
   end
 
   test "offset for form group without label respects multiple label widths for horizontal forms" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 row">
@@ -657,7 +657,7 @@ class BootstrapFormTest < ActionView::TestCase
   end
 
   test "custom input width for horizontal forms" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 row">
@@ -673,7 +673,7 @@ class BootstrapFormTest < ActionView::TestCase
   end
 
   test "additional input col class" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 row">
@@ -697,7 +697,7 @@ class BootstrapFormTest < ActionView::TestCase
       f.text_field(:email, help: "This is required")
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
@@ -718,7 +718,7 @@ class BootstrapFormTest < ActionView::TestCase
       f.text_field(:email, help: "This is required")
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
@@ -743,7 +743,7 @@ class BootstrapFormTest < ActionView::TestCase
       f.text_field(:email, help: "This is required")
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
@@ -763,15 +763,15 @@ class BootstrapFormTest < ActionView::TestCase
       f.text_field(:email)
     end
 
-    expected = <<-HTML.strip_heredoc
-        <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
-          #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-          <div class="mb-3">
-            <label class="form-label required" for="user_email">Email</label>
-            <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
-            <small class="form-text text-muted">This is <strong>useful</strong> help</small>
-          </div>
-        </form>
+    expected = <<~HTML
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
+        #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
+        <div class="mb-3">
+          <label class="form-label required" for="user_email">Email</label>
+          <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+          <small class="form-text text-muted">This is <strong>useful</strong> help</small>
+        </div>
+      </form>
     HTML
     assert_equivalent_xml expected, output
   ensure
@@ -780,7 +780,7 @@ class BootstrapFormTest < ActionView::TestCase
 
   test "allows the form object to be nil" do
     builder = BootstrapForm::FormBuilder.new :other_model, nil, self, {}
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="other_model_email">Email</label>
         <input class="form-control" id="other_model_email" name="other_model[email]" type="text" />

--- a/test/bootstrap_other_components_test.rb
+++ b/test/bootstrap_other_components_test.rb
@@ -8,7 +8,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
   test "static control" do
     output = @horizontal_builder.static_control :email
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 row">
         <label class="form-label col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
@@ -22,7 +22,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
   test "static control can have custom_id" do
     output = @horizontal_builder.static_control :email, id: "custom_id"
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 row">
         <label class="form-label col-form-label col-sm-2 required" for="custom_id">Email</label>
         <div class="col-sm-10">
@@ -36,7 +36,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
   test "static control doesn't require an actual attribute" do
     output = @horizontal_builder.static_control nil, label: "My Label", value: "this is a test"
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 row">
         <label class="form-label col-form-label col-sm-2" for="user_">My Label</label>
         <div class="col-sm-10">
@@ -50,7 +50,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
   test "static control doesn't require a name" do
     output = @horizontal_builder.static_control label: "Custom Label", value: "Custom Control"
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 row">
         <label class="form-label col-form-label col-sm-2" for="user_">Custom Label</label>
         <div class="col-sm-10">
@@ -64,7 +64,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
   test "static control support a nil value" do
     output = @horizontal_builder.static_control label: "Custom Label", value: nil
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 row">
         <label class="form-label col-form-label col-sm-2" for="user_">Custom Label</label>
         <div class="col-sm-10">
@@ -78,7 +78,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
   test "static control won't overwrite a control_class that is passed by the user" do
     output = @horizontal_builder.static_control :email, control_class: "test_class"
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 row">
         <label class="form-label col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
@@ -94,7 +94,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
       "this is a test"
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 row">
         <label class="form-label col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">this is a test</div>
@@ -108,7 +108,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
       "this is a test"
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 row">
         <label class="form-label col-form-label col-sm-2" for="user_">My Label</label>
         <div class="col-sm-10">this is a test</div>
@@ -122,7 +122,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
       "Custom Control"
     end
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 row">
         <label class="form-label col-form-label col-sm-2" for="user_">Custom Label</label>
         <div class="col-sm-10">Custom Control</div>
@@ -132,7 +132,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
   end
 
   test "regular button uses proper css classes" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <button class="btn btn-secondary" name="button" type="submit"><span>I'm HTML!</span> in a button!</button>
     HTML
     assert_equivalent_xml expected,
@@ -140,7 +140,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
   end
 
   test "regular button can have extra css classes" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <button class="btn btn-secondary test-button" name="button" type="submit"><span>I'm HTML!</span> in a button!</button>
     HTML
     assert_equivalent_xml expected,

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -6,7 +6,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   setup :setup_test_fixture
 
   test "radio_button is wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check">
         <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
         <label class="form-check-label" for="user_misc_1">
@@ -18,7 +18,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   end
 
   test "radio_button no label" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check">
         <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
         <label class="form-check-label" for="user_misc_1">&#8203;</label>
@@ -30,17 +30,17 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "radio_button with error is wrapped correctly" do
     @user.errors.add(:misc, "error for test")
-    expected = <<-HTML.strip_heredoc
-    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
-      #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-      <div class="form-check">
-        <input class="form-check-input is-invalid" id="user_misc_1" name="user[misc]" type="radio" value="1" />
-        <label class="form-check-label" for="user_misc_1">
-          This is a radio button
-        </label>
-        <div class="invalid-feedback">error for test</div>
-      </div>
-    </form>
+    expected = <<~HTML
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
+        #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
+        <div class="form-check">
+          <input class="form-check-input is-invalid" id="user_misc_1" name="user[misc]" type="radio" value="1" />
+          <label class="form-check-label" for="user_misc_1">
+            This is a radio button
+          </label>
+          <div class="invalid-feedback">error for test</div>
+        </div>
+      </form>
     HTML
     actual = bootstrap_form_for(@user) do |f|
       f.radio_button(:misc, "1", label: "This is a radio button", error_message: true)
@@ -49,7 +49,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   end
 
   test "radio_button disabled label is set correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check disabled">
         <input class="form-check-input" disabled="disabled" id="user_misc_1" name="user[misc]" type="radio" value="1" />
         <label class="form-check-label" for="user_misc_1">
@@ -61,7 +61,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   end
 
   test "radio_button label class is set correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check">
         <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
         <label class="form-check-label btn" for="user_misc_1">
@@ -73,7 +73,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   end
 
   test "radio_button 'id' attribute is used to specify label 'for' attribute" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check">
         <input class="form-check-input" id="custom_id" name="user[misc]" type="radio" value="1" />
         <label class="form-check-label" for="custom_id">
@@ -85,7 +85,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   end
 
   test "radio_button inline label is set correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check form-check-inline">
         <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
         <label class="form-check-label" for="user_misc_1">
@@ -97,7 +97,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   end
 
   test "radio_button inline label is set correctly from form level" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user col-auto g-3" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-check form-check-inline">
@@ -115,7 +115,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   end
 
   test "radio_button disabled inline label is set correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check form-check-inline disabled">
         <input class="form-check-input" disabled="disabled" id="user_misc_1" name="user[misc]" type="radio" value="1" />
         <label class="form-check-label" for="user_misc_1">
@@ -127,7 +127,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   end
 
   test "radio_button inline label class is set correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check form-check-inline">
         <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
         <label class="form-check-label btn" for="user_misc_1">
@@ -141,7 +141,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "collection_radio_buttons renders the form_group correctly" do
     collection = [Address.new(id: 1, street: "Foobar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">This is a radio button collection</label>
         <div class="form-check">
@@ -161,7 +161,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "collection_radio_buttons renders multiple radios correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -181,7 +181,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "collection_radio_buttons renders multiple radios with error correctly" do
     @user.errors.add(:misc, "error for test")
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
@@ -207,7 +207,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "collection_radio_buttons renders inline radios correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check form-check-inline">
@@ -226,7 +226,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "collection_radio_buttons renders with checked option correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -245,7 +245,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "collection_radio_buttons renders label defined by Proc correctly" do
     collection = [Address.new(id: 1, street: "Foobar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">This is a radio button collection</label>
         <div class="form-check">
@@ -263,7 +263,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "collection_radio_buttons renders value defined by Proc correctly" do
     collection = [Address.new(id: 1, street: "Foobar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">This is a radio button collection</label>
         <div class="form-check">
@@ -282,7 +282,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "collection_radio_buttons renders multiple radios with label defined by Proc correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -301,7 +301,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "collection_radio_buttons renders multiple radios with value defined by Proc correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -320,7 +320,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "collection_radio_buttons renders label defined by lambda correctly" do
     collection = [Address.new(id: 1, street: "Foobar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">This is a radio button collection</label>
         <div class="form-check">
@@ -338,7 +338,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "collection_radio_buttons renders value defined by lambda correctly" do
     collection = [Address.new(id: 1, street: "Foobar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">This is a radio button collection</label>
         <div class="form-check">
@@ -357,7 +357,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "collection_radio_buttons renders multiple radios with label defined by lambda correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -376,7 +376,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
   test "collection_radio_buttons renders multiple radios with value defined by lambda correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -394,7 +394,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   end
 
   test "radio button skip label" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check">
         <input class="form-check-input position-static" id="user_misc_1" name="user[misc]" type="radio" value="1" />
       </div>
@@ -403,7 +403,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   end
 
   test "radio button hide label" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check">
         <input class="form-check-input position-static" id="user_misc_1" name="user[misc]" type="radio" value="1" />
         <label class="form-check-label sr-only" for="user_misc_1">This is a radio button</label>
@@ -413,7 +413,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   end
 
   test "radio button with custom wrapper class" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check custom-class">
         <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
         <label class="form-check-label" for="user_misc_1">
@@ -426,7 +426,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   end
 
   test "inline radio button with custom wrapper class" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="form-check form-check-inline custom-class">
         <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
         <label class="form-check-label" for="user_misc_1">

--- a/test/bootstrap_rich_text_area_test.rb
+++ b/test/bootstrap_rich_text_area_test.rb
@@ -8,12 +8,12 @@ if ::Rails::VERSION::STRING > "6"
     setup :setup_test_fixture
 
     test "rich text areas are wrapped correctly" do
-      expected = <<-HTML.strip_heredoc
-      <div class="mb-3">
-        <label class="form-label" for="user_life_story">Life story</label>
-        <input type="hidden" name="user[life_story]" id="user_life_story_trix_input_user"/>
-        <trix-editor id="user_life_story" data-blob-url-template="#{data_blob_url_template}" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" input="user_life_story_trix_input_user" class="trix-content form-control" />
-      </div>
+      expected = <<~HTML
+        <div class="mb-3">
+          <label class="form-label" for="user_life_story">Life story</label>
+          <input type="hidden" name="user[life_story]" id="user_life_story_trix_input_user"/>
+          <trix-editor id="user_life_story" data-blob-url-template="#{data_blob_url_template}" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" input="user_life_story_trix_input_user" class="trix-content form-control" />
+        </div>
       HTML
       assert_equivalent_xml expected, form_with_builder.rich_text_area(:life_story)
     end

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -15,7 +15,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   end
 
   test "time zone selects are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <select class="form-select" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
@@ -25,7 +25,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   end
 
   test "time zone selects are wrapped correctly with wrapper" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 none-margin">
         <label class="form-label" for="user_misc">Misc</label>
         <select class="form-select" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
@@ -36,21 +36,21 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "time zone selects are wrapped correctly with error" do
     @user.errors.add(:misc, "error for test")
-    expected = <<-HTML.strip_heredoc
-    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
-      #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-      <div class="mb-3">
-        <label class="form-label" for="user_misc">Misc</label>
-        <select class="form-select is-invalid" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
-        <div class="invalid-feedback">error for test</div>
-      </div>
-    </form>
+    expected = <<~HTML
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
+        #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
+        <div class="mb-3">
+          <label class="form-label" for="user_misc">Misc</label>
+          <select class="form-select is-invalid" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
+          <div class="invalid-feedback">error for test</div>
+        </div>
+      </form>
     HTML
     assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.time_zone_select(:misc) }
   end
 
   test "selects are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
         <select class="form-select" id="user_status" name="user[status]">
@@ -63,7 +63,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   end
 
   test "bootstrap_specific options are handled correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_status">My Status Label</label>
         <select class="form-select" id="user_status" name="user[status]">
@@ -78,7 +78,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   end
 
   test "selects with options are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
         <select class="form-select" id="user_status" name="user[status]">
@@ -92,7 +92,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   end
 
   test "selects with both options and html_options are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
         <select class="form-select my-select" id="user_status" name="user[status]">
@@ -108,7 +108,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   end
 
   test "select 'id' attribute is used to specify label 'for' attribute" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="custom_id">Status</label>
         <select class="form-select" id="custom_id" name="user[status]">
@@ -123,7 +123,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   end
 
   test "selects with addons are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
         <div class="input-group">
@@ -140,7 +140,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   end
 
   test "selects with block use block as content" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
         <select class="form-select" name="user[status]" id="user_status">
@@ -157,7 +157,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   end
 
   test "selects render labels properly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_status">User Status</label>
         <select class="form-select" id="user_status" name="user[status]">
@@ -170,7 +170,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   end
 
   test "collection_selects are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
         <select class="form-select" id="user_status" name="user[status]"></select>
@@ -180,7 +180,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   end
 
   test "collection_selects are wrapped correctly with wrapper" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 none-margin">
         <label class="form-label" for="user_status">Status</label>
         <select class="form-select" id="user_status" name="user[status]"></select>
@@ -191,21 +191,21 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "collection_selects are wrapped correctly with error" do
     @user.errors.add(:status, "error for test")
-    expected = <<-HTML.strip_heredoc
-    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
-      #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-      <div class="mb-3">
-        <label class="form-label" for="user_status">Status</label>
-        <select class="form-select is-invalid" id="user_status" name="user[status]"></select>
-        <div class="invalid-feedback">error for test</div>
-      </div>
-    </form>
+    expected = <<~HTML
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
+        #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
+        <div class="mb-3">
+          <label class="form-label" for="user_status">Status</label>
+          <select class="form-select is-invalid" id="user_status" name="user[status]"></select>
+          <div class="invalid-feedback">error for test</div>
+        </div>
+      </form>
     HTML
     assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.collection_select(:status, [], :id, :name) }
   end
 
   test "collection_selects with options are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
         <select class="form-select" id="user_status" name="user[status]">
@@ -217,7 +217,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   end
 
   test "collection_selects with options and html_options are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
         <select class="form-select my-select" id="user_status" name="user[status]">
@@ -230,7 +230,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   end
 
   test "grouped_collection_selects are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
         <select class="form-select" id="user_status" name="user[status]"></select>
@@ -240,7 +240,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   end
 
   test "grouped_collection_selects are wrapped correctly with wrapper" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 none-margin">
         <label class="form-label" for="user_status">Status</label>
         <select class="form-select" id="user_status" name="user[status]"></select>
@@ -252,22 +252,22 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "grouped_collection_selects are wrapped correctly with error" do
     @user.errors.add(:status, "error for test")
-    expected = <<-HTML.strip_heredoc
-    <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
-      #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-      <div class="mb-3">
-        <label class="form-label" for="user_status">Status</label>
-        <select class="form-select is-invalid" id="user_status" name="user[status]"></select>
-        <div class="invalid-feedback">error for test</div>
-      </div>
-    </form>
+    expected = <<~HTML
+      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
+        #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
+        <div class="mb-3">
+          <label class="form-label" for="user_status">Status</label>
+          <select class="form-select is-invalid" id="user_status" name="user[status]"></select>
+          <div class="invalid-feedback">error for test</div>
+        </div>
+      </form>
     HTML
     assert_equivalent_xml expected,
                           bootstrap_form_for(@user) { |f| f.grouped_collection_select(:status, [], :last, :first, :to_s, :to_s) }
   end
 
   test "grouped_collection_selects with options are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
         <select class="form-select" id="user_status" name="user[status]">
@@ -280,7 +280,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   end
 
   test "grouped_collection_selects with options and html_options are wrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
         <select class="form-select my-select" id="user_status" name="user[status]">
@@ -295,7 +295,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "date selects are wrapped correctly" do
     travel_to(Time.utc(2012, 2, 3)) do
-      expected = <<-HTML.strip_heredoc
+      expected = <<~HTML
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
@@ -317,7 +317,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "date selects are wrapped correctly with wrapper class" do
     travel_to(Time.utc(2012, 2, 3)) do
-      expected = <<-HTML.strip_heredoc
+      expected = <<~HTML
         <div class="mb-3 none-margin">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
@@ -339,26 +339,26 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "date selects inline when layout is horizontal" do
     travel_to(Time.utc(2012, 2, 3)) do
-      expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
-        #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="mb-3 row">
-          <label class="form-label col-form-label col-sm-2" for="user_misc">Misc</label>
-          <div class="col-sm-10">
-            <div class="rails-bootstrap-forms-date-select col-auto g-3">
-              <select class="form-select" id="user_misc_1i" name="user[misc(1i)]">
-                #{options_range(start: 2007, stop: 2017, selected: 2012)}
-              </select>
-              <select class="form-select" id="user_misc_2i" name="user[misc(2i)]">
-                #{options_range(start: 1, stop: 12, selected: 2, months: true)}
-              </select>
-              <select class="form-select" id="user_misc_3i" name="user[misc(3i)]">
-                #{options_range(start: 1, stop: 31, selected: 3)}
-              </select>
+      expected = <<~HTML
+        <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
+          #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
+          <div class="mb-3 row">
+            <label class="form-label col-form-label col-sm-2" for="user_misc">Misc</label>
+            <div class="col-sm-10">
+              <div class="rails-bootstrap-forms-date-select col-auto g-3">
+                <select class="form-select" id="user_misc_1i" name="user[misc(1i)]">
+                  #{options_range(start: 2007, stop: 2017, selected: 2012)}
+                </select>
+                <select class="form-select" id="user_misc_2i" name="user[misc(2i)]">
+                  #{options_range(start: 1, stop: 12, selected: 2, months: true)}
+                </select>
+                <select class="form-select" id="user_misc_3i" name="user[misc(3i)]">
+                  #{options_range(start: 1, stop: 31, selected: 3)}
+                </select>
+              </div>
             </div>
           </div>
-        </div>
-      </form>
+        </form>
       HTML
       assert_equivalent_xml expected, bootstrap_form_for(@user, layout: :horizontal) { |f| f.date_select(:misc) }
     end
@@ -367,25 +367,25 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "date selects are wrapped correctly with error" do
     @user.errors.add(:misc, "error for test")
     travel_to(Time.utc(2012, 2, 3)) do
-      expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
-        #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="mb-3">
-          <label class="form-label" for="user_misc">Misc</label>
-          <div class="rails-bootstrap-forms-date-select">
-            <select class="form-select is-invalid" id="user_misc_1i" name="user[misc(1i)]">
-              #{options_range(start: 2007, stop: 2017, selected: 2012)}
-            </select>
-            <select class="form-select is-invalid" id="user_misc_2i" name="user[misc(2i)]">
-              #{options_range(start: 1, stop: 12, selected: 2, months: true)}
-            </select>
-            <select class="form-select is-invalid" id="user_misc_3i" name="user[misc(3i)]">
-              #{options_range(start: 1, stop: 31, selected: 3)}
-            </select>
-            <div class="invalid-feedback">error for test</div>
+      expected = <<~HTML
+        <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
+          #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
+          <div class="mb-3">
+            <label class="form-label" for="user_misc">Misc</label>
+            <div class="rails-bootstrap-forms-date-select">
+              <select class="form-select is-invalid" id="user_misc_1i" name="user[misc(1i)]">
+                #{options_range(start: 2007, stop: 2017, selected: 2012)}
+              </select>
+              <select class="form-select is-invalid" id="user_misc_2i" name="user[misc(2i)]">
+                #{options_range(start: 1, stop: 12, selected: 2, months: true)}
+              </select>
+              <select class="form-select is-invalid" id="user_misc_3i" name="user[misc(3i)]">
+                #{options_range(start: 1, stop: 31, selected: 3)}
+              </select>
+              <div class="invalid-feedback">error for test</div>
+            </div>
           </div>
-        </div>
-      </form>
+        </form>
       HTML
       assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.date_select(:misc) }
     end
@@ -393,7 +393,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "date selects with options are wrapped correctly" do
     travel_to(Time.utc(2012, 2, 3)) do
-      expected = <<-HTML.strip_heredoc
+      expected = <<~HTML
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
@@ -419,7 +419,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "date selects with options and html_options are wrapped correctly" do
     travel_to(Time.utc(2012, 2, 3)) do
-      expected = <<-HTML.strip_heredoc
+      expected = <<~HTML
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
@@ -444,7 +444,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "time selects are wrapped correctly" do
     travel_to(Time.utc(2012, 2, 3, 12, 0, 0)) do
-      expected = <<-HTML.strip_heredoc
+      expected = <<~HTML
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-time-select">
@@ -468,26 +468,26 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "time selects are wrapped correctly with error" do
     @user.errors.add(:misc, "error for test")
     travel_to(Time.utc(2012, 2, 3, 12, 0, 0)) do
-      expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
-        #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="mb-3">
-          <label class="form-label" for="user_misc">Misc</label>
-          <div class="rails-bootstrap-forms-time-select">
-            <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="2012" />
-            <input id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="2" />
-            <input id="user_misc_3i" name="user[misc(3i)]" type="hidden" value="3" />
-            <select class="form-select is-invalid" id="user_misc_4i" name="user[misc(4i)]">
-              #{options_range(start: '00', stop: '23', selected: '12')}
-            </select>
-            :
-            <select class="form-select is-invalid" id="user_misc_5i" name="user[misc(5i)]">
-              #{options_range(start: '00', stop: '59', selected: '00')}
-            </select>
-            <div class="invalid-feedback">error for test</div>
+      expected = <<~HTML
+        <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
+          #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
+          <div class="mb-3">
+            <label class="form-label" for="user_misc">Misc</label>
+            <div class="rails-bootstrap-forms-time-select">
+              <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="2012" />
+              <input id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="2" />
+              <input id="user_misc_3i" name="user[misc(3i)]" type="hidden" value="3" />
+              <select class="form-select is-invalid" id="user_misc_4i" name="user[misc(4i)]">
+                #{options_range(start: '00', stop: '23', selected: '12')}
+              </select>
+              :
+              <select class="form-select is-invalid" id="user_misc_5i" name="user[misc(5i)]">
+                #{options_range(start: '00', stop: '59', selected: '00')}
+              </select>
+              <div class="invalid-feedback">error for test</div>
+            </div>
           </div>
-        </div>
-      </form>
+        </form>
       HTML
       assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.time_select(:misc) }
     end
@@ -495,7 +495,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "time selects with options are wrapped correctly" do
     travel_to(Time.utc(2012, 2, 3, 12, 0, 0)) do
-      expected = <<-HTML.strip_heredoc
+      expected = <<~HTML
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-time-select">
@@ -520,7 +520,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "time selects with options and html_options are wrapped correctly" do
     travel_to(Time.utc(2012, 2, 3, 12, 0, 0)) do
-      expected = <<-HTML.strip_heredoc
+      expected = <<~HTML
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-time-select">
@@ -545,7 +545,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "datetime selects are wrapped correctly" do
     travel_to(Time.utc(2012, 2, 3, 12, 0, 0)) do
-      expected = <<-HTML.strip_heredoc
+      expected = <<~HTML
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-datetime-select">
@@ -576,33 +576,33 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "datetime selects are wrapped correctly with error" do
     @user.errors.add(:misc, "error for test")
     travel_to(Time.utc(2012, 2, 3, 12, 0, 0)) do
-      expected = <<-HTML.strip_heredoc
-      <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
-        #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="mb-3">
-          <label class="form-label" for="user_misc">Misc</label>
-          <div class="rails-bootstrap-forms-datetime-select">
-            <select class="form-select is-invalid" id="user_misc_1i" name="user[misc(1i)]">
-              #{options_range(start: 2007, stop: 2017, selected: 2012)}
-            </select>
-            <select class="form-select is-invalid" id="user_misc_2i" name="user[misc(2i)]">
-              #{options_range(start: 1, stop: 12, selected: 2, months: true)}
-            </select>
-            <select class="form-select is-invalid" id="user_misc_3i" name="user[misc(3i)]">
-              #{options_range(start: 1, stop: 31, selected: 3)}
-            </select>
-            &mdash;
-            <select class="form-select is-invalid" id="user_misc_4i" name="user[misc(4i)]">
-              #{options_range(start: '00', stop: '23', selected: '12')}
-            </select>
-            :
-            <select class="form-select is-invalid" id="user_misc_5i" name="user[misc(5i)]">
-              #{options_range(start: '00', stop: '59', selected: '00')}
-            </select>
-            <div class="invalid-feedback">error for test</div>
+      expected = <<~HTML
+        <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
+          #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
+          <div class="mb-3">
+            <label class="form-label" for="user_misc">Misc</label>
+            <div class="rails-bootstrap-forms-datetime-select">
+              <select class="form-select is-invalid" id="user_misc_1i" name="user[misc(1i)]">
+                #{options_range(start: 2007, stop: 2017, selected: 2012)}
+              </select>
+              <select class="form-select is-invalid" id="user_misc_2i" name="user[misc(2i)]">
+                #{options_range(start: 1, stop: 12, selected: 2, months: true)}
+              </select>
+              <select class="form-select is-invalid" id="user_misc_3i" name="user[misc(3i)]">
+                #{options_range(start: 1, stop: 31, selected: 3)}
+              </select>
+              &mdash;
+              <select class="form-select is-invalid" id="user_misc_4i" name="user[misc(4i)]">
+                #{options_range(start: '00', stop: '23', selected: '12')}
+              </select>
+              :
+              <select class="form-select is-invalid" id="user_misc_5i" name="user[misc(5i)]">
+                #{options_range(start: '00', stop: '59', selected: '00')}
+              </select>
+              <div class="invalid-feedback">error for test</div>
+            </div>
           </div>
-        </div>
-      </form>
+        </form>
       HTML
       assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.datetime_select(:misc) }
     end
@@ -610,7 +610,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "datetime selects with options are wrapped correctly" do
     travel_to(Time.utc(2012, 2, 3, 12, 0, 0)) do
-      expected = <<-HTML.strip_heredoc
+      expected = <<~HTML
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-datetime-select">
@@ -645,7 +645,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "datetime selects with options and html_options are wrapped correctly" do
     travel_to(Time.utc(2012, 2, 3, 12, 0, 0)) do
-      expected = <<-HTML.strip_heredoc
+      expected = <<~HTML
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-datetime-select">
@@ -679,7 +679,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   end
 
   test "confirm documentation example for HTML options" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 has-warning" data-foo="bar">
         <label class="form-label" for="user_misc">Choose your favorite fruit:</label>
         <select class="form-select selectpicker" id="user_misc" name="user[misc]">
@@ -699,7 +699,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   end
 
   test "can have a floating label" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3 form-floating">
         <select class="form-select" id="user_misc" name="user[misc]">
           <option value="1">Apple</option>

--- a/test/bootstrap_without_fields_test.rb
+++ b/test/bootstrap_without_fields_test.rb
@@ -6,7 +6,7 @@ class BootstrapWithoutFieldsTest < ActionView::TestCase
   setup :setup_test_fixture
 
   test "color fields are unwrapped correctly" do
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <input id="user_misc" name="user[misc]" type="color" value="#000000"/>
     HTML
     assert_equivalent_xml expected, @builder.color_field_without_bootstrap(:misc)

--- a/test/special_form_class_models_test.rb
+++ b/test/special_form_class_models_test.rb
@@ -19,7 +19,7 @@ class SpecialFormClassModelsTest < ActionView::TestCase
                                       }
                                     })
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="date" />
@@ -39,7 +39,7 @@ class SpecialFormClassModelsTest < ActionView::TestCase
                                       }
                                     })
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="date" />
@@ -61,7 +61,7 @@ class SpecialFormClassModelsTest < ActionView::TestCase
                                       }
                                     })
 
-    expected = <<-HTML.strip_heredoc
+    expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="date" />


### PR DESCRIPTION
Fixes #585 for branch. The original intent was just merge `master` but it turned out to be messy. I hope I haven't included anything that shouldn't be here.

Review ignoring whitespace for optimum experience. (Click on the settings gear when you're looking at the "Files changed".)