### PR TITLE
Lint on oldest Rails version

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   Lint:
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: gemfiles/6.0.gemfile
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
   TargetRubyVersion: 2.7
+  TargetRailsVersion: 6.0
   NewCops: enable
   Exclude:
     - bin/*

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -71,7 +71,7 @@ class ActionView::TestCase
       Diffy::Diff.new(
         sort_attributes(expected_xml.root).to_xml(indent: 2),
         sort_attributes(actual_xml.root).to_xml(indent: 2)
-      ).to_fs(:color)
+      ).to_formatted_s(:color)
     }
   end
 


### PR DESCRIPTION
It looks like a recent update to Rubocop rules means that we can't apply the latest Rails rules on the earliest Rails version we support. This PR adds an explicit Rails version to the `rubocop.yml` file.