### PR TITLE
Fix text alignment in alert message when there is no error summary

### DIFF
--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -27,8 +27,12 @@ module BootstrapForm
         return unless object.respond_to?(:errors) && object.errors.full_messages.any?
 
         tag.div class: css do
-          concat tag.p title
-          concat error_summary unless options[:error_summary] == false
+          if options[:error_summary] == false
+            title
+          else
+            concat tag.p title
+            concat error_summary
+          end
         end
       end
 


### PR DESCRIPTION
When there is no error summary the alert message is wrapped in a p tag. This causes the message to be misaligned vertically. In the Bootstrap examples where there is single line of text, the text is not wrapped in a p tag: https://getbootstrap.com/docs/5.0/components/alerts/#examples

Screenshots below illustrate the issue.

Before:
<img width="1320" alt="Before" src="https://user-images.githubusercontent.com/2070/151075605-d0951a2b-9a83-4c1e-9a33-9dcd8791ba8c.png">
After:
<img width="1319" alt="After" src="https://user-images.githubusercontent.com/2070/151075599-9f1df821-62bb-4230-a042-58d7b48bba95.png">
