### PR TITLE
Enable include hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#572](https://github.com/bootstrap-ruby/bootstrap_form/issues/572): Simplify the formatting of the file upload control to follow the new Bootstrap 5 styles
 * [#573](https://github.com/bootstrap-ruby/bootstrap_form/issues/573): Add support for Bootstrap 5's floating labels
 
+* [#215](https://github.com/bootstrap-ruby/bootstrap_form/issues/215): Add `include_hidden` option to `check_box`
 ### Bugfixes
 
 * [#582](https://github.com/bootstrap-ruby/bootstrap_form/issues/582): Fix tests in bootstrap-5 branch, removes Rubocop offenses, and adds testing with Rails 6.1.

--- a/lib/bootstrap_form/inputs/collection_check_boxes.rb
+++ b/lib/bootstrap_form/inputs/collection_check_boxes.rb
@@ -13,7 +13,9 @@ module BootstrapForm
             options[:multiple] = true
             check_box(name, options, value, nil)
           end
-          hidden_field(args.first, value: "", multiple: true).concat(html)
+  
+          include_hidden = args.extract_options!.symbolize_keys!.delete(:include_hidden) { true }
+          include_hidden ? hidden_field(args.first, value: "", multiple: true).concat(html) : html
         end
 
         bootstrap_alias :collection_check_boxes

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -502,6 +502,25 @@ class BootstrapCheckboxTest < ActionView::TestCase
                                                                     :street, checked: collection)
   end
 
+  test "collection_check_boxes renders with include_hidden options correctly" do
+    collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
+    expected = <<~HTML
+      <div class="mb-3">
+        <label class="form-label" for="user_misc">Misc</label>
+        <div class="form-check">
+          <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
+          <label class="form-check-label" for="user_misc_1">Foo</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
+          <label class="form-check-label" for="user_misc_2">Bar</label>
+        </div>
+      </div>
+    HTML
+
+    assert_equivalent_xml expected, @builder.collection_check_boxes(:misc, collection, :id, :street, include_hidden: false)
+  end
+
   test "check_box skip label" do
     expected = <<~HTML
       <div class="form-check">


### PR DESCRIPTION
Fixes https://github.com/bootstrap-ruby/bootstrap_form/issues/215

Enable include_hidden option with collection_check_boxes:
