### PR TITLE
Use the minitest test runner

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,12 +17,13 @@ end
 
 require 'bundler/gem_tasks'
 
-require 'rake/testtask'
+require "minitest/test_task"
 
-Rake::TestTask.new(:test) do |t|
-  t.libs << 'test'
-  t.pattern = 'test/**/*_test.rb'
-  t.verbose = false
+Minitest::TestTask.create(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.warning = false
+  t.test_globs = ["test/**/*_test.rb"]
 end
 
 # This automatically updates GitHub Releases whenever we `rake release` the gem


### PR DESCRIPTION
Minitest has a test runner. I have no idea how long it's been available, or why we weren't using it before. It offers a few options that I don't think we had before, when running `rake test`. They're described [here](https://github.com/minitest/minitest#rake-task-variables-).