### PR TITLE
More portable `docker-compose.yml` and better documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,41 @@ The Ruby on Rails support policy is [here](https://guides.rubyonrails.org/mainte
 
 ### Developing with Docker
 
+This repository offers experimental support support for a couple of ways to develop using Docker, if you're interested:
+
+- Using `docker-compose`. This way is less tested, and is an attempt to make the Docker container a more complete environment where you can conveniently develop and release the gem.
+- Using just a simple Dockerfile. This way works for simple testing, but doesn't make it easy to release the gem, among other things.
+
+Docker is _not_ requied to work on this gem.
+
+#### Using `docker-compose`
+
+You can run a shell in a Docker container that pretty much should behave like a Debian distrobution with:
+
+```bash
+docker-compose run shell
+```
+
+Linux users should add a `docker-compose.override.yml` in their local directory, that looks like this:
+
+```docker-compose.yml
+version: '3.3'
+
+services:
+  shell:
+    # You have to set the user and group for this process, because you're going to be
+    # creating all kinds of files from inside the container, that need to persist
+    # outside the container.
+    # Change `1000:1000` to the user and default group of your laptop user.
+    user: 1000:1000
+```
+
+You may have to change the `1000:1000` to the user and group IDs of your laptop. You may also have to change the `version` parameter to match the version of the `docker-compose.yml` file.
+
+If your host is Linux, the `docker-compose` approach should link to enough of your networking configuration that you can release the gem.
+
+#### Simple Dockerfile
+
 This repository includes a `Dockerfile` to build an image with the minimum `bootstrap_form`-supported Ruby environment. To build the image:
 
 ```bash
@@ -98,6 +133,8 @@ bundle install
 You can run tests in the container as normal, with `rake test`.
 
 (Some of that command line is need for Linux hosts, to run the container as the current user.)
+
+One of the disadvantages of this approach is that you can't release the gem from here, because the Docker container doesn't have access to your SSH credentials, or the right user name, or perhaps other things needed to release a gem. But for simple testing, it works.
 
 ### The Demo Application
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,16 +83,22 @@ Docker is _not_ requied to work on this gem.
 
 #### Using `docker-compose`
 
-You can run a shell in a Docker container that pretty much should behave like a Debian distrobution with:
+The `docker-compose` approach should link to enough of your networking configuration that you can release the gem.
+However, you have to do some of the configuration yourself, because it's dependent on your host operating system.
+You can run a shell in a Docker container that pretty much should behave like a Debian distribution with:
 
 ```bash
 docker-compose run shell
 ```
 
-Linux users should add a `docker-compose.override.yml` in their local directory, that looks like this:
+The following instructions work for an Ubuntu host, and will probably work for other commong Linux distributions.
+
+Add a `docker-compose.override.yml` in the local directory, that looks like this:
 
 ```docker-compose.yml
 version: '3.3'
+
+# https://blog.giovannidemizio.eu/2021/05/24/how-to-set-user-and-group-in-docker-compose/
 
 services:
   shell:
@@ -101,11 +107,19 @@ services:
     # outside the container.
     # Change `1000:1000` to the user and default group of your laptop user.
     user: 1000:1000
+    volumes:
+      - /etc/passwd:/etc/passwd:ro
+      - ~/.gem/credentials:/app/.gem/credentials:ro
+      # $HOME here is your host computer's `~`, e.g. `/home/reid`.
+      # `ssh` explicitly looks for its config in the home directory from `/etc/passwd`,
+      # so the target for this has to look like your home directory on the host.
+      - ~/.ssh:${HOME}/.ssh:ro
+      - ${SSH_AUTH_SOCK}:/ssh-agent
 ```
 
 You may have to change the `1000:1000` to the user and group IDs of your laptop. You may also have to change the `version` parameter to match the version of the `docker-compose.yml` file.
 
-If your host is Linux, the `docker-compose` approach should link to enough of your networking configuration that you can release the gem.
+Adapting the above `docker-compose.override.yml` for MacOS should be relatively straight-forward. Windows users, I'm afraid you're on your own.
 
 #### Simple Dockerfile
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,8 @@ services:
       # so the target for this has to look like your home directory on the host.
       - ~/.ssh:${HOME}/.ssh:ro
       - ${SSH_AUTH_SOCK}:/ssh-agent
+    environment:
+      - SSH_AUTH_SOCK=/ssh-agent
 ```
 
 You may have to change the `1000:1000` to the user and group IDs of your laptop. You may also have to change the `version` parameter to match the version of the `docker-compose.yml` file.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       args:
         NODE_MAJOR: '12'
         YARN_VERSION: '1.22.4'
-    image: bootstrap-form:0.0.1
+    image: bootstrap-form:latest
     tmpfs:
       - /tmp
 
@@ -17,15 +17,6 @@ services:
     tty: true
     volumes:
       - .:/app:cached
-      # - rails_cache:/app/tmp/cache
-      # - bundle:/app/vendor/bundle
-      # - node_modules:/app/node_modules
-      # - packs:/app/public/packs
-      - /etc/passwd:/etc/passwd:ro
-      # One or the other of the following lines might be redundant, or one might be
-      # better than the other.
-      - ~/.ssh:${HOME}/.ssh
-      - ${SSH_AUTH_SOCK}:/ssh-agent
     environment:
       - SSH_AUTH_SOCK=/ssh-agent
       - NODE_ENV=development
@@ -35,15 +26,3 @@ services:
       - WEB_CONCURRENCY=1
       - HISTFILE=/app/.bash_history
     command: /bin/bash
-
-  # server:
-  #   <<: *shell
-  #   command: sh -c "cd demo/app && bundle exec rails server -b 0.0.0.0"
-  #   ports:
-  #     - '3000:3000'
-
-# volumes:
-#   bundle:
-#   node_modules:
-#   rails_cache:
-#   packs:


### PR DESCRIPTION
Removed some of the Linux-specific config from `docker-compose.yml`, and improved the documentation showing `docker-compose.override.yml` that exposes the host's credentials in the container, so you can release the gem from within the Docker container.