### PR TITLE
Rails 7.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ gemfiles/*.lock
 .ruby-version
 Vagrantfile
 .vagrant
+.yarnrc
 
 # For the demo app.
 
@@ -47,3 +48,4 @@ vendor/bundle
 .bash_history
 # For Alpine images
 .ash_history
+.sqlite_history

--- a/gemfiles/7.0.gemfile
+++ b/gemfiles/7.0.gemfile
@@ -1,4 +1,5 @@
 gems = "#{File.dirname __dir__}/Gemfile"
 eval File.read(gems), binding, gems # rubocop: disable Security/Eval
 
-gem "rails", github: "rails/rails", branch: "7-0-stable"
+# 7.0.0 has an issue with Ruby 3.1.
+gem "rails", "~> 7.0.1"


### PR DESCRIPTION
CI has been failing due to an issue between Rails 7.0.0 and Ruby 3.1. Rails 7.0.1 fixes it.