### PR TITLE
Fix the bogus Rubocop Autocorrect

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -71,7 +71,7 @@ class ActionView::TestCase
       Diffy::Diff.new(
         sort_attributes(expected_xml.root).to_xml(indent: 2),
         sort_attributes(actual_xml.root).to_xml(indent: 2)
-      ).to_formatted_s(:color)
+      ).to_s(:color)
     }
   end
 


### PR DESCRIPTION
I've been fighting with Rubocop and realized that the suggestion/autocorrect is simply wrong, because the method isn't a method on `Date` or `Time`.