### PR TITLE
allow for data- attributes to pass through for radio button collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,6 +739,28 @@ Collection methods accept these options:
 * `:help`: Add a help span to the `form_group`
 * Other options will be forwarded to the `radio_button`/`check_box` method
 
+
+To add `data-` attributes to a collection of radio buttons, map your models to an array and add a hash:
+
+```erb
+<%# Use the :first and :second elements of the array to be the value and label repsectively %>
+<%- choices = @collection.map { |addr| [ addr.id, addr.street, { 'data-zip-code':  addr.zip_code } ] } -%>
+
+<%= form.collection_radio_buttons :misc, choices, :first, :second %>
+```
+
+This generates:
+```html
+<div class="form-check">
+  <input data-zip-code="47805" class="form-check-input" type="radio" value="1" name="user[misc]" id="user_misc_1">
+  <label class="form-check-label" for="user_misc_1">Foo</label>
+</div>
+<div class="form-check">
+  <input data-zip-code="89807" class="form-check-input" type="radio" value="2" name="user[misc]" id="user_misc_2">
+  <label class="form-check-label" for="user_misc_2">Bar</label>
+</div>
+```
+
 ## Range Controls
 
 You can create a range control like this:

--- a/lib/bootstrap_form/inputs/inputs_collection.rb
+++ b/lib/bootstrap_form/inputs/inputs_collection.rb
@@ -29,7 +29,7 @@ module BootstrapForm
           input_options[:checked] = form_group_collection_input_checked?(checked, obj, input_value)
         end
 
-        # add things like 'data-' directives to the HTML
+        # add things like 'data-' attributes to the HTML
         obj.each do |inner_obj|
           input_options.merge!(inner_obj) if inner_obj.is_a?(Hash)
         end if obj.respond_to?(:each)

--- a/lib/bootstrap_form/inputs/inputs_collection.rb
+++ b/lib/bootstrap_form/inputs/inputs_collection.rb
@@ -29,6 +29,11 @@ module BootstrapForm
           input_options[:checked] = form_group_collection_input_checked?(checked, obj, input_value)
         end
 
+        # add things like 'data-' directives to the HTML
+        obj.each do |inner_obj|
+          input_options.merge!(inner_obj) if inner_obj.is_a?(Hash)
+        end if obj.respond_to?(:each)
+
         input_options[:error_message] = index == collection.size - 1
         input_options.except!(:class)
         input_options

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -547,6 +547,28 @@ class BootstrapCheckboxTest < ActionView::TestCase
     assert_equivalent_xml expected, actual
   end
 
+  test "collection_check_boxes renders data attributes" do
+    collection = [
+        ['1', 'Foo', {'data-city': 'east'} ],
+        ['2', 'Bar', {'data-city': 'west' }],
+      ]
+    expected = <<~HTML
+      <div class="mb-3">
+        <label class="form-label" for="user_misc">Misc</label>
+        <div class="form-check">
+          <input class="form-check-input" data-city="east" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
+          <label class="form-check-label" for="user_misc_1">Foo</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input" data-city="west" id="user_misc_2" name="user[misc][]" type="checkbox" value="2" />
+          <label class="form-check-label" for="user_misc_2">Bar</label>
+        </div>
+      </div>
+    HTML
+
+    assert_equivalent_xml expected, @builder.collection_check_boxes(:misc, collection, :first, :second, include_hidden: false)
+  end
+
   test "collection_check_boxes renders multiple check boxes with error correctly" do
     @user.errors.add(:misc, "error for test")
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]


### PR DESCRIPTION
Hi, I need the capability to add `data-` HTML attributes to collections of radio buttons. If found that this works, it may or may not be implemented the way you'd like - so I'm happy to fix/change whatever you ask (this PR is editable by maintainers). 


Just a little more information here, you can see from the tests I'm adding `data-city` attributes to each input tag.
```html
<input class="form-check-input" data-city="east" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
```

We pass in `Array`s using `:first` and `:second`  for value and label functions respectively. One element, the `Hash`, is all the extra HTML `data-` attributes we'd like to add.
```ruby
['1', 'Foo', {'data-city': 'east'} ],
```