### PR TITLE
Document How to Run Demo App

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -2,9 +2,9 @@ name: Ruby
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   Lint:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,6 +19,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           gem install danger
+          export DANGER_GITHUB_API_TOKEN=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
           danger
       - name: Rubocop
         run: bundle exec rubocop --auto-correct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,20 @@ You can run tests in the container as normal, with `rake test`.
 
 (Some of that command line is need for Linux hosts, to run the container as the current user.)
 
+### The Demo App
+
+There is a demo app in this repository. It shows some of the features of `bootstrap_form`, and provides a base on which to build ad-hoc testing, if you need it.
+
 To run the demo app, set up the database and run the server:
+
+```bash
+cd demo
+export BUNDLER_GEMFILE=../gemfiles/6.1.gemfile
+rails db:setup
+rails s -b 0.0.0.0
+```
+
+To run the demo app in the Docker container:
 
 ```bash
 docker run --volume "$PWD:/app" --user $UID:`grep ^$USERNAME /etc/passwd | cut -d: -f4` -p 3000:3000 -it bootstrap_form /bin/bash
@@ -118,6 +131,8 @@ export BUNDLER_GEMFILE=../gemfiles/6.1.gemfile
 rails db:setup
 rails s -b 0.0.0.0
 ```
+
+To use other supported versions of Rails, change the `export BUNDLER_GEMFILE...` line to another gem file.
 
 ## Documentation Contributions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,16 +112,11 @@ You can run tests in the container as normal, with `rake test`.
 To run the demo app, set up the database and run the server:
 
 ```bash
-cd demo
 docker run --volume "$PWD:/app" --user $UID:`grep ^$USERNAME /etc/passwd | cut -d: -f4` -p 3000:3000 -it bootstrap_form /bin/bash
+cd demo
+export BUNDLER_GEMFILE=../gemfiles/6.1.gemfile
 rails db:setup
 rails s -b 0.0.0.0
-```
-
-Once the database is set up, you can run the server as a one-liner:
-
-```bash
-docker run --volume "$PWD:/app" --user $UID:`grep ^$USERNAME /etc/passwd | cut -d: -f4` -p 3000:3000 -it bootstrap_form rails s -b 0.0.0.0
 ```
 
 ## Documentation Contributions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ You may find the demo application useful for development and debugging.
 ### 7. Done!
 
 Somebody will shortly review your pull request and if everything is good, it will be
-merged into the master branch. Eventually the gem will be published with your changes.
+merged into the main branch. Eventually the gem will be published with your changes.
 
 ### Coding guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ If you want to use a different Ruby version, or a smaller Linux distribution (al
 docker build --build-arg "RUBY_VERSION=2.7" --build-arg "DISTRO=slim-buster" --tag bootstrap_form .
 ```
 
-Then run whichever container you built with the shell to create the bundle:
+Then run the container you built with the shell, and create the bundle:
 
 ```bash
 docker run --volume "$PWD:/app" --user $UID:`grep ^$USERNAME /etc/passwd | cut -d: -f4` -it bootstrap_form /bin/bash
@@ -108,6 +108,21 @@ bundle install
 You can run tests in the container as normal, with `rake test`.
 
 (Some of that command line is need for Linux hosts, to run the container as the current user.)
+
+To run the demo app, set up the database and run the server:
+
+```bash
+cd demo
+docker run --volume "$PWD:/app" --user $UID:`grep ^$USERNAME /etc/passwd | cut -d: -f4` -p 3000:3000 -it bootstrap_form /bin/bash
+rails db:setup
+rails s -b 0.0.0.0
+```
+
+Once the database is set up, you can run the server as a one-liner:
+
+```bash
+docker run --volume "$PWD:/app" --user $UID:`grep ^$USERNAME /etc/passwd | cut -d: -f4` -p 3000:3000 -it bootstrap_form rails s -b 0.0.0.0
+```
 
 ## Documentation Contributions
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN (echo 'docker'; echo 'docker') | passwd root
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt update -y -q && \
-    apt install -y -q yarn
+    apt install -y -q yarn sqlite3
 
 # Ruby now comes with bundler, but we're not using the default version yet, because we were using
 # a newer version of bundler already. Ruby 3 comes with Bundler 2.2.3. Ruby 2.7 has Bundler 2.1.2,

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a new take on the `bootstrap_form` README. Please leave comments at: #52
 
 # bootstrap_form
 
-[![Build Status](https://travis-ci.org/bootstrap-ruby/bootstrap_form.svg?branch=master)](https://travis-ci.org/bootstrap-ruby/bootstrap_form)
+[![Build Status](https://travis-ci.org/bootstrap-ruby/bootstrap_form.svg?branch=main)](https://travis-ci.org/bootstrap-ruby/bootstrap_form)
 [![Gem Version](https://badge.fury.io/rb/bootstrap_form.svg)](https://rubygems.org/gems/bootstrap_form)
 
 `bootstrap_form` is a Rails form builder that makes it super easy to integrate Bootstrap v4-style forms into your Rails application. It provides form helpers that augment the Rails form helpers. `bootstrap_forms`'s form helpers generate the form field and its label and all the Bootstrap mark-up required for proper Bootstrap display. `bootstrap_form` also provides:
@@ -159,7 +159,7 @@ The current configuration options are:
 
 | Option | Default value | Description |
 |---------------------------|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `default_form_attributes` | `{role: "form"}` | version [2.2.0](https://github.com/bootstrap-ruby/bootstrap_form/blob/master/CHANGELOG.md#220-2014-09-16) added a role="form" attribute to all forms.   The W3C validator will raise a **warning** on forms with a role="form" attribute.   Set this option to `{}` to make forms be W3C compliant. |
+| `default_form_attributes` | `{role: "form"}` | version [2.2.0](https://github.com/bootstrap-ruby/bootstrap_form/blob/main/CHANGELOG.md#220-2014-09-16) added a role="form" attribute to all forms.   The W3C validator will raise a **warning** on forms with a role="form" attribute.   Set this option to `{}` to make forms be W3C compliant. |
 
 
 Example:

--- a/demo/app/assets/config/manifest.js
+++ b/demo/app/assets/config/manifest.js
@@ -1,2 +1,1 @@
-//= link_tree ../images
-//= link_directory ../stylesheets .css
+//= link application.css

--- a/demo/db/schema.rb
+++ b/demo/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.


### PR DESCRIPTION
The demo app was no longer easy to run. This PR documents how to run it, and fixes the `Dockerfile` for those using it to run the demo app.