### PR TITLE
Don't commit lockfiles or bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ demo/tmp/
 *.swp
 Gemfile.lock
 test/gemfiles/*.lock
+gemfiles/*.lock
 .ruby-version
 Vagrantfile
 .vagrant
@@ -31,6 +32,7 @@ demo/node_modules
 demo/yarn-error.log
 demo/yarn-debug.log*
 demo/.yarn-integrity
+demo/vendor/bundle
 
 # For stuff that gets created if using the Dockerfile image
 .bundle/


### PR DESCRIPTION
Add the various permutations of `gemfiles/x.y.gemfile.lock` to `.gitignore`. Perhaps when the test app got moved from `test/dummy` this wasn't updated.

Also don't check in whatever might be in the demo app's `vendor/bundle`. Some ways of using Docker might create the bundle in this location.