### PR TITLE
Need 7.0.2 for file upload test

### DIFF
--- a/gemfiles/7.0.gemfile
+++ b/gemfiles/7.0.gemfile
@@ -2,4 +2,5 @@ gems = "#{File.dirname __dir__}/Gemfile"
 eval File.read(gems), binding, gems # rubocop: disable Security/Eval
 
 # 7.0.0 has an issue with Ruby 3.1.
-gem "rails", "~> 7.0.1"
+# And a test case has an issue with 7.0.1
+gem "rails", "~> 7.0.2"


### PR DESCRIPTION
I got confused by test failures when all that was missing was the fact that a test for Rails 7 requires 7.0.2 at least.