### PR TITLE
Add support for append and prepend on collection_select (fixes #428)

### DIFF
--- a/demo/test/system/bootstrap_test.rb
+++ b/demo/test/system/bootstrap_test.rb
@@ -71,7 +71,7 @@ class BootstrapTest < ApplicationSystemTestCase
         #{html}
       MD
     end
-    augmented_readme.gsub!(/127.0.0.1:\d+/,'test.host')
+    augmented_readme.gsub!(/127.0.0.1:\d+/, "test.host")
     File.write(File.expand_path("../../../README.md", __dir__), augmented_readme)
   end
 

--- a/lib/bootstrap_form/inputs/collection_select.rb
+++ b/lib/bootstrap_form/inputs/collection_select.rb
@@ -12,7 +12,7 @@ module BootstrapForm
         def collection_select_with_bootstrap(method, collection, value_method, text_method, options={}, html_options={})
           html_options = html_options.reverse_merge(control_class: "form-select")
           form_group_builder(method, options, html_options) do
-            input_with_error(method) do
+            prepend_and_append_input(method, options) do
               collection_select_without_bootstrap(method, collection, value_method, text_method, options, html_options)
             end
           end

--- a/lib/bootstrap_form/inputs/grouped_collection_select.rb
+++ b/lib/bootstrap_form/inputs/grouped_collection_select.rb
@@ -14,7 +14,7 @@ module BootstrapForm
                                                      option_value_method, options={}, html_options={})
           html_options = html_options.reverse_merge(control_class: "form-select")
           form_group_builder(method, options, html_options) do
-            input_with_error(method) do
+            prepend_and_append_input(method, options) do
               grouped_collection_select_without_bootstrap(method, collection, group_method,
                                                           group_label_method, option_key_method,
                                                           option_value_method, options, html_options)

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -229,6 +229,24 @@ class BootstrapSelectsTest < ActionView::TestCase
                           @builder.collection_select(:status, [], :id, :name, { prompt: "Please Select" }, class: "my-select")
   end
 
+  test "collection_selects with addons are wrapped correctly" do
+    expected = <<~HTML
+      <div class="mb-3">
+        <label class="form-label" for="user_status">Status</label>
+        <div class="input-group">
+          <span class="input-group-text">Before</span>
+          <select class="form-select" id="user_status" name="user[status]">
+            <option value="">Please Select</option>
+          </select>
+          <span class="input-group-text">After</span>
+        </div>
+      </div>
+    HTML
+    assert_equivalent_xml expected,
+                          @builder.collection_select(:status, [], :id, :name,
+                                                     { prepend: "Before", append: "After", prompt: "Please Select" })
+  end
+
   test "grouped_collection_selects are wrapped correctly" do
     expected = <<~HTML
       <div class="mb-3">

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -311,6 +311,24 @@ class BootstrapSelectsTest < ActionView::TestCase
                                                              class: "my-select")
   end
 
+  test "grouped_collection_selects with addons are wrapped correctly" do
+    expected = <<~HTML
+      <div class="mb-3">
+        <label class="form-label" for="user_status">Status</label>
+        <div class="input-group">
+          <span class="input-group-text">Before</span>
+          <select class="form-select" id="user_status" name="user[status]">
+            <option value="">Please Select</option>
+          </select>
+          <span class="input-group-text">After</span>
+        </div>
+      </div>
+    HTML
+    assert_equivalent_xml expected,
+                          @builder.grouped_collection_select(:status, [], :last, :first, :to_s, :to_s,
+                                                             { prepend: "Before", append: "After", prompt: "Please Select" })
+  end
+
   test "date selects are wrapped correctly" do
     travel_to(Time.utc(2012, 2, 3)) do
       expected = <<~HTML


### PR DESCRIPTION
Hello,
thanks a lot for creating this gem! 
Today I would have needed a `collection_select` with `prepend` and noticed that this does not work yet.
Here's a fix for it. I hope everything's alright and would be happy if it got merged :slightly_smiling_face: 
Best,
Judith