### PR TITLE
CVE fix breaks serialization of symbols -- fix test

### DIFF
--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -312,11 +312,11 @@ class BootstrapFieldsTest < ActionView::TestCase
   end
 
   test "bootstrap_form_for helper works for serialized hash attributes" do
-    @user.preferences = { favorite_color: "cerulean" }
+    @user.preferences = { "favorite_color" => "cerulean" }
 
     output = bootstrap_form_for(@user) do |f|
       f.fields_for :preferences do |builder|
-        builder.text_field :favorite_color, value: @user.preferences[:favorite_color]
+        builder.text_field :favorite_color, value: @user.preferences["favorite_color"]
       end
     end
 


### PR DESCRIPTION
https://discuss.rubyonrails.org/t/cve-2022-32224-possible-rce-escalation-bug-with-serialized-columns-in-active-record/81017 prevents serialization of a `Symbol` because it's potentially a security vulnerability. This PR changes a test so it serializes and attribute value with a `String` key rather than a `Symbol`.