### PR TITLE
Allow overriding the wrapper class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Breaking changes
 
+* [#618](https://github.com/bootstrap-ruby/bootstrap_form/pull/618): Allow overriding the wrapper class - [@donv](https://github.com/donv).
 * Your contribution here!
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -314,10 +314,10 @@ To add a class to the input group wrapper, use the `:input_group_class` option.
 
 Bootstrap mark-up dictates that most input field types have the label and input wrapped in a `div.mb-3`.
 
-If you want to add an additional CSS class or any other attribute to the form group div, you can use the `wrapper: { class: 'additional-class', data: { foo: 'bar' } }` option.
+If you want to change the CSS class or any other attribute to the form group div, you can use the `wrapper: { class: 'mb-3 additional-class', data: { foo: 'bar' } }` option.
 
 ```erb
-<%= f.text_field :name, wrapper: { class: 'has-warning', data: { foo: 'bar' } } %>
+<%= f.text_field :name, wrapper: { class: 'mb-3 has-warning', data: { foo: 'bar' } } %>
 ```
 
 Which produces the following output:
@@ -329,7 +329,10 @@ Which produces the following output:
 </div>
 ```
 
-If you only want to set the class on the form group div, you can use the `wrapper_class` option. It's just a short form of `wrapper: { class: 'additional-class' }`.
+If you only want to set the class on the form group div, you can use the `wrapper_class` option: `wrapper_class: 'mb-3 additional-class''`.
+It's just a short form of `wrapper: { class: 'mb-3 additional-class' }`.
+
+If you don't want any class on the form group div, you can set it to `false`: `wrapper_class: false`.
 
 ### Suppressing the Form Group Altogether
 

--- a/lib/bootstrap_form/form_group.rb
+++ b/lib/bootstrap_form/form_group.rb
@@ -52,12 +52,12 @@ module BootstrapForm
     end
 
     def form_group_classes(options)
-      classes = ["mb-3", options[:class].try(:split)].flatten.compact
+      classes = (options[:class] == false) ? [] : (options[:class] || "mb-3").split
       classes << "row" if horizontal_group_with_gutters?(options[:layout], classes)
       classes << "col-auto g-3" if field_inline_override?(options[:layout])
       classes << feedback_class if options[:icon]
       classes << "form-floating" if options[:floating]
-      classes
+      classes.presence
     end
 
     def horizontal_group_with_gutters?(layout, classes)

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -225,8 +225,8 @@ class BootstrapFieldsTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, @horizontal_builder.text_field(:email, wrapper_class: "g-3")
-    assert_equivalent_xml expected, @horizontal_builder.text_field(:email, wrapper: { class: "g-3" })
+    assert_equivalent_xml expected, @horizontal_builder.text_field(:email, wrapper_class: "mb-3 g-3")
+    assert_equivalent_xml expected, @horizontal_builder.text_field(:email, wrapper: { class: "mb-3 g-3" })
   end
 
   test "field 'id' attribute is used to specify label 'for' attribute" do

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -326,7 +326,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "form_group accepts class thorugh options hash" do
-    output = @horizontal_builder.form_group :email, class: "foo" do
+    output = @horizontal_builder.form_group :email, class: "mb-3 foo" do
       '<input class="form-control-plaintext" value="Bar">'.html_safe
     end
 
@@ -341,7 +341,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "form_group accepts class thorugh options hash without needing a name" do
-    output = @horizontal_builder.form_group class: "foo" do
+    output = @horizontal_builder.form_group class: "mb-3 foo" do
       '<input class="form-control-plaintext" value="Bar">'.html_safe
     end
 
@@ -356,7 +356,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "form_group horizontal lets caller override .row" do
-    output = @horizontal_builder.form_group class: "g-3" do
+    output = @horizontal_builder.form_group class: "mb-3 g-3" do
       '<input class="form-control-plaintext" value="Bar">'.html_safe
     end
 
@@ -442,9 +442,9 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equivalent_xml expected, output
   end
 
-  test "adds class to wrapped form_group by a field" do
+  test "overrides the class of the wrapped form_group by a field" do
     expected = <<~HTML
-      <div class="mb-3 none-margin">
+      <div class="none-margin">
         <label class="form-label" for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="search" />
       </div>
@@ -452,12 +452,12 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.search_field(:misc, wrapper_class: "none-margin")
   end
 
-  test "adds class to wrapped form_group by a field with errors" do
+  test "overrides the class of the wrapped form_group by a field with errors" do
     @user.email = nil
     assert @user.invalid?
 
     expected = <<~HTML
-      <div class="mb-3 none-margin">
+      <div class="none-margin">
         <div class="field_with_errors">
           <label class="form-label required" for="user_email">Email</label>
         </div>
@@ -470,7 +470,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.email_field(:email, wrapper_class: "none-margin")
   end
 
-  test "adds class to wrapped form_group by a field with errors when bootstrap_form_for is used" do
+  test "overrides the class of the wrapped form_group by a field with errors when bootstrap_form_for is used" do
     @user.email = nil
     assert @user.invalid?
 
@@ -481,7 +481,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <div class="mb-3 none-margin">
+        <div class="none-margin">
           <label class="form-label required" for="user_email">Email</label>
           <input class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
@@ -556,6 +556,16 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "rendering without wrapper" do
     expected = '<input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />'
     assert_equivalent_xml expected, @builder.text_field(:email, wrapper: false)
+  end
+
+  test "rendering without wrapper class" do
+    expected = <<~HTML
+      <div>
+        <label class="form-label" for="user_misc">Misc</label>
+        <input class="form-control" id="user_misc" name="user[misc]" type="search" />
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.search_field(:misc, wrapper: { class: false })
   end
 
   test "passing options to a form control get passed through" do

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -26,7 +26,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "time zone selects are wrapped correctly with wrapper" do
     expected = <<~HTML
-      <div class="mb-3 none-margin">
+      <div class="none-margin">
         <label class="form-label" for="user_misc">Misc</label>
         <select class="form-select" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
       </div>
@@ -181,7 +181,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "collection_selects are wrapped correctly with wrapper" do
     expected = <<~HTML
-      <div class="mb-3 none-margin">
+      <div class="none-margin">
         <label class="form-label" for="user_status">Status</label>
         <select class="form-select" id="user_status" name="user[status]"></select>
       </div>
@@ -241,7 +241,7 @@ class BootstrapSelectsTest < ActionView::TestCase
 
   test "grouped_collection_selects are wrapped correctly with wrapper" do
     expected = <<~HTML
-      <div class="mb-3 none-margin">
+      <div class="none-margin">
         <label class="form-label" for="user_status">Status</label>
         <select class="form-select" id="user_status" name="user[status]"></select>
       </div>
@@ -318,7 +318,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "date selects are wrapped correctly with wrapper class" do
     travel_to(Time.utc(2012, 2, 3)) do
       expected = <<~HTML
-        <div class="mb-3 none-margin">
+        <div class="none-margin">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
             <select class="form-select" id="user_misc_1i" name="user[misc(1i)]">
@@ -705,7 +705,7 @@ class BootstrapSelectsTest < ActionView::TestCase
                                           [["Apple", 1], ["Grape", 2]],
                                           {
                                             label: "Choose your favorite fruit:",
-                                            wrapper: { class: "has-warning", data: { foo: "bar" } }
+                                            wrapper: { class: "mb-3 has-warning", data: { foo: "bar" } }
                                           },
                                           class: "selectpicker")
   end


### PR DESCRIPTION
The wrapper now has a `mb-3` class by default which is correct by the Bootstrap 5 migration guide and documentation.  👍 

However, when you want to remove the bottom margin like some of the tests do, there should be a way to omit the `mb-3` class.  I think `wrapper_class: false`  should do this, so I'll add it to this PR.

Then, when you add classes, you should be able to add them to a clean slate.  That means that you need to include the `mb-3` class if you want it.

What do you think?