### PR TITLE
Remove dependecies from gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,15 @@ gemspec path: __dir__
 # gem "rails", "~> 7.0.1"
 # gem "rails", git: "https://github.com/rails/rails.git", branch: "main"
 
+RAILS_VERSION = ENV.fetch("RAILS_VERSION", "7")
+
+group :development, :test do
+  gem "actionmailer", "~> #{RAILS_VERSION}"
+  gem "actionpack", "~> #{RAILS_VERSION}"
+  gem "actiontext", "~> #{RAILS_VERSION}" if RAILS_VERSION > "6"
+  gem "activemodel", "~> #{RAILS_VERSION}"
+end
+
 group :development do
   gem "chandler", ">= 0.7.0"
   gem "htmlbeautifier"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Some other nice things that `bootstrap_form` does for you are:
 
 `bootstrap_form` supports at a minimum the currently supported versions of Ruby and Rails:
 
-* Ruby 2.5+
+* Ruby 2.7+
 * Rails 5.2+
 * Bootstrap 5.0+
 
@@ -38,8 +38,6 @@ gem "bootstrap", "~> 5.0"
 ```
 
 And follow the remaining instructions in the [official bootstrap installation guide](https://github.com/twbs/bootstrap-rubygem#a-ruby-on-rails) for setting up `application.scss` and `application.js`.
-
-You also need to use the SASS preprocessor, so uncomment the following line in your `Gemfile`:
 
 Add the `bootstrap_form` gem to your `Gemfile`:
 
@@ -1085,7 +1083,7 @@ This generates:
       </div>
     </div>
   </div>
-  
+
   <div class="mb-3 row">
     <div class="col-sm-10 offset-sm-2">
       <input class="btn btn-secondary" data-disable-with="Create User" name="commit" type="submit" value="Create User">
@@ -1541,6 +1539,19 @@ or
 label: "<span></span>".html_safe
 ```
 
+### Dependencies
+
+Due to some tricky issues due to the range of Rails versions supported, the gem doesn't specify any dependencies itself. Since most uses of this gem are in a Rails application, the right version of all the dependencies will be loaded by the Rails version in your `Gemfile`.
+
+If you were to use this gem without `rails` in your `Gemfile`, you need to include at least the following components of Rails in your `Gemfile`:
+
+```gemfile
+  gem "actionmailer", ">= #{DESIRED_RAILS_VERSION}"
+  gem "actionpack", ">= #{DESIRED_RAILS_VERSION}"
+  gem "actiontext", ">= #{DESIRED_RAILS_VERSION}" # for Rails version 6 and up.
+  gem "activemodel", ">= #{DESIRED_RAILS_VERSION}"
+```
+
 ## Contributing
 
 We welcome contributions.
@@ -1554,4 +1565,4 @@ If you're looking for `bootstrap_form` for Bootstrap 4, go [here](https://github
 
 ## License
 
-MIT License. Copyright 2012-2021 Stephen Potenza (https://github.com/potenza) and others
+MIT License. Copyright 2012-2022 Stephen Potenza (https://github.com/potenza) and others

--- a/bootstrap_form.gemspec
+++ b/bootstrap_form.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require "bootstrap_form/version"
 
-REQUIRED_RAILS_VERSION = ">= 5.2".freeze
+REQUIRED_RAILS_VERSION = ENV.fetch("REQUIRED_RAILS_VERSION".freeze, "5.2".freeze)
 
 Gem::Specification.new do |s|
   s.name        = "bootstrap_form"
@@ -27,6 +27,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.7"
 
-  s.add_dependency("actionpack", REQUIRED_RAILS_VERSION)
-  s.add_dependency("activemodel", REQUIRED_RAILS_VERSION)
+  s.add_dependency("actionmailer", ">= #{REQUIRED_RAILS_VERSION}")
+  s.add_dependency("actionpack", ">= #{REQUIRED_RAILS_VERSION}")
+  s.add_dependency("actiontext", ">= #{REQUIRED_RAILS_VERSION}") if REQUIRED_RAILS_VERSION >= "6"
+  s.add_dependency("activemodel", ">= #{REQUIRED_RAILS_VERSION}")
 end

--- a/bootstrap_form.gemspec
+++ b/bootstrap_form.gemspec
@@ -3,8 +3,6 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require "bootstrap_form/version"
 
-REQUIRED_RAILS_VERSION = ENV.fetch("REQUIRED_RAILS_VERSION".freeze, "5.2".freeze)
-
 Gem::Specification.new do |s|
   s.name        = "bootstrap_form"
   s.version     = BootstrapForm::VERSION
@@ -26,9 +24,4 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.required_ruby_version = ">= 2.7"
-
-  s.add_dependency("actionmailer", ">= #{REQUIRED_RAILS_VERSION}")
-  s.add_dependency("actionpack", ">= #{REQUIRED_RAILS_VERSION}")
-  s.add_dependency("actiontext", ">= #{REQUIRED_RAILS_VERSION}") if REQUIRED_RAILS_VERSION >= "6"
-  s.add_dependency("activemodel", ">= #{REQUIRED_RAILS_VERSION}")
 end


### PR DESCRIPTION
It's not possible to specify the dependencies in the gemspec. `ActionText` only applies if the Rails version is greater than or equal to 6. This gem doesn't make sense unless it's used with Rails anyway, so there's not much value in having dependencies in the gemspec. 

For simple development and testing, the `Gemfile` in the top-level directory pulls in the minimal components of Rails.
