### PR TITLE
Remove tests for versions before 5.2

### DIFF
--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -75,16 +75,14 @@ class BootstrapFieldsTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.file_field(:misc, placeholder: "Pick a file")
   end
 
-  if ::Rails::VERSION::STRING > "5.1"
-    test "file field placeholder has appropriate `for` attribute when used in form_with" do
-      expected = <<~HTML
-        <div class="mb-3">
-          <label class="form-label" for="custom-id">Misc</label>
-          <input class="form-control" id="custom-id" name="user[misc]" type="file"/>
-        </div>
-      HTML
-      assert_equivalent_xml expected, form_with_builder.file_field(:misc, id: "custom-id")
-    end
+  test "file field placeholder has appropriate `for` attribute when used in form_with" do
+    expected = <<~HTML
+      <div class="mb-3">
+        <label class="form-label" for="custom-id">Misc</label>
+        <input class="form-control" id="custom-id" name="user[misc]" type="file"/>
+      </div>
+    HTML
+    assert_equivalent_xml expected, form_with_builder.file_field(:misc, id: "custom-id")
   end
 
   test "file fields are wrapped correctly with error" do
@@ -181,28 +179,14 @@ class BootstrapFieldsTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.text_area(:comments)
   end
 
-  if ::Rails::VERSION::STRING > "5.1" && ::Rails::VERSION::STRING < "5.2"
-    test "text areas are wrapped correctly form_with Rails 5.1" do
-      expected = <<~HTML
-        <div class="mb-3">
-          <label class="form-label" for="user_comments">Comments</label>
-          <textarea class="form-control" name="user[comments]">\nmy comment</textarea>
-        </div>
-      HTML
-      assert_equivalent_xml expected, form_with_builder.text_area(:comments)
-    end
-  end
-
-  if ::Rails::VERSION::STRING > "5.2"
-    test "text areas are wrapped correctly form_with Rails 5.2+" do
-      expected = <<~HTML
-        <div class="mb-3">
-          <label class="form-label" for="user_comments">Comments</label>
-          <textarea class="form-control" id="user_comments" name="user[comments]">\nmy comment</textarea>
-        </div>
-      HTML
-      assert_equivalent_xml expected, form_with_builder.text_area(:comments)
-    end
+  test "text areas are wrapped correctly form_with Rails 5.2+" do
+    expected = <<~HTML
+      <div class="mb-3">
+        <label class="form-label" for="user_comments">Comments</label>
+        <textarea class="form-control" id="user_comments" name="user[comments]">\nmy comment</textarea>
+      </div>
+    HTML
+    assert_equivalent_xml expected, form_with_builder.text_area(:comments)
   end
 
   test "text fields are wrapped correctly" do
@@ -415,24 +399,22 @@ class BootstrapFieldsTest < ActionView::TestCase
     assert_equivalent_xml expected, output
   end
 
-  if ::Rails::VERSION::STRING >= "5.1"
-    test "fields correctly uses options from parent builder" do
-      @user.address = Address.new(street: "123 Main Street")
+  test "fields correctly uses options from parent builder" do
+    @user.address = Address.new(street: "123 Main Street")
 
-      bootstrap_form_with(model: @user,
-                          control_col: "control-style",
-                          inline_errors: false,
-                          label_col: "label-style",
-                          label_errors: true,
-                          layout: :inline) do |f|
-        f.fields :address do |af|
-          af.text_field(:street)
-          assert_equal "control-style", af.control_col
-          assert_equal false, af.inline_errors
-          assert_equal "label-style", af.label_col
-          assert_equal true, af.label_errors
-          assert_equal :inline, af.layout
-        end
+    bootstrap_form_with(model: @user,
+                        control_col: "control-style",
+                        inline_errors: false,
+                        label_col: "label-style",
+                        label_errors: true,
+                        layout: :inline) do |f|
+      f.fields :address do |af|
+        af.text_field(:street)
+        assert_equal "control-style", af.control_col
+        assert_equal false, af.inline_errors
+        assert_equal "label-style", af.label_col
+        assert_equal true, af.label_errors
+        assert_equal :inline, af.layout
       end
     end
   end

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -115,17 +115,13 @@ class BootstrapFormTest < ActionView::TestCase
     # TODO: Align baseline better.
   end
 
-  if ::Rails::VERSION::STRING >= "5.1"
-    # No need to test 5.2 separately for this case, since 5.2 does *not*
-    # generate a default ID for the form element.
-    test "default-style forms bootstrap_form_with Rails 5.1+" do
-      expected = <<~HTML
-        <form accept-charset="UTF-8" action="/users" method="post" #{'data-remote="true"' if ::Rails::VERSION::STRING < '6.1'}>
-          #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        </form>
-      HTML
-      assert_equivalent_xml expected, bootstrap_form_with(model: @user) { |_f| nil }
-    end
+  test "default-style forms bootstrap_form_with Rails 5.1+" do
+    expected = <<~HTML
+      <form accept-charset="UTF-8" action="/users" method="post" #{'data-remote="true"' if ::Rails::VERSION::STRING < '6.1'}>
+        #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
+      </form>
+    HTML
+    assert_equivalent_xml expected, bootstrap_form_with(model: @user) { |_f| nil }
   end
 
   test "inline-style forms" do
@@ -402,20 +398,13 @@ class BootstrapFormTest < ActionView::TestCase
   end
 
   test "bootstrap_form_tag allows an empty name for checkboxes" do
-    if ::Rails::VERSION::STRING >= "5.1"
-      id = "misc"
-      name = "misc"
-    else
-      id = "_misc"
-      name = "[misc]"
-    end
     expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-check mb-3">
-          <input class="form-check-input" id="#{id}" name="#{name}" type="checkbox" value="1" />
-          <input #{autocomplete_attr} name="#{name}" type="hidden" value="0" />
-          <label class="form-check-label" for="#{id}"> Misc</label>
+          <input class="form-check-input" id="misc" name="misc" type="checkbox" value="1" />
+          <input #{autocomplete_attr} name="misc" type="hidden" value="0" />
+          <label class="form-check-label" for="misc"> Misc</label>
         </div>
       </form>
     HTML


### PR DESCRIPTION
Some tests were only run for versions of Rails that we're no longer testing against. This PR removes them. Some tests were only run for versions 5.2 and greater. This PR removes the conditionals around those tests, since we don't test against those older versions anymore.