### PR TITLE
Test extra arguments

### DIFF
--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -9,13 +9,13 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<~HTML
       <div class="form-check mb-3">
         <input #{autocomplete_attr} name="user[terms]" type="hidden" value="0" />
-        <input class="form-check-input" id="user_terms" name="user[terms]" type="checkbox" value="1" />
+        <input class="form-check-input" extra="extra arg" id="user_terms" name="user[terms]" type="checkbox" value="1" />
         <label class="form-check-label" for="user_terms">
           I agree to the terms
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms")
+    assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", extra: "extra arg")
   end
 
   test "check_box empty label" do

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -19,10 +19,10 @@ class BootstrapFieldsTest < ActionView::TestCase
     expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
-        <input class="form-control" id="user_misc" name="user[misc]" type="date" />
+        <input class="form-control" extra="extra arg" id="user_misc" name="user[misc]" type="date" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.date_field(:misc)
+    assert_equivalent_xml expected, @builder.date_field(:misc, extra: "extra arg")
   end
 
   test "date time fields are wrapped correctly" do

--- a/test/bootstrap_other_components_test.rb
+++ b/test/bootstrap_other_components_test.rb
@@ -6,13 +6,13 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
   setup :setup_test_fixture
 
   test "static control" do
-    output = @horizontal_builder.static_control :email
+    output = @horizontal_builder.static_control :email, extra: "extra arg"
 
     expected = <<~HTML
       <div class="mb-3 row">
         <label class="form-label col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
-          <input aria-required="true" required="required" class="form-control-plaintext" id="user_email" name="user[email]" readonly="readonly" type="text" value="steve@example.com"/>
+          <input aria-required="true" required="required" class="form-control-plaintext" id="user_email" extra="extra arg" name="user[email]" readonly="readonly" type="text" value="steve@example.com"/>
         </div>
       </div>
     HTML
@@ -90,7 +90,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
   end
 
   test "custom control does't wrap given block in a p tag" do
-    output = @horizontal_builder.custom_control :email do
+    output = @horizontal_builder.custom_control :email, extra: "extra arg" do
       "this is a test"
     end
 
@@ -133,10 +133,13 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
 
   test "regular button uses proper css classes" do
     expected = <<~HTML
-      <button class="btn btn-secondary" name="button" type="submit"><span>I'm HTML!</span> in a button!</button>
+      <button class="btn btn-secondary" extra="extra arg" name="button" type="submit"><span>I'm HTML!</span> in a button!</button>
     HTML
     assert_equivalent_xml expected,
-                          @builder.button("<span>I'm HTML!</span> in a button!".html_safe)
+                          @builder.button(
+                            "<span>I'm HTML!</span> in a button!".html_safe,
+                            extra: "extra arg"
+                          )
   end
 
   test "regular button can have extra css classes" do
@@ -168,8 +171,8 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
   end
 
   test "primary button uses proper css classes" do
-    expected = '<input class="btn btn-primary" name="commit" type="submit" value="Submit Form" />'
-    assert_equivalent_xml expected, @builder.primary("Submit Form")
+    expected = '<input class="btn btn-primary" extra="extra arg" name="commit" type="submit" value="Submit Form" />'
+    assert_equivalent_xml expected, @builder.primary("Submit Form", extra: "extra arg")
   end
 
   test "primary button can have extra css classes" do

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -8,13 +8,13 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "radio_button is wrapped correctly" do
     expected = <<~HTML
       <div class="form-check">
-        <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
+        <input class="form-check-input" extra="extra arg" id="user_misc_1" name="user[misc]" type="radio" value="1" />
         <label class="form-check-label" for="user_misc_1">
           This is a radio button
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.radio_button(:misc, "1", label: "This is a radio button")
+    assert_equivalent_xml expected, @builder.radio_button(:misc, "1", label: "This is a radio button", extra: "extra arg")
   end
 
   test "radio_button no label" do

--- a/test/bootstrap_rich_text_area_test.rb
+++ b/test/bootstrap_rich_text_area_test.rb
@@ -16,7 +16,7 @@ if ::Rails::VERSION::STRING > "6"
             <div class="mb-3">
               <label class="form-label" for="user_life_story">Life story</label>
               <input autocomplete="off" type="hidden" name="user[life_story]" id="user_life_story_trix_input_user"/>
-              <trix-editor class="trix-content form-control" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" id="user_life_story" input="user_life_story_trix_input_user"/>
+              <trix-editor class="trix-content form-control" extra="extra arg" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" id="user_life_story" input="user_life_story_trix_input_user"/>
             </div>
           HTML
         end
@@ -25,11 +25,11 @@ if ::Rails::VERSION::STRING > "6"
           <div class="mb-3">
             <label class="form-label" for="user_life_story">Life story</label>
             <input #{autocomplete_attr} type="hidden" name="user[life_story]" id="user_life_story_trix_input_user"/>
-            <trix-editor id="user_life_story" data-blob-url-template="#{data_blob_url_template}" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" input="user_life_story_trix_input_user" class="trix-content form-control" />
+            <trix-editor id="user_life_story" extra="extra arg" data-blob-url-template="#{data_blob_url_template}" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" input="user_life_story_trix_input_user" class="trix-content form-control" />
           </div>
         HTML
       end
-      assert_equivalent_xml expected, form_with_builder.rich_text_area(:life_story)
+      assert_equivalent_xml expected, form_with_builder.rich_text_area(:life_story, extra: "extra arg")
     end
 
     def data_blob_url_template

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -59,7 +59,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         </select>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.select(:status, [["activated", 1], ["blocked", 2]])
+    assert_equivalent_xml expected, @builder.select(:status, [["activated", 1], ["blocked", 2]], extra: "extra arg")
   end
 
   test "bootstrap_specific options are handled correctly" do
@@ -74,7 +74,14 @@ class BootstrapSelectsTest < ActionView::TestCase
       </div>
     HTML
     assert_equivalent_xml expected,
-                          @builder.select(:status, [["activated", 1], ["blocked", 2]], label: "My Status Label", help: "Help!")
+                          @builder.select(:status,
+                                          [
+                                            ["activated", 1],
+                                            ["blocked", 2]
+                                          ],
+                                          label: "My Status Label",
+                                          help: "Help!",
+                                          extra: "extra arg")
   end
 
   test "selects with options are wrapped correctly" do
@@ -95,7 +102,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_status">Status</label>
-        <select class="form-select my-select" id="user_status" name="user[status]">
+        <select class="form-select my-select" extra="extra arg" id="user_status" name="user[status]">
           <option value="">Please Select</option>
           <option value="1">activated</option>
           <option value="2">blocked</option>
@@ -104,7 +111,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     HTML
     assert_equivalent_xml expected,
                           @builder.select(:status, [["activated", 1], ["blocked", 2]], { prompt: "Please Select" },
-                                          class: "my-select")
+                                          class: "my-select", extra: "extra arg")
   end
 
   test "select 'id' attribute is used to specify label 'for' attribute" do
@@ -176,7 +183,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         <select class="form-select" id="user_status" name="user[status]"></select>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.collection_select(:status, [], :id, :name)
+    assert_equivalent_xml expected, @builder.collection_select(:status, [], :id, :name, extra: "extra arg")
   end
 
   test "collection_selects are wrapped correctly with wrapper" do
@@ -254,7 +261,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         <select class="form-select" id="user_status" name="user[status]"></select>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.grouped_collection_select(:status, [], :last, :first, :to_s, :to_s)
+    assert_equivalent_xml expected, @builder.grouped_collection_select(:status, [], :last, :first, :to_s, :to_s, extra: "extra arg")
   end
 
   test "grouped_collection_selects are wrapped correctly with wrapper" do
@@ -369,7 +376,7 @@ class BootstrapSelectsTest < ActionView::TestCase
           </div>
         </div>
       HTML
-      assert_equivalent_xml expected, @builder.date_select(:misc, wrapper_class: "none-margin")
+      assert_equivalent_xml expected, @builder.date_select(:misc, wrapper_class: "none-margin", extra: "extra arg")
     end
   end
 
@@ -497,7 +504,7 @@ class BootstrapSelectsTest < ActionView::TestCase
           </div>
         </div>
       HTML
-      assert_equivalent_xml expected, @builder.time_select(:misc)
+      assert_equivalent_xml expected, @builder.time_select(:misc, extra: "extra arg")
     end
   end
 
@@ -685,32 +692,35 @@ class BootstrapSelectsTest < ActionView::TestCase
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-datetime-select">
-            <select class="form-select my-datetime-select" id="user_misc_1i" name="user[misc(1i)]">
+            <select class="form-select my-datetime-select" extra="extra arg" id="user_misc_1i" name="user[misc(1i)]">
               #{blank_option}
               #{options_range(start: 2007, stop: 2017)}
             </select>
-            <select class="form-select my-datetime-select" id="user_misc_2i" name="user[misc(2i)]">
+            <select class="form-select my-datetime-select" extra="extra arg" id="user_misc_2i" name="user[misc(2i)]">
               #{blank_option}
               #{options_range(start: 1, stop: 12, months: true)}
             </select>
-            <select class="form-select my-datetime-select" id="user_misc_3i" name="user[misc(3i)]">
+            <select class="form-select my-datetime-select" extra="extra arg" id="user_misc_3i" name="user[misc(3i)]">
               #{blank_option}
               #{options_range(start: 1, stop: 31)}
             </select>
             &mdash;
-            <select class="form-select my-datetime-select" id="user_misc_4i" name="user[misc(4i)]">
+            <select class="form-select my-datetime-select" extra="extra arg" id="user_misc_4i" name="user[misc(4i)]">
               #{blank_option}
               #{options_range(start: '00', stop: '23')}
             </select>
             :
-            <select class="form-select my-datetime-select" id="user_misc_5i" name="user[misc(5i)]">
+            <select class="form-select my-datetime-select" extra="extra arg" id="user_misc_5i" name="user[misc(5i)]">
               #{blank_option}
               #{options_range(start: '00', stop: '59')}
             </select>
           </div>
         </div>
       HTML
-      assert_equivalent_xml expected, @builder.datetime_select(:misc, { include_blank: true }, class: "my-datetime-select")
+      assert_equivalent_xml expected, @builder.datetime_select(:misc,
+                                                               { include_blank: true },
+                                                               class: "my-datetime-select",
+                                                               extra: "extra arg")
     end
   end
 


### PR DESCRIPTION
If we're going to do major work/refactoring, I think we need to make sure we preserve the behaviour of arguments that _are not_ processed by `bootstrap_form`. This PR adds an extra arg to a few tests, which should cover variations of at least the current implementation.