### PR TITLE
Add Puma and Debuggers to common.gemfile

### DIFF
--- a/gemfiles/common.gemfile
+++ b/gemfiles/common.gemfile
@@ -6,6 +6,7 @@ gemspec path: File.dirname(__dir__)
 
 group :development do
   gem "htmlbeautifier"
+  gem "puma"
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false
   gem "webpacker"
@@ -16,6 +17,11 @@ group :test do
   gem "equivalent-xml"
   gem "mocha"
   gem "sqlite3"
+end
+
+group :development, :test do
+  gem "debug"
+  gem "pry-byebug"
 end
 
 group :ci do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -71,7 +71,7 @@ class ActionView::TestCase
       Diffy::Diff.new(
         sort_attributes(expected_xml.root).to_xml(indent: 2),
         sort_attributes(actual_xml.root).to_xml(indent: 2)
-      ).to_s(:color)
+      ).to_fs(:color)
     }
   end
 


### PR DESCRIPTION
Adding `debug` and `pry-byebug` to the `:development, :test` group in the `common.gemfile`. `pry-byebug` should allow the use of either `binding.pry` or `byebug`, whichever you prefer.

Also adding `puma` to the `:dev` group, so the demo app runs under Puma.