### PR TITLE
Test wrapper_class and wrapper: { class: specified

### DIFF
--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -228,6 +228,44 @@ class BootstrapFieldsTest < ActionView::TestCase
     assert_equivalent_xml expected, @horizontal_builder.text_field(:email, wrapper: { class: "mb-3 g-3" })
   end
 
+  test "text fields are wrapped correctly when horizontal and multiple wrapper classes specified" do
+    expected = <<~HTML
+      <div class="bogus-2 row">
+        <label class="form-label col-form-label col-sm-2 required" for="user_email">Email</label>
+        <div class="col-sm-10">
+          <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+        </div>
+      </div>
+    HTML
+    assert_equivalent_xml expected,
+                          @horizontal_builder.text_field(:email, wrapper_class: "bogus-1", wrapper: { class: "bogus-2" })
+  end
+
+  test "text fields are wrapped correctly when horizontal and wrapper class specified" do
+    expected = <<~HTML
+      <div class="bogus-1 row">
+        <label class="form-label col-form-label col-sm-2 required" for="user_email">Email</label>
+        <div class="col-sm-10">
+          <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+        </div>
+      </div>
+    HTML
+    assert_equivalent_xml expected, @horizontal_builder.text_field(:email, wrapper_class: "bogus-1")
+  end
+
+  test "text fields are wrapped correctly when horizontal and multiple wrapper classes specified (reverse order)" do
+    expected = <<~HTML
+      <div class="bogus-2 row">
+        <label class="form-label col-form-label col-sm-2 required" for="user_email">Email</label>
+        <div class="col-sm-10">
+          <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+        </div>
+      </div>
+    HTML
+    assert_equivalent_xml expected,
+                          @horizontal_builder.text_field(:email, wrapper: { class: "bogus-2" }, wrapper_class: "bogus-1")
+  end
+
   test "field 'id' attribute is used to specify label 'for' attribute" do
     expected = <<~HTML
       <div class="mb-3">


### PR DESCRIPTION
It wasn't clear what should happen if both `wrapper_class: ...` and `wrapper: { class: ...` were specified. These tests show that `wrapper: { class: ...` wins.