### PR TITLE
CI Updates

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,7 @@ jobs:
       #   run: |
       #     bundle exec danger
       - name: Rubocop
-        run: bundle exec rubocop --auto-correct
+        run: bundle exec rubocop --autocorrect
   Test:
     runs-on: ubuntu-latest
     strategy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,11 +46,11 @@ You may find the [demo application](#the-demo-application) useful for developmen
 
 ### 6. Make a pull request
 
-- If you've never made a pull request (PR) before, read this: https://help.github.com/articles/about-pull-requests/.
+- If you've never made a pull request (PR) before, read [this](https://help.github.com/articles/about-pull-requests/).
 - If your PR fixes an issues, be sure to put "Fixes #nnn" in the description of the PR (where `nnn` is the issue number). Github will automatically close the issue when the PR is merged.
 - When the PR is submitted, check if Travis CI ran all the tests successfully, and didn't raise any issues.
 
-### 7. Done!
+### 7. Done
 
 Somebody will shortly review your pull request and if everything is good, it will be
 merged into the main branch. Eventually the gem will be published with your changes.
@@ -124,7 +124,6 @@ services:
 You may have to change the `1000:1000` to the user and group IDs of your laptop. You may also have to change the `version` parameter to match the version of the `docker-compose.yml` file.
 
 Adapting the above `docker-compose.override.yml` for MacOS should be relatively straight-forward. Windows users, I'm afraid you're on your own.
-
 
 #### Simple Dockerfile
 
@@ -207,7 +206,7 @@ We are an entirely volunteer project. Sometimes it's hard for people to find the
 
 ---
 
-Thanks to all the great contributors over the years: https://github.com/bootstrap-ruby/bootstrap_form/graphs/contributors
+Thanks to all the [great contributors](https://github.com/bootstrap-ruby/bootstrap_form/graphs/contributors) over the years.
 
 ## Troubleshooting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,3 +222,21 @@ cd demo
 rails db:setup # create the databases from `schema.rb`
 rails db:migrate # add the new tables and create a new `schema.rb`
 ```
+
+### RuboCop
+
+When you push a branch, RuboCop checks may fail, but locally you can't reproduce the failure. This may be because you're using a different version of RuboCop locally. When you push, the RuboCop tests use the currently available version of RuboCop. If you've been working on the branch for a while, it's likely you have a `Gemfile.lock` that specifies an older version of RuboCop.
+
+The first thing to try is to update your `Gemfile.lock` locally:
+
+```bash
+bundle update
+```
+
+Or, if you really want to minimize your work:
+
+```bash
+bundle update --conservative rubocop
+```
+
+This should enable you to reproduce the RuboCop failures locally, and then you can fix them.

--- a/demo/app/models/user.rb
+++ b/demo/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   attr_accessor :remember_me
 
-  serialize :preferences
+  serialize :preferences, coder: JSON
 
   validates :email, presence: true, length: { minimum: 5 }
   validates :terms, acceptance: { accept: true }

--- a/demo/app/models/user.rb
+++ b/demo/app/models/user.rb
@@ -1,7 +1,11 @@
 class User < ApplicationRecord
   attr_accessor :remember_me
 
-  serialize :preferences, coder: JSON
+  if Rails::VERSION::STRING >= "6.1"
+    serialize :preferences, coder: JSON
+  else
+    serialize :preferences, JSON
+  end
 
   validates :email, presence: true, length: { minimum: 5 }
   validates :terms, acceptance: { accept: true }

--- a/gemfiles/edge.gemfile
+++ b/gemfiles/edge.gemfile
@@ -1,4 +1,4 @@
 gems = "#{__dir__}/common.gemfile"
 eval File.read(gems), binding, gems # rubocop: disable Security/Eval
 
-gem "rails", git: "https://github.com/rails/rails.git"
+gem "rails", git: "https://github.com/rails/rails.git", branch: "main"

--- a/lib/bootstrap_form.rb
+++ b/lib/bootstrap_form.rb
@@ -1,7 +1,7 @@
 # NOTE: The rich_text_area and rich_text_area_tag helpers are defined in a file with a different
 # name and not in the usual autoload-reachable way.
 # The following line is definitely need to make `bootstrap_form` work.
-if ::Rails::VERSION::STRING > "6"
+if Rails::VERSION::STRING > "6"
   require "#{Gem::Specification.find_by_name('actiontext').gem_dir}/app/helpers/action_text/tag_helper"
 end
 require "action_view"

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -99,7 +99,7 @@ module BootstrapForm
       end
 
       def input_group_content(content)
-        return content if /btn/.match?(content)
+        return content if content.include?("btn")
 
         tag.span(content, class: "input-group-text")
       end

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -188,7 +188,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
             <span class="input-group-text">$</div>
             <input aria-required="true" required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
             <span class="input-group-text">.00</span>
-            <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</span>
+            <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</span>
           </div>
         </div>
       </form>
@@ -404,7 +404,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     expected = <<~HTML
       <div class="mb-3">
         <p class="form-control-plaintext">Bar</p>
-        <div class="invalid-feedback" style="display: block;">can't be blank, is too short (minimum is 5 characters)</div>
+        <div class="invalid-feedback" style="display: block;">can’t be blank, is too short (minimum is 5 characters)</div>
       </div>
     HTML
     assert_equivalent_xml expected, output
@@ -466,10 +466,11 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <div class="field_with_errors">
           <input aria-required="true" required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="email" />
         </div>
-        <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
+        <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</div>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.email_field(:email, wrapper_class: "none-margin")
+    output = @builder.email_field(:email, wrapper_class: "none-margin")
+    assert_equivalent_xml expected, output
   end
 
   test "overrides the class of the wrapped form_group by a field with errors when bootstrap_form_for is used" do
@@ -486,7 +487,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <div class="none-margin">
           <label class="form-label required" for="user_email">Email</label>
           <input aria-required="true" required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
-          <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
+          <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</div>
           <small class="form-text text-muted">This is required</small>
         </div>
       </form>

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -430,7 +430,7 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label class="form-label required text-danger" for="user_email">Email can't be blank, is too short (minimum is 5 characters)</label>
+          <label class="form-label required text-danger" for="user_email">Email can’t be blank, is too short (minimum is 5 characters)</label>
           <input aria-required="true" required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
         </div>
       </form>
@@ -446,9 +446,9 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label class="form-label required text-danger" for="user_email">Email can&#39;t be blank, is too short (minimum is 5 characters)</label>
+          <label class="form-label required text-danger" for="user_email">Email can’t be blank, is too short (minimum is 5 characters)</label>
           <input aria-required="true" required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
-          <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</span>
+          <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</span>
         </div>
       </form>
     HTML
@@ -465,9 +465,9 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label class="form-label required text-danger" for="user_email">Your e-mail address can&#39;t be blank, is too short (minimum is 5 characters)</label>
+          <label class="form-label required text-danger" for="user_email">Your e-mail address can’t be blank, is too short (minimum is 5 characters)</label>
           <input aria-required="true" required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
-          <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
+          <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</div>
         </div>
       </form>
     HTML
@@ -484,7 +484,7 @@ class BootstrapFormTest < ActionView::TestCase
       <div class="alert alert-danger">
         <p>Please fix the following errors:</p>
         <ul class="rails-bootstrap-forms-error-summary">
-          <li>Email can&#39;t be blank</li>
+          <li>Email can’t be blank</li>
           <li>Email is too short (minimum is 5 characters)</li>
           <li>Terms must be accepted</li>
         </ul>
@@ -501,7 +501,7 @@ class BootstrapFormTest < ActionView::TestCase
       <div class="my-css-class">
         <p>Please fix the following errors:</p>
         <ul class="rails-bootstrap-forms-error-summary">
-          <li>Email can&#39;t be blank</li>
+          <li>Email can’t be blank</li>
           <li>Email is too short (minimum is 5 characters)</li>
           <li>Terms must be accepted</li>
         </ul>
@@ -524,7 +524,7 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="alert alert-danger">
           <p>Please fix the following errors:</p>
           <ul class="rails-bootstrap-forms-error-summary">
-            <li>Email can&#39;t be blank</li>
+            <li>Email can’t be blank</li>
             <li>Email is too short (minimum is 5 characters)</li>
             <li>Terms must be accepted</li>
           </ul>
@@ -565,7 +565,7 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="alert alert-danger">
           <p>Please fix the following errors:</p>
           <ul class="rails-bootstrap-forms-error-summary">
-            <li>Email can&#39;t be blank</li>
+            <li>Email can’t be blank</li>
             <li>Email is too short (minimum is 5 characters)</li>
             <li>Terms must be accepted</li>
           </ul>
@@ -581,7 +581,7 @@ class BootstrapFormTest < ActionView::TestCase
 
     expected = <<~HTML
       <ul class="rails-bootstrap-forms-error-summary">
-        <li>Email can&#39;t be blank</li>
+        <li>Email can’t be blank</li>
         <li>Email is too short (minimum is 5 characters)</li>
         <li>Terms must be accepted</li>
       </ul>
@@ -601,7 +601,7 @@ class BootstrapFormTest < ActionView::TestCase
     assert @user.invalid?
 
     expected = <<~HTML
-      <div class="invalid-feedback">Email can&#39;t be blank, Email is too short (minimum is 5 characters)</div>
+      <div class="invalid-feedback">Email can’t be blank, Email is too short (minimum is 5 characters)</div>
     HTML
     assert_equivalent_xml expected, @builder.errors_on(:email)
   end
@@ -701,7 +701,7 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="mb-3">
           <label class="form-label required" for="user_email">Email</label>
           <input aria-required="true" required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
-          <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
+          <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</div>
           <small class="form-text text-muted">This is required</small>
         </div>
       </form>
@@ -727,7 +727,7 @@ class BootstrapFormTest < ActionView::TestCase
           <div class="field_with_errors">
             <input aria-required="true" required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           </div>
-          <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</span>
+          <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</span>
           <small class="form-text text-muted">This is required</small>
         </div>
       </form>
@@ -793,7 +793,7 @@ class BootstrapFormTest < ActionView::TestCase
     @user.email = nil
     assert @user.invalid?
 
-    expected = '<div class="invalid-feedback">can&#39;t be blank, is too short (minimum is 5 characters)</div>'
+    expected = '<div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</div>'
 
     assert_equivalent_xml expected, @builder.errors_on(:email, hide_attribute_name: true)
   end
@@ -802,7 +802,7 @@ class BootstrapFormTest < ActionView::TestCase
     @user.email = nil
     assert @user.invalid?
 
-    expected = '<div class="custom-error-class">Email can&#39;t be blank, Email is too short (minimum is 5 characters)</div>'
+    expected = '<div class="custom-error-class">Email can’t be blank, Email is too short (minimum is 5 characters)</div>'
 
     assert_equivalent_xml expected, @builder.errors_on(:email, custom_class: "custom-error-class")
   end

--- a/test/bootstrap_rich_text_area_test.rb
+++ b/test/bootstrap_rich_text_area_test.rb
@@ -1,7 +1,7 @@
 require_relative "./test_helper"
 require "minitest/mock"
 
-if ::Rails::VERSION::STRING > "6"
+if Rails::VERSION::STRING > "6"
   class BootstrapRichTextAreaTest < ActionView::TestCase
     tests ActionText::TagHelper
     include BootstrapForm::ActionViewExtensions::FormHelper

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -56,6 +56,7 @@ class ActionView::TestCase
 
   # Expected and actual are wrapped in a root tag to ensure proper XML structure
   def assert_equivalent_xml(expected, actual)
+    expected = expected.tr("’", "'") if Rails::VERSION::STRING < "7.1"
     expected_xml        = Nokogiri::XML("<test-xml>\n#{expected}\n</test-xml>") { |config| config.default_xml.noblanks }
     actual_xml          = Nokogiri::XML("<test-xml>\n#{actual}\n</test-xml>") { |config| config.default_xml.noblanks }
     ignored_attributes  = %w[style data-disable-with]


### PR DESCRIPTION
A number of changes to Rails in Edge or recent versions, and RuboCop:

- Error messages use a curly apostrophe.
- `ActiveRecord::AttributeMethods::Serialization::ClassMethods#serialize` starts requiring a keyword argument for the serializer class.
- `master` no longer seems to be a branch alias in Rails.
- New RuboCop offenses.