### PR TITLE
Fix Rails Edge tests

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -2,9 +2,7 @@ name: Ruby
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   Lint:

--- a/Dangerfile
+++ b/Dangerfile
@@ -44,7 +44,7 @@ end
 # ------------------------------------------------------------------------------
 # Did you remove the CHANGELOG's "Your contribution here!" line?
 # ------------------------------------------------------------------------------
-if has_changelog_changes && IO.read("CHANGELOG.md").scan(/^\s*[-*] Your contribution here/i).count < 3
+if has_changelog_changes && File.read("CHANGELOG.md").scan(/^\s*[-*] Your contribution here/i).count < 3
   raise(
     "Please put the `- Your contribution here!` line back into CHANGELOG.md.",
     sticky: false

--- a/Gemfile
+++ b/Gemfile
@@ -21,5 +21,6 @@ group :test do
   gem "diffy"
   gem "equivalent-xml"
   gem "mocha"
+  gem "sassc-rails"
   gem "sqlite3"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec path: __dir__
 # gem "rails", "~> 5.2.0"
 # gem "rails", "~> 6.0.0"
 # gem "rails", "~> 6.1.0"
-# gem "rails", git: "https://github.com/rails/rails.git"
+# gem "rails", git: "https://github.com/rails/rails.git", branch: "main"
 
 group :development do
   gem "chandler", ">= 0.7.0"

--- a/bootstrap_form.gemspec
+++ b/bootstrap_form.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.description = "bootstrap_form is a rails form builder that makes it super "\
                   "easy to create beautiful-looking forms using Bootstrap 5"
   s.license     = "MIT"
+  s.metadata    = { "rubygems_mfa_required" => "true" }
 
   s.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test)/})

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -8,7 +8,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "check_box is wrapped correctly" do
     expected = <<~HTML
       <div class="form-check">
-        <input name="user[terms]" type="hidden" value="0" />
+        <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+          name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
         <label class="form-check-label" for="user_terms">
           I agree to the terms
@@ -21,7 +22,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "check_box empty label" do
     expected = <<~HTML
       <div class="form-check">
-        <input name="user[terms]" type="hidden" value="0" />
+        <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+          name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
         <label class="form-check-label" for="user_terms">&#8203;</label>
       </div>
@@ -33,7 +35,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "disabled check_box has proper wrapper classes" do
     expected = <<~HTML
       <div class="form-check">
-        <input name="user[terms]" type="hidden" value="0" disabled="disabled" />
+        <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+          name="user[terms]" type="hidden" value="0" disabled="disabled" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" disabled="disabled" />
         <label class="form-check-label" for="user_terms">
           I agree to the terms
@@ -46,7 +49,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "check_box label allows html" do
     expected = <<~HTML
       <div class="form-check">
-        <input name="user[terms]" type="hidden" value="0" />
+        <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+          name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
         <label class="form-check-label" for="user_terms">
           I agree to the <a href="#">terms</a>
@@ -59,7 +63,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "check_box accepts a block to define the label" do
     expected = <<~HTML
       <div class="form-check">
-        <input name="user[terms]" type="hidden" value="0" />
+        <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+          name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
         <label class="form-check-label" for="user_terms">
           I agree to the terms
@@ -72,7 +77,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "check_box accepts a custom label class" do
     expected = <<~HTML
       <div class="form-check">
-        <input name="user[terms]" type="hidden" value="0" />
+        <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+          name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
         <label class="form-check-label btn" for="user_terms">
           Terms
@@ -85,7 +91,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "check_box 'id' attribute is used to specify label 'for' attribute" do
     expected = <<~HTML
       <div class="form-check">
-        <input name="user[terms]" type="hidden" value="0" />
+        <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+          name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="custom_id" name="user[terms]" type="checkbox" value="1" />
         <label class="form-check-label" for="custom_id">
           Terms
@@ -98,7 +105,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "check_box responds to checked_value and unchecked_value arguments" do
     expected = <<~HTML
       <div class="form-check">
-        <input name="user[terms]" type="hidden" value="no" />
+        <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+          name="user[terms]" type="hidden" value="no" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="yes" />
         <label class="form-check-label" for="user_terms">
           I agree to the terms
@@ -111,7 +119,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "inline checkboxes" do
     expected = <<~HTML
       <div class="form-check form-check-inline">
-        <input name="user[terms]" type="hidden" value="0" />
+        <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+          name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
         <label class="form-check-label" for="user_terms">
           I agree to the terms
@@ -126,7 +135,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user col-auto g-3" id="new_user" method="post">
       #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-check form-check-inline">
-          <input name="user[terms]" type="hidden" value="0" />
+          <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+            name="user[terms]" type="hidden" value="0" />
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_terms">
             I agree to the terms
@@ -143,7 +153,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "disabled inline check_box" do
     expected = <<~HTML
       <div class="form-check form-check-inline">
-        <input name="user[terms]" type="hidden" value="0" disabled="disabled" />
+        <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+          name="user[terms]" type="hidden" value="0" disabled="disabled" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" disabled="disabled" />
         <label class="form-check-label" for="user_terms">
           I agree to the terms
@@ -157,7 +168,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "inline checkboxes with custom label class" do
     expected = <<~HTML
       <div class="form-check form-check-inline">
-        <input name="user[terms]" type="hidden" value="0" />
+        <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+          name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
         <label class="form-check-label btn" for="user_terms">
           Terms
@@ -170,7 +182,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders the form_group correctly" do
     collection = [Address.new(id: 1, street: "Foobar")]
     expected = <<~HTML
-      <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+        id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">This is a checkbox collection</label>
         <div class="form-check">
@@ -188,7 +201,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders multiple checkboxes correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<~HTML
-      <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+        id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -213,7 +227,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
     struct = Struct.new(:id, :name)
     collection = [struct.new(1, "Foo"), struct.new("二", "Bar")]
     expected = <<~HTML
-      <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+        id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -237,7 +252,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders inline checkboxes correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<~HTML
-      <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+        id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check form-check-inline">
@@ -262,7 +278,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders with checked option correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<~HTML
-      <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+        id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -289,7 +306,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders with multiple checked options correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<~HTML
-      <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+        id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -312,7 +330,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes sanitizes values when generating label `for`" do
     collection = [Address.new(id: 1, street: "Foo St")]
     expected = <<~HTML
-      <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+        id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -329,7 +348,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders multiple checkboxes with labels defined by Proc :text_method correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<~HTML
-      <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+        id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -353,7 +373,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders multiple checkboxes with values defined by Proc :value_method correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<~HTML
-      <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+        id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -377,7 +398,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders multiple checkboxes with labels defined by lambda :text_method correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<~HTML
-      <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+        id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -401,7 +423,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders multiple checkboxes with values defined by lambda :value_method correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<~HTML
-      <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+        id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -426,7 +449,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders with checked option correctly with Proc :value_method" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<~HTML
-      <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+        id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -453,7 +477,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders with multiple checked options correctly with lambda :value_method" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<~HTML
-      <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+        id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -480,7 +505,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "check_box skip label" do
     expected = <<~HTML
       <div class="form-check">
-        <input name="user[terms]" type="hidden" value="0" />
+        <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+          name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input position-static" id="user_terms" name="user[terms]" type="checkbox" value="1" />
       </div>
     HTML
@@ -490,7 +516,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "check_box hide label" do
     expected = <<~HTML
       <div class="form-check">
-        <input name="user[terms]" type="hidden" value="0" />
+        <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+          name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input position-static" id="user_terms" name="user[terms]" type="checkbox" value="1" />
         <label class="form-check-label sr-only" for="user_terms">I agree to the terms</label>
       </div>
@@ -505,7 +532,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+        <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+          id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="form-check">
@@ -534,7 +562,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+        <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+          id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="form-check">
@@ -562,7 +591,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-check">
-          <input name="user[terms]" type="hidden" value="0" />
+          <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+            name="user[terms]" type="hidden" value="0" />
           <input class="form-check-input is-invalid" id="user_terms" name="user[terms]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_terms">
             I agree to the terms
@@ -580,7 +610,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "check box with custom wrapper class" do
     expected = <<~HTML
       <div class="form-check custom-class">
-        <input name="user[terms]" type="hidden" value="0" />
+        <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+          name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
         <label class="form-check-label" for="user_terms">
           I agree to the terms
@@ -593,7 +624,8 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "inline check box with custom wrapper class" do
     expected = <<~HTML
       <div class="form-check form-check-inline custom-class">
-        <input name="user[terms]" type="hidden" value="0" />
+        <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+          name="user[terms]" type="hidden" value="0" />
         <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
         <label class="form-check-label" for="user_terms">
           I agree to the terms

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -103,7 +103,10 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "hidden fields are supported" do
-    expected = '<input id="user_misc" name="user[misc]" type="hidden" />'
+    expected = <<~HTML
+      <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+        id="user_misc" name="user[misc]" type="hidden" />
+    HTML
     assert_equivalent_xml expected, @builder.hidden_field(:misc)
   end
 
@@ -259,7 +262,8 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "check_box fields are wrapped correctly" do
     expected = <<~HTML
       <div class="form-check">
-        <input name="user[misc]" type="hidden" value="0"/>
+        <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+          name="user[misc]" type="hidden" value="0"/>
         <input class="form-check-input" id="user_misc" name="user[misc]" type="checkbox" value="1"/>
         <label class="form-check-label" for="user_misc">Misc</label>
       </div>
@@ -270,7 +274,8 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "switch-style check_box fields are wrapped correctly" do
     expected = <<~HTML
       <div class="form-check form-switch">
-        <input name="user[misc]" type="hidden" value="0"/>
+        <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+          name="user[misc]" type="hidden" value="0"/>
         <input class="form-check-input" id="user_misc" name="user[misc]" type="checkbox" value="1"/>
         <label class="form-check-label" for="user_misc">Misc</label>
       </div>

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -25,7 +25,8 @@ class BootstrapFormTest < ActionView::TestCase
           </div>
         </div>
         <div class="form-check">
-          <input name="user[terms]" type="hidden" value="0" />
+          <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+            name="user[terms]" type="hidden" value="0" />
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_terms">I agree to the terms</label>
         </div>
@@ -75,7 +76,8 @@ class BootstrapFormTest < ActionView::TestCase
           <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
         </div>
         <div class="form-check form-check-inline">
-          <input name="user[terms]" type="hidden" value="0" />
+          <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+            name="user[terms]" type="hidden" value="0" />
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_terms">I agree to the terms</label>
         </div>
@@ -137,7 +139,8 @@ class BootstrapFormTest < ActionView::TestCase
           <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
         </div>
         <div class="form-check form-check-inline">
-          <input name="user[terms]" type="hidden" value="0" />
+          <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+            name="user[terms]" type="hidden" value="0" />
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_terms">I agree to the terms</label>
         </div>
@@ -184,7 +187,8 @@ class BootstrapFormTest < ActionView::TestCase
           </div>
         </div>
         <div class="form-check">
-          <input name="user[terms]" type="hidden" value="0" />
+          <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+            name="user[terms]" type="hidden" value="0" />
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_terms">I agree to the terms</label>
         </div>
@@ -233,7 +237,8 @@ class BootstrapFormTest < ActionView::TestCase
           <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
         </div>
         <div class="form-check">
-          <input name="user[terms]" type="hidden" value="0" />
+          <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+            name="user[terms]" type="hidden" value="0" />
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_terms">I agree to the terms</label>
         </div>
@@ -279,7 +284,8 @@ class BootstrapFormTest < ActionView::TestCase
           <input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
         </div>
         <div class="form-check form-check-inline">
-          <input name="user[terms]" type="hidden" value="0" />
+          <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+            name="user[terms]" type="hidden" value="0" />
           <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_terms">I agree to the terms</label>
         </div>
@@ -414,7 +420,8 @@ class BootstrapFormTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-check">
           <input class="form-check-input" id="#{id}" name="#{name}" type="checkbox" value="1" />
-          <input name="#{name}" type="hidden" value="0" />
+          <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+            name="#{name}" type="hidden" value="0" />
           <label class="form-check-label" for="#{id}"> Misc</label>
         </div>
       </form>

--- a/test/bootstrap_rich_text_area_test.rb
+++ b/test/bootstrap_rich_text_area_test.rb
@@ -1,4 +1,5 @@
 require_relative "./test_helper"
+require "minitest/mock"
 
 if ::Rails::VERSION::STRING > "6"
   class BootstrapRichTextAreaTest < ActionView::TestCase
@@ -8,18 +9,39 @@ if ::Rails::VERSION::STRING > "6"
     setup :setup_test_fixture
 
     test "rich text areas are wrapped correctly" do
-      expected = <<~HTML
-        <div class="mb-3">
-          <label class="form-label" for="user_life_story">Life story</label>
-          <input type="hidden" name="user[life_story]" id="user_life_story_trix_input_user"/>
+      with_stub_token do
+        expected = <<~HTML
+          <div class="mb-3">
+            <label class="form-label" for="user_life_story">Life story</label>
+            <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+              type="hidden" name="user[life_story]" id="user_life_story_trix_input_user"/>
+            #{trix_editor_html}
+          </div>
+        HTML
+        assert_equivalent_xml expected, form_with_builder.rich_text_area(:life_story)
+      end
+    end
+
+    def trix_editor_html
+      if ::Rails::VERSION::STRING >= "7"
+        <<~HTML
+          <trix-editor class="trix-content form-control" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename" data-direct-upload-attachment-name="ActionText::RichText#embeds" data-direct-upload-token="token" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" id="user_life_story" input="user_life_story_trix_input_user"/>
+        HTML
+      else
+        <<~HTML
           <trix-editor id="user_life_story" data-blob-url-template="#{data_blob_url_template}" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" input="user_life_story_trix_input_user" class="trix-content form-control" />
-        </div>
-      HTML
-      assert_equivalent_xml expected, form_with_builder.rich_text_area(:life_story)
+        HTML
+      end
     end
 
     def data_blob_url_template
       "http://test.host/rails/active_storage/blobs/#{'redirect/' if ::Rails::VERSION::STRING >= '6.1'}:signed_id/:filename"
+    end
+
+    def with_stub_token(&block)
+      return if ::Rails::VERSION::STRING < "7"
+
+      ActiveStorage::DirectUploadToken.stub(:generate_direct_upload_token, "token", &block)
     end
   end
 end

--- a/test/bootstrap_rich_text_area_test.rb
+++ b/test/bootstrap_rich_text_area_test.rb
@@ -9,28 +9,26 @@ if ::Rails::VERSION::STRING > "6"
     setup :setup_test_fixture
 
     test "rich text areas are wrapped correctly" do
-      with_stub_token do
+      if ::Rails::VERSION::STRING >= "7"
+        with_stub_token do
+          expected = <<~HTML
+            <div class="mb-3">
+              <label class="form-label" for="user_life_story">Life story</label>
+              <input autocomplete="off" type="hidden" name="user[life_story]" id="user_life_story_trix_input_user"/>
+              <trix-editor class="trix-content form-control" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename" data-direct-upload-attachment-name="ActionText::RichText#embeds" data-direct-upload-token="token" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" id="user_life_story" input="user_life_story_trix_input_user"/>
+            </div>
+          HTML
+          assert_equivalent_xml expected, form_with_builder.rich_text_area(:life_story)
+        end
+      else
         expected = <<~HTML
           <div class="mb-3">
             <label class="form-label" for="user_life_story">Life story</label>
-            <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
-              type="hidden" name="user[life_story]" id="user_life_story_trix_input_user"/>
-            #{trix_editor_html}
+            <input type="hidden" name="user[life_story]" id="user_life_story_trix_input_user"/>
+            <trix-editor id="user_life_story" data-blob-url-template="#{data_blob_url_template}" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" input="user_life_story_trix_input_user" class="trix-content form-control" />
           </div>
         HTML
         assert_equivalent_xml expected, form_with_builder.rich_text_area(:life_story)
-      end
-    end
-
-    def trix_editor_html
-      if ::Rails::VERSION::STRING >= "7"
-        <<~HTML
-          <trix-editor class="trix-content form-control" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename" data-direct-upload-attachment-name="ActionText::RichText#embeds" data-direct-upload-token="token" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" id="user_life_story" input="user_life_story_trix_input_user"/>
-        HTML
-      else
-        <<~HTML
-          <trix-editor id="user_life_story" data-blob-url-template="#{data_blob_url_template}" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" input="user_life_story_trix_input_user" class="trix-content form-control" />
-        HTML
       end
     end
 
@@ -39,8 +37,6 @@ if ::Rails::VERSION::STRING > "6"
     end
 
     def with_stub_token(&block)
-      return if ::Rails::VERSION::STRING < "7"
-
       ActiveStorage::DirectUploadToken.stub(:generate_direct_upload_token, "token", &block)
     end
   end

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -448,9 +448,12 @@ class BootstrapSelectsTest < ActionView::TestCase
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-time-select">
-            <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="2012" />
-            <input id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="2" />
-            <input id="user_misc_3i" name="user[misc(3i)]" type="hidden" value="3" />
+            <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+              id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="2012" />
+            <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+              id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="2" />
+            <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+              id="user_misc_3i" name="user[misc(3i)]" type="hidden" value="3" />
             <select class="form-select" id="user_misc_4i" name="user[misc(4i)]">
               #{options_range(start: '00', stop: '23', selected: '12')}
             </select>
@@ -474,9 +477,12 @@ class BootstrapSelectsTest < ActionView::TestCase
           <div class="mb-3">
             <label class="form-label" for="user_misc">Misc</label>
             <div class="rails-bootstrap-forms-time-select">
-              <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="2012" />
-              <input id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="2" />
-              <input id="user_misc_3i" name="user[misc(3i)]" type="hidden" value="3" />
+              <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+                id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="2012" />
+              <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+                id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="2" />
+              <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+                id="user_misc_3i" name="user[misc(3i)]" type="hidden" value="3" />
               <select class="form-select is-invalid" id="user_misc_4i" name="user[misc(4i)]">
                 #{options_range(start: '00', stop: '23', selected: '12')}
               </select>
@@ -499,9 +505,12 @@ class BootstrapSelectsTest < ActionView::TestCase
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-time-select">
-            <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="1" />
-            <input id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="1" />
-            <input id="user_misc_3i" name="user[misc(3i)]" type="hidden" value="1" />
+            <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+              id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="1" />
+            <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+              id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="1" />
+            <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+              id="user_misc_3i" name="user[misc(3i)]" type="hidden" value="1" />
             <select class="form-select" id="user_misc_4i" name="user[misc(4i)]">
               #{blank_option}
               #{options_range(start: '00', stop: '23')}
@@ -524,9 +533,12 @@ class BootstrapSelectsTest < ActionView::TestCase
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-time-select">
-            <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="1" />
-            <input id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="1" />
-            <input id="user_misc_3i" name="user[misc(3i)]" type="hidden" value="1" />
+            <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+              id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="1" />
+            <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+              id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="1" />
+            <input #{'autocomplete="off"' if ::Rails::VERSION::STRING >= '7'}
+              id="user_misc_3i" name="user[misc(3i)]" type="hidden" value="1" />
             <select class="form-select my-time-select" id="user_misc_4i" name="user[misc(4i)]">
               #{blank_option}
               #{options_range(start: '00', stop: '23')}


### PR DESCRIPTION
Tests would no longer even start to run because `Rails.application.config.assets` was not available to set in `demo/config/initializers/assets.rb`. Adding gem `sassc-rails` makes the part of config available again.

Next rendering changed for hidden fields ('autocomplete="off"' was added) and rich text area.

Additionally a few Rubocop offences have been removed.

Fixes #609.