### PR TITLE
674 html tests

### DIFF
--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -15,7 +15,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", extra: "extra arg")
+    assert_equivalent_html expected, @builder.check_box(:terms, label: "I agree to the terms", extra: "extra arg")
   end
 
   test "check_box empty label" do
@@ -27,7 +27,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       </div>
     HTML
     # &#8203; is a zero-width space.
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: "&#8203;".html_safe)
+    assert_equivalent_html expected, @builder.check_box(:terms, label: "&#8203;".html_safe)
   end
 
   test "disabled check_box has proper wrapper classes" do
@@ -40,7 +40,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", disabled: true)
+    assert_equivalent_html expected, @builder.check_box(:terms, label: "I agree to the terms", disabled: true)
   end
 
   test "check_box label allows html" do
@@ -53,7 +53,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: 'I agree to the <a href="#">terms</a>'.html_safe)
+    assert_equivalent_html expected, @builder.check_box(:terms, label: 'I agree to the <a href="#">terms</a>'.html_safe)
   end
 
   test "check_box accepts a block to define the label" do
@@ -66,7 +66,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms) { "I agree to the terms" }
+    assert_equivalent_html expected, @builder.check_box(:terms) { "I agree to the terms" }
   end
 
   test "check_box accepts a custom label class" do
@@ -79,7 +79,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label_class: "btn")
+    assert_equivalent_html expected, @builder.check_box(:terms, label_class: "btn")
   end
 
   test "check_box 'id' attribute is used to specify label 'for' attribute" do
@@ -92,7 +92,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, id: "custom_id")
+    assert_equivalent_html expected, @builder.check_box(:terms, id: "custom_id")
   end
 
   test "check_box responds to checked_value and unchecked_value arguments" do
@@ -105,7 +105,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, { label: "I agree to the terms" }, "yes", "no")
+    assert_equivalent_html expected, @builder.check_box(:terms, { label: "I agree to the terms" }, "yes", "no")
   end
 
   test "inline checkboxes" do
@@ -118,7 +118,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", inline: true)
+    assert_equivalent_html expected, @builder.check_box(:terms, label: "I agree to the terms", inline: true)
   end
 
   test "inline checkboxes from form layout" do
@@ -137,7 +137,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     actual = bootstrap_form_for(@user, layout: :inline) do |f|
       f.check_box(:terms, label: "I agree to the terms")
     end
-    assert_equivalent_xml expected, actual
+    assert_equivalent_html expected, actual
   end
 
   test "disabled inline check_box" do
@@ -150,7 +150,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", inline: true,
+    assert_equivalent_html expected, @builder.check_box(:terms, label: "I agree to the terms", inline: true,
                                                                disabled: true)
   end
 
@@ -164,7 +164,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, inline: true, label_class: "btn")
+    assert_equivalent_html expected, @builder.check_box(:terms, inline: true, label_class: "btn")
   end
 
   test "collection_check_boxes renders the form_group correctly" do
@@ -181,7 +181,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected, @builder.collection_check_boxes(:misc, collection, :id, :street,
+    assert_equivalent_html expected, @builder.collection_check_boxes(:misc, collection, :id, :street,
                                                                     label: "This is a checkbox collection", help: "With a help!")
   end
 
@@ -206,7 +206,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected, @builder.collection_check_boxes(:misc, collection, :id, :street)
+    assert_equivalent_html expected, @builder.collection_check_boxes(:misc, collection, :id, :street)
   end
 
   test "collection_check_boxes renders multiple checkboxes contains unicode characters in IDs correctly" do
@@ -231,7 +231,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected, @builder.collection_check_boxes(:misc, collection, :id, :name)
+    assert_equivalent_html expected, @builder.collection_check_boxes(:misc, collection, :id, :name)
   end
 
   test "collection_check_boxes renders inline checkboxes correctly" do
@@ -255,7 +255,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected, @builder.collection_check_boxes(:misc, collection, :id, :street,
+    assert_equivalent_html expected, @builder.collection_check_boxes(:misc, collection, :id, :street,
                                                                     inline: true)
   end
 
@@ -280,9 +280,9 @@ class BootstrapCheckboxTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected, @builder.collection_check_boxes(:misc, collection, :id, :street,
+    assert_equivalent_html expected, @builder.collection_check_boxes(:misc, collection, :id, :street,
                                                                     checked: 1)
-    assert_equivalent_xml expected, @builder.collection_check_boxes(:misc, collection, :id, :street,
+    assert_equivalent_html expected, @builder.collection_check_boxes(:misc, collection, :id, :street,
                                                                     checked: collection.first)
   end
 
@@ -303,9 +303,9 @@ class BootstrapCheckboxTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected, @builder.collection_check_boxes(:misc, collection, :id, :street,
+    assert_equivalent_html expected, @builder.collection_check_boxes(:misc, collection, :id, :street,
                                                                     checked: [1, 2])
-    assert_equivalent_xml expected, @builder.collection_check_boxes(:misc, collection, :id, :street,
+    assert_equivalent_html expected, @builder.collection_check_boxes(:misc, collection, :id, :street,
                                                                     checked: collection)
   end
 
@@ -323,7 +323,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.collection_check_boxes(:misc, collection, :street, :street)
+    assert_equivalent_html expected, @builder.collection_check_boxes(:misc, collection, :street, :street)
   end
 
   test "collection_check_boxes renders multiple checkboxes with labels defined by Proc :text_method correctly" do
@@ -347,7 +347,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected, @builder.collection_check_boxes(:misc, collection, :id, proc { |a| a.street.reverse })
+    assert_equivalent_html expected, @builder.collection_check_boxes(:misc, collection, :id, proc { |a| a.street.reverse })
   end
 
   test "collection_check_boxes renders multiple checkboxes with values defined by Proc :value_method correctly" do
@@ -370,7 +370,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.collection_check_boxes(:misc, collection, proc { |a| "address_#{a.id}" },
+    assert_equivalent_html expected, @builder.collection_check_boxes(:misc, collection, proc { |a| "address_#{a.id}" },
                                                                     :street)
   end
 
@@ -395,7 +395,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected, @builder.collection_check_boxes(:misc, collection, :id, ->(a) { a.street.reverse })
+    assert_equivalent_html expected, @builder.collection_check_boxes(:misc, collection, :id, ->(a) { a.street.reverse })
   end
 
   test "collection_check_boxes renders multiple checkboxes with values defined by lambda :value_method correctly" do
@@ -419,7 +419,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected, @builder.collection_check_boxes(:misc, collection, ->(a) { "address_#{a.id}" },
+    assert_equivalent_html expected, @builder.collection_check_boxes(:misc, collection, ->(a) { "address_#{a.id}" },
                                                                     :street)
   end
 
@@ -444,9 +444,9 @@ class BootstrapCheckboxTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected, @builder.collection_check_boxes(:misc, collection, proc { |a| "address_#{a.id}" },
+    assert_equivalent_html expected, @builder.collection_check_boxes(:misc, collection, proc { |a| "address_#{a.id}" },
                                                                     :street, checked: "address_1")
-    assert_equivalent_xml expected, @builder.collection_check_boxes(:misc, collection, proc { |a| "address_#{a.id}" },
+    assert_equivalent_html expected, @builder.collection_check_boxes(:misc, collection, proc { |a| "address_#{a.id}" },
                                                                     :street, checked: collection.first)
   end
 
@@ -471,9 +471,9 @@ class BootstrapCheckboxTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected, @builder.collection_check_boxes(:misc, collection, ->(a) { "address_#{a.id}" },
+    assert_equivalent_html expected, @builder.collection_check_boxes(:misc, collection, ->(a) { "address_#{a.id}" },
                                                                     :street, checked: %w[address_1 address_2])
-    assert_equivalent_xml expected, @builder.collection_check_boxes(:misc, collection, ->(a) { "address_#{a.id}" },
+    assert_equivalent_html expected, @builder.collection_check_boxes(:misc, collection, ->(a) { "address_#{a.id}" },
                                                                     :street, checked: collection)
   end
 
@@ -493,7 +493,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected, @builder.collection_check_boxes(:misc, collection, :id, :street, include_hidden: false)
+    assert_equivalent_html expected, @builder.collection_check_boxes(:misc, collection, :id, :street, include_hidden: false)
   end
 
   test "check_box skip label" do
@@ -503,7 +503,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
         <input class="form-check-input position-static" id="user_terms" name="user[terms]" type="checkbox" value="1" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", skip_label: true)
+    assert_equivalent_html expected, @builder.check_box(:terms, label: "I agree to the terms", skip_label: true)
   end
 
   test "check_box hide label" do
@@ -514,7 +514,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
         <label class="form-check-label visually-hidden" for="user_terms">I agree to the terms</label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", hide_label: true)
+    assert_equivalent_html expected, @builder.check_box(:terms, label: "I agree to the terms", hide_label: true)
   end
 
   test "collection_check_boxes renders error after last check box" do
@@ -544,7 +544,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       f.collection_check_boxes(:misc, collection, :id, :street)
     end
 
-    assert_equivalent_xml expected, actual
+    assert_equivalent_html expected, actual
   end
 
   test "collection_check_boxes renders multiple check boxes with error correctly" do
@@ -572,7 +572,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     actual = bootstrap_form_for(@user) do |f|
       f.collection_check_boxes(:misc, collection, :id, :street, checked: collection)
     end
-    assert_equivalent_xml expected, actual
+    assert_equivalent_html expected, actual
   end
 
   test "check_box renders error when asked" do
@@ -593,7 +593,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     actual = bootstrap_form_for(@user) do |f|
       f.check_box(:terms, label: "I agree to the terms", error_message: true)
     end
-    assert_equivalent_xml expected, actual
+    assert_equivalent_html expected, actual
   end
 
   test "check box with custom wrapper class" do
@@ -606,7 +606,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", wrapper_class: "custom-class")
+    assert_equivalent_html expected, @builder.check_box(:terms, label: "I agree to the terms", wrapper_class: "custom-class")
   end
 
   test "inline check box with custom wrapper class" do
@@ -619,7 +619,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", inline: true,
+    assert_equivalent_html expected, @builder.check_box(:terms, label: "I agree to the terms", inline: true,
                                                                wrapper_class: "custom-class")
   end
 
@@ -631,7 +631,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
         <label class="form-check-label required" for="user_terms">I agree to the terms</label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.check_box(:terms, label: "I agree to the terms", required: true)
+    assert_equivalent_html expected, @builder.check_box(:terms, label: "I agree to the terms", required: true)
   end
 
   test "a required attribute as checkbox" do
@@ -642,6 +642,6 @@ class BootstrapCheckboxTest < ActionView::TestCase
         <label class="form-check-label" for="user_email">Email</label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.check_box(:email, label: "Email")
+    assert_equivalent_html expected, @builder.check_box(:email, label: "Email")
   end
 end

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -12,7 +12,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         <input class="form-control" id="user_misc" name="user[misc]" type="color" value="#000000" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.color_field(:misc)
+    assert_equivalent_html expected, @builder.color_field(:misc)
   end
 
   test "date fields are wrapped correctly" do
@@ -22,7 +22,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         <input class="form-control" extra="extra arg" id="user_misc" name="user[misc]" type="date" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.date_field(:misc, extra: "extra arg")
+    assert_equivalent_html expected, @builder.date_field(:misc, extra: "extra arg")
   end
 
   test "date time fields are wrapped correctly" do
@@ -32,7 +32,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         <input class="form-control" id="user_misc" name="user[misc]" type="datetime" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.datetime_field(:misc)
+    assert_equivalent_html expected, @builder.datetime_field(:misc)
   end
 
   test "date time local fields are wrapped correctly" do
@@ -42,7 +42,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         <input class="form-control" id="user_misc" name="user[misc]" type="datetime-local" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.datetime_local_field(:misc)
+    assert_equivalent_html expected, @builder.datetime_local_field(:misc)
   end
 
   test "email fields are wrapped correctly" do
@@ -52,7 +52,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         <input class="form-control" id="user_misc" name="user[misc]" type="email" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.email_field(:misc)
+    assert_equivalent_html expected, @builder.email_field(:misc)
   end
 
   test "file fields are wrapped correctly" do
@@ -62,7 +62,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         <input class="form-control" id="user_misc" name="user[misc]" type="file"/>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.file_field(:misc)
+    assert_equivalent_html expected, @builder.file_field(:misc)
   end
 
   test "file field placeholder can be customized" do
@@ -72,7 +72,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         <input class="form-control" id="user_misc" name="user[misc]" placeholder="Pick a file" type="file"/>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.file_field(:misc, placeholder: "Pick a file")
+    assert_equivalent_html expected, @builder.file_field(:misc, placeholder: "Pick a file")
   end
 
   test "file field placeholder has appropriate `for` attribute when used in form_with" do
@@ -82,7 +82,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         <input class="form-control" id="custom-id" name="user[misc]" type="file"/>
       </div>
     HTML
-    assert_equivalent_xml expected, form_with_builder.file_field(:misc, id: "custom-id")
+    assert_equivalent_html expected, form_with_builder.file_field(:misc, id: "custom-id")
   end
 
   test "file fields are wrapped correctly with error" do
@@ -97,14 +97,14 @@ class BootstrapFieldsTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.file_field(:misc) }
+    assert_equivalent_html expected, bootstrap_form_for(@user) { |f| f.file_field(:misc) }
   end
 
   test "hidden fields are supported" do
     expected = <<~HTML
       <input #{autocomplete_attr} id="user_misc" name="user[misc]" type="hidden" />
     HTML
-    assert_equivalent_xml expected, @builder.hidden_field(:misc)
+    assert_equivalent_html expected, @builder.hidden_field(:misc)
   end
 
   test "month local fields are wrapped correctly" do
@@ -114,7 +114,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         <input class="form-control" id="user_misc" name="user[misc]" type="month" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.month_field(:misc)
+    assert_equivalent_html expected, @builder.month_field(:misc)
   end
 
   test "number fields are wrapped correctly" do
@@ -124,7 +124,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         <input class="form-control" id="user_misc" name="user[misc]" type="number" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.number_field(:misc)
+    assert_equivalent_html expected, @builder.number_field(:misc)
   end
 
   test "password fields are wrapped correctly" do
@@ -135,7 +135,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         <small class="form-text text-muted">A good password should be at least six characters long</small>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.password_field(:password)
+    assert_equivalent_html expected, @builder.password_field(:password)
   end
 
   test "phone/telephone fields are wrapped correctly" do
@@ -145,8 +145,8 @@ class BootstrapFieldsTest < ActionView::TestCase
         <input class="form-control" id="user_misc" name="user[misc]" type="tel" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.phone_field(:misc)
-    assert_equivalent_xml expected, @builder.telephone_field(:misc)
+    assert_equivalent_html expected, @builder.phone_field(:misc)
+    assert_equivalent_html expected, @builder.telephone_field(:misc)
   end
 
   test "range fields are wrapped correctly" do
@@ -156,7 +156,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         <input class="form-control" id="user_misc" name="user[misc]" type="range" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.range_field(:misc)
+    assert_equivalent_html expected, @builder.range_field(:misc)
   end
 
   test "search fields are wrapped correctly" do
@@ -166,7 +166,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         <input class="form-control" id="user_misc" name="user[misc]" type="search" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.search_field(:misc)
+    assert_equivalent_html expected, @builder.search_field(:misc)
   end
 
   test "text areas are wrapped correctly" do
@@ -176,7 +176,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         <textarea class="form-control" id="user_comments" name="user[comments]">\nmy comment</textarea>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.text_area(:comments)
+    assert_equivalent_html expected, @builder.text_area(:comments)
   end
 
   test "text areas are wrapped correctly form_with Rails 5.2+" do
@@ -186,7 +186,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         <textarea class="form-control" id="user_comments" name="user[comments]">\nmy comment</textarea>
       </div>
     HTML
-    assert_equivalent_xml expected, form_with_builder.text_area(:comments)
+    assert_equivalent_html expected, form_with_builder.text_area(:comments)
   end
 
   test "text fields are wrapped correctly" do
@@ -196,7 +196,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.text_field(:email)
+    assert_equivalent_html expected, @builder.text_field(:email)
   end
 
   test "text fields are wrapped correctly when horizontal and gutter classes are given" do
@@ -208,8 +208,8 @@ class BootstrapFieldsTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, @horizontal_builder.text_field(:email, wrapper_class: "mb-3 g-3")
-    assert_equivalent_xml expected, @horizontal_builder.text_field(:email, wrapper: { class: "mb-3 g-3" })
+    assert_equivalent_html expected, @horizontal_builder.text_field(:email, wrapper_class: "mb-3 g-3")
+    assert_equivalent_html expected, @horizontal_builder.text_field(:email, wrapper: { class: "mb-3 g-3" })
   end
 
   test "text fields are wrapped correctly when horizontal and multiple wrapper classes specified" do
@@ -221,7 +221,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @horizontal_builder.text_field(:email, wrapper_class: "bogus-1", wrapper: { class: "bogus-2" })
   end
 
@@ -234,7 +234,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, @horizontal_builder.text_field(:email, wrapper_class: "bogus-1")
+    assert_equivalent_html expected, @horizontal_builder.text_field(:email, wrapper_class: "bogus-1")
   end
 
   test "text fields are wrapped correctly when horizontal and multiple wrapper classes specified (reverse order)" do
@@ -246,7 +246,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @horizontal_builder.text_field(:email, wrapper: { class: "bogus-2" }, wrapper_class: "bogus-1")
   end
 
@@ -257,7 +257,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         <input aria-required="true" required="required" class="form-control" id="custom_id" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.text_field(:email, id: :custom_id)
+    assert_equivalent_html expected, @builder.text_field(:email, id: :custom_id)
   end
 
   test "time fields are wrapped correctly" do
@@ -267,7 +267,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         <input class="form-control" id="user_misc" name="user[misc]" type="time" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.time_field(:misc)
+    assert_equivalent_html expected, @builder.time_field(:misc)
   end
 
   test "url fields are wrapped correctly" do
@@ -277,7 +277,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         <input class="form-control" id="user_misc" name="user[misc]" type="url" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.url_field(:misc)
+    assert_equivalent_html expected, @builder.url_field(:misc)
   end
 
   test "check_box fields are wrapped correctly" do
@@ -288,7 +288,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         <label class="form-check-label" for="user_misc">Misc</label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.check_box(:misc)
+    assert_equivalent_html expected, @builder.check_box(:misc)
   end
 
   test "switch-style check_box fields are wrapped correctly" do
@@ -299,7 +299,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         <label class="form-check-label" for="user_misc">Misc</label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.check_box(:misc, switch: true)
+    assert_equivalent_html expected, @builder.check_box(:misc, switch: true)
   end
 
   test "week fields are wrapped correctly" do
@@ -309,7 +309,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         <input class="form-control" id="user_misc" name="user[misc]" type="week" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.week_field(:misc)
+    assert_equivalent_html expected, @builder.week_field(:misc)
   end
 
   test "bootstrap_form_for helper works for associations" do
@@ -330,7 +330,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "bootstrap_form_for helper works for serialized hash attributes" do
@@ -351,7 +351,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "fields_for correctly passes horizontal style from parent builder" do
@@ -374,7 +374,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "fields_for correctly passes inline style from parent builder" do
@@ -396,7 +396,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "fields correctly uses options from parent builder" do
@@ -446,6 +446,6 @@ class BootstrapFieldsTest < ActionView::TestCase
         <label class="form-label required" for="user_email">Email</label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.text_field(:email, floating: true)
+    assert_equivalent_html expected, @builder.text_field(:email, floating: true)
   end
 end

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -12,7 +12,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.text_field(:email, label: "Email Address")
+    assert_equivalent_html expected, @builder.text_field(:email, label: "Email Address")
   end
 
   test "changing the label text via the html_options label hash" do
@@ -22,7 +22,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.text_field(:email, label: { text: "Email Address" })
+    assert_equivalent_html expected, @builder.text_field(:email, label: { text: "Email Address" })
   end
 
   test "hiding a label" do
@@ -32,7 +32,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.text_field(:email, hide_label: true)
+    assert_equivalent_html expected, @builder.text_field(:email, hide_label: true)
   end
 
   test "adding a custom label class via the label_class parameter" do
@@ -42,7 +42,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.text_field(:email, label_class: "btn")
+    assert_equivalent_html expected, @builder.text_field(:email, label_class: "btn")
   end
 
   test "adding a custom label class via the html_options label hash" do
@@ -52,7 +52,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.text_field(:email, label: { class: "btn" })
+    assert_equivalent_html expected, @builder.text_field(:email, label: { class: "btn" })
   end
 
   test "adding a custom label and changing the label text via the html_options label hash" do
@@ -62,7 +62,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.text_field(:email, label: { class: "btn", text: "Email Address" })
+    assert_equivalent_html expected, @builder.text_field(:email, label: { class: "btn", text: "Email Address" })
   end
 
   test "skipping a label" do
@@ -71,7 +71,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.text_field(:email, skip_label: true)
+    assert_equivalent_html expected, @builder.text_field(:email, skip_label: true)
   end
 
   test "preventing a label from having the required class with :skip_required" do
@@ -82,7 +82,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       </div>
     HTML
     assert_output(nil, "`:skip_required` is deprecated, use `:required: false` instead\n") do
-      assert_equivalent_xml expected, @builder.text_field(:email, skip_required: true)
+      assert_equivalent_html expected, @builder.text_field(:email, skip_required: true)
     end
   end
 
@@ -93,7 +93,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.text_field(:email, required: false)
+    assert_equivalent_html expected, @builder.text_field(:email, required: false)
   end
 
   test "forcing a label to have the required class" do
@@ -103,7 +103,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <input aria-required="true" class="form-control" id="user_comments" name="user[comments]" type="text" value="my comment" required="required" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.text_field(:comments, required: true)
+    assert_equivalent_html expected, @builder.text_field(:comments, required: true)
   end
 
   test "label as placeholder" do
@@ -113,7 +113,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <input aria-required="true" required="required" class="form-control" id="user_email" placeholder="Email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.text_field(:email, label_as_placeholder: true)
+    assert_equivalent_html expected, @builder.text_field(:email, label_as_placeholder: true)
   end
 
   test "adding prepend text" do
@@ -126,7 +126,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.text_field(:email, prepend: "@")
+    assert_equivalent_html expected, @builder.text_field(:email, prepend: "@")
   end
 
   test "adding append text" do
@@ -139,7 +139,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.text_field(:email, append: ".00")
+    assert_equivalent_html expected, @builder.text_field(:email, append: ".00")
   end
 
   test "append and prepend button" do
@@ -155,10 +155,10 @@ class BootstrapFormGroupTest < ActionView::TestCase
     before_button = prefix + button_prepend + field + suffix
     both_button = prefix + button_prepend + field + button_append + suffix
     multiple_button = prefix + button_prepend + button_prepend + field + button_append + button_append + suffix
-    assert_equivalent_xml after_button, @builder.text_field(:email, append: button_src)
-    assert_equivalent_xml before_button, @builder.text_field(:email, prepend: button_src)
-    assert_equivalent_xml both_button, @builder.text_field(:email, append: button_src, prepend: button_src)
-    assert_equivalent_xml multiple_button, @builder.text_field(:email, append: [button_src] * 2, prepend: [button_src] * 2)
+    assert_equivalent_html after_button, @builder.text_field(:email, append: button_src)
+    assert_equivalent_html before_button, @builder.text_field(:email, prepend: button_src)
+    assert_equivalent_html both_button, @builder.text_field(:email, append: button_src, prepend: button_src)
+    assert_equivalent_html multiple_button, @builder.text_field(:email, append: [button_src] * 2, prepend: [button_src] * 2)
   end
 
   test "adding both prepend and append text" do
@@ -166,13 +166,13 @@ class BootstrapFormGroupTest < ActionView::TestCase
       <div class="mb-3">
         <label class="form-label required" for="user_email">Email</label>
         <div class="input-group">
-          <span class="input-group-text">$</div>
+          <span class="input-group-text">$</span>
           <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
           <span class="input-group-text">.00</span>
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.text_field(:email, prepend: "$", append: ".00")
+    assert_equivalent_html expected, @builder.text_field(:email, prepend: "$", append: ".00")
   end
 
   test "adding both prepend and append text with validation error" do
@@ -185,7 +185,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <div class="mb-3">
           <label class="form-label required" for="user_email">Email</label>
           <div class="input-group">
-            <span class="input-group-text">$</div>
+            <span class="input-group-text">$</span>
             <input aria-required="true" required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
             <span class="input-group-text">.00</span>
             <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</span>
@@ -193,7 +193,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.text_field :email, prepend: "$", append: ".00" }
+    assert_equivalent_html expected, bootstrap_form_for(@user) { |f| f.text_field :email, prepend: "$", append: ".00" }
   end
 
   test "help messages for default forms" do
@@ -204,7 +204,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <small class="form-text text-muted">This is required</small>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.text_field(:email, help: "This is required")
+    assert_equivalent_html expected, @builder.text_field(:email, help: "This is required")
   end
 
   test "help messages for horizontal forms" do
@@ -217,7 +217,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, @horizontal_builder.text_field(:email, help: "This is required")
+    assert_equivalent_html expected, @horizontal_builder.text_field(:email, help: "This is required")
   end
 
   test "help messages to look up I18n automatically" do
@@ -228,7 +228,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <small class="form-text text-muted">A good password should be at least six characters long</small>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.text_field(:password)
+    assert_equivalent_html expected, @builder.text_field(:password)
   end
 
   test "help messages to look up I18n automatically using HTML key" do
@@ -249,7 +249,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <small class="form-text text-muted">A <strong>good</strong> password should be at least six characters long</small>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.text_field(:password)
+    assert_equivalent_html expected, @builder.text_field(:password)
   end
 
   test "help messages to warn about deprecated I18n key" do
@@ -277,7 +277,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <input class="form-control" id="user_password" name="user[password]" type="text" value="secret" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.text_field(:password, help: false)
+    assert_equivalent_html expected, @builder.text_field(:password, help: false)
   end
 
   test "form_group creates a valid structure and allows arbitrary html to be added via a block" do
@@ -293,7 +293,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "form_group adds a spacer when no label exists for a horizontal form" do
@@ -308,7 +308,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "form_group renders the label correctly" do
@@ -324,7 +324,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "form_group accepts class thorugh options hash" do
@@ -339,7 +339,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "form_group accepts class thorugh options hash without needing a name" do
@@ -354,7 +354,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "form_group horizontal lets caller override .row" do
@@ -369,7 +369,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "form_group overrides the label's 'class' and 'for' attributes if others are passed" do
@@ -385,7 +385,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test 'upgrade doc for form_group renders the "error" class and message corrrectly when object is invalid' do
@@ -407,7 +407,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <div class="invalid-feedback" style="display: block;">can’t be blank, is too short (minimum is 5 characters)</div>
       </div>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "upgrade doc for form_group renders check box corrrectly when object is invalid" do
@@ -441,7 +441,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "overrides the class of the wrapped form_group by a field" do
@@ -451,7 +451,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <input class="form-control" id="user_misc" name="user[misc]" type="search" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.search_field(:misc, wrapper_class: "none-margin")
+    assert_equivalent_html expected, @builder.search_field(:misc, wrapper_class: "none-margin")
   end
 
   test "overrides the class of the wrapped form_group by a field with errors" do
@@ -470,7 +470,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       </div>
     HTML
     output = @builder.email_field(:email, wrapper_class: "none-margin")
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "overrides the class of the wrapped form_group by a field with errors when bootstrap_form_for is used" do
@@ -492,7 +492,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "adds offset for form_group without label" do
@@ -507,7 +507,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "adds offset for form_group without label but specific label_col" do
@@ -522,7 +522,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   # TODO: What is this actually testing? Improve the test name
@@ -544,7 +544,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "adds data-attributes (or any other options) to wrapper" do
@@ -554,14 +554,14 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <input class="form-control" id="user_misc" name="user[misc]" type="search" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.search_field(:misc, wrapper: { data: { foo: "bar" } })
+    assert_equivalent_html expected, @builder.search_field(:misc, wrapper: { data: { foo: "bar" } })
   end
 
   test "rendering without wrapper" do
     expected = <<~HTML
       <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
     HTML
-    assert_equivalent_xml expected, @builder.text_field(:email, wrapper: false)
+    assert_equivalent_html expected, @builder.text_field(:email, wrapper: false)
   end
 
   test "rendering without wrapper class" do
@@ -571,7 +571,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <input class="form-control" id="user_misc" name="user[misc]" type="search" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.search_field(:misc, wrapper: { class: false })
+    assert_equivalent_html expected, @builder.search_field(:misc, wrapper: { class: false })
   end
 
   test "passing options to a form control get passed through" do
@@ -581,7 +581,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <input aria-required="true" required="required" autofocus="autofocus" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.text_field(:email, autofocus: true)
+    assert_equivalent_html expected, @builder.text_field(:email, autofocus: true)
   end
 
   test "doesn't throw undefined method error when the content block returns nil" do
@@ -594,7 +594,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <label class="form-label" for="user_nil">Foo</label>
       </div>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "custom form group layout option" do
@@ -607,7 +607,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, bootstrap_form_for(@user, layout: :horizontal) { |f| f.email_field :email, layout: :inline }
+    assert_equivalent_html expected, bootstrap_form_for(@user, layout: :horizontal) { |f| f.email_field :email, layout: :inline }
   end
 
   test "non-default column span on form is reflected in form_group" do
@@ -625,7 +625,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "non-default column span on form isn't mutated" do
@@ -635,7 +635,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     output = frozen_horizontal_builder.form_group { "test" }
 
     expected = '<div class="mb-3 row"><div class="col-sm-9 offset-sm-3">test</div></div>'
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test ":input_group_class should apply to input-group" do
@@ -648,7 +648,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.email_field(:email, append: @builder.primary("Subscribe"),
+    assert_equivalent_html expected, @builder.email_field(:email, append: @builder.primary("Subscribe"),
                                                                  input_group_class: "input-group-lg")
   end
 end

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -11,7 +11,7 @@ class BootstrapFormTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       </form>
     HTML
-    assert_equivalent_xml expected, bootstrap_form_for(@user) { |_f| nil }
+    assert_equivalent_html expected, bootstrap_form_for(@user) { |_f| nil }
   end
 
   test "default-style form fields layout horizontal" do
@@ -62,7 +62,7 @@ class BootstrapFormTest < ActionView::TestCase
       concat(f.select(:status, [["activated", 1], ["blocked", 2]], layout: :horizontal))
     end
 
-    assert_equivalent_xml expected, actual
+    assert_equivalent_html expected, actual
     # See the rendered output at: https://www.bootply.com/S2WFzEYChf
   end
 
@@ -108,7 +108,7 @@ class BootstrapFormTest < ActionView::TestCase
       concat(f.select(:status, [["activated", 1], ["blocked", 2]], layout: :inline))
     end
 
-    assert_equivalent_xml expected, actual
+    assert_equivalent_html expected, actual
     # See the rendered output at: https://www.bootply.com/fH5sF4fcju
     # Note that the baseline of the label text to the left of the two radio buttons
     # isn't aligned with the text of the radio button labels.
@@ -121,7 +121,7 @@ class BootstrapFormTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       </form>
     HTML
-    assert_equivalent_xml expected, bootstrap_form_with(model: @user) { |_f| nil }
+    assert_equivalent_html expected, bootstrap_form_with(model: @user) { |_f| nil }
   end
 
   test "inline-style forms" do
@@ -166,7 +166,7 @@ class BootstrapFormTest < ActionView::TestCase
       concat(f.select(:status, [["activated", 1], ["blocked", 2]]))
     end
 
-    assert_equivalent_xml expected, actual
+    assert_equivalent_html expected, actual
   end
 
   test "horizontal-style forms" do
@@ -217,7 +217,7 @@ class BootstrapFormTest < ActionView::TestCase
       concat(f.select(:status, [["activated", 1], ["blocked", 2]]))
     end
 
-    assert_equivalent_xml expected, actual
+    assert_equivalent_html expected, actual
   end
 
   test "horizontal-style form fields layout default" do
@@ -262,7 +262,7 @@ class BootstrapFormTest < ActionView::TestCase
       concat(f.select(:status, [["activated", 1], ["blocked", 2]], layout: :default))
     end
 
-    assert_equivalent_xml expected, actual
+    assert_equivalent_html expected, actual
     # See the rendered output at: https://www.bootply.com/4f23be1nLn
   end
 
@@ -308,7 +308,7 @@ class BootstrapFormTest < ActionView::TestCase
       concat(f.select(:status, [["activated", 1], ["blocked", 2]], layout: :inline))
     end
 
-    assert_equivalent_xml expected, actual
+    assert_equivalent_html expected, actual
     # See the rendered output here: https://www.bootply.com/Qby9FC9d3u#
   end
 
@@ -324,7 +324,7 @@ class BootstrapFormTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           bootstrap_form_for(@user, layout: :horizontal, html: { class: "my-style" }) { |f| f.email_field :email }
   end
 
@@ -334,7 +334,7 @@ class BootstrapFormTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       </form>
     HTML
-    assert_equivalent_xml expected, bootstrap_form_for(@user, html: { role: "not-a-form" }) { |_f| nil }
+    assert_equivalent_html expected, bootstrap_form_for(@user, html: { role: "not-a-form" }) { |_f| nil }
   end
 
   test "allows to set blank default form attributes via configuration" do
@@ -344,7 +344,7 @@ class BootstrapFormTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       </form>
     HTML
-    assert_equivalent_xml expected, bootstrap_form_for(@user) { |_f| nil }
+    assert_equivalent_html expected, bootstrap_form_for(@user) { |_f| nil }
   end
 
   test "allows to set custom default form attributes via configuration" do
@@ -354,7 +354,7 @@ class BootstrapFormTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
       </form>
     HTML
-    assert_equivalent_xml expected, bootstrap_form_for(@user) { |_f| nil }
+    assert_equivalent_html expected, bootstrap_form_for(@user) { |_f| nil }
   end
 
   test "bootstrap_form_tag acts like a form tag" do
@@ -367,7 +367,7 @@ class BootstrapFormTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           bootstrap_form_tag(url: "/users") { |f| f.text_field :email, label: "Your Email" }
   end
 
@@ -381,7 +381,7 @@ class BootstrapFormTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.text_field :email, name: "NAME", id: "ID" }
+    assert_equivalent_html expected, bootstrap_form_for(@user) { |f| f.text_field :email, name: "NAME", id: "ID" }
   end
 
   test "bootstrap_form_tag does not clobber custom options" do
@@ -394,7 +394,7 @@ class BootstrapFormTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, bootstrap_form_tag(url: "/users") { |f| f.text_field :email, name: "NAME", id: "ID" }
+    assert_equivalent_html expected, bootstrap_form_tag(url: "/users") { |f| f.text_field :email, name: "NAME", id: "ID" }
   end
 
   test "bootstrap_form_tag allows an empty name for checkboxes" do
@@ -408,7 +408,7 @@ class BootstrapFormTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, bootstrap_form_tag(url: "/users") { |f| f.check_box :misc }
+    assert_equivalent_html expected, bootstrap_form_tag(url: "/users") { |f| f.check_box :misc }
   end
 
   test "errors display correctly and inline_errors are turned off by default when label_errors is true" do
@@ -424,7 +424,7 @@ class BootstrapFormTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, bootstrap_form_for(@user, label_errors: true) { |f| f.text_field :email }
+    assert_equivalent_html expected, bootstrap_form_for(@user, label_errors: true) { |f| f.text_field :email }
   end
 
   test "errors display correctly and inline_errors can also be on when label_errors is true" do
@@ -441,7 +441,7 @@ class BootstrapFormTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, bootstrap_form_for(@user, label_errors: true, inline_errors: true) { |f| f.text_field :email }
+    assert_equivalent_html expected, bootstrap_form_for(@user, label_errors: true, inline_errors: true) { |f| f.text_field :email }
   end
 
   test "label error messages use humanized attribute names" do
@@ -460,7 +460,7 @@ class BootstrapFormTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, bootstrap_form_for(@user, label_errors: true, inline_errors: true) { |f| f.text_field :email }
+    assert_equivalent_html expected, bootstrap_form_for(@user, label_errors: true, inline_errors: true) { |f| f.text_field :email }
   ensure
     I18n.backend.store_translations(:en, activerecord: { attributes: { user: { email: nil } } })
   end
@@ -479,7 +479,7 @@ class BootstrapFormTest < ActionView::TestCase
         </ul>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.alert_message("Please fix the following errors:")
+    assert_equivalent_html expected, @builder.alert_message("Please fix the following errors:")
   end
 
   test "changing the class name for the alert message" do
@@ -496,7 +496,7 @@ class BootstrapFormTest < ActionView::TestCase
         </ul>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.alert_message("Please fix the following errors:", class: "my-css-class")
+    assert_equivalent_html expected, @builder.alert_message("Please fix the following errors:", class: "my-css-class")
   end
 
   test "alert_message contains the error summary when inline_errors are turned off" do
@@ -520,7 +520,7 @@ class BootstrapFormTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "alert_message allows the error_summary to be turned off" do
@@ -537,7 +537,7 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="alert alert-danger">Please fix the following errors:</div>
       </form>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "alert_message allows the error_summary to be turned on with inline_errors also turned on" do
@@ -561,7 +561,7 @@ class BootstrapFormTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "error_summary returns an unordered list of errors" do
@@ -575,7 +575,7 @@ class BootstrapFormTest < ActionView::TestCase
         <li>Terms must be accepted</li>
       </ul>
     HTML
-    assert_equivalent_xml expected, @builder.error_summary
+    assert_equivalent_html expected, @builder.error_summary
   end
 
   test "error_summary returns nothing if no errors" do
@@ -592,7 +592,7 @@ class BootstrapFormTest < ActionView::TestCase
     expected = <<~HTML
       <div class="invalid-feedback">Email can’t be blank, Email is too short (minimum is 5 characters)</div>
     HTML
-    assert_equivalent_xml expected, @builder.errors_on(:email)
+    assert_equivalent_html expected, @builder.errors_on(:email)
   end
 
   test "custom label width for horizontal forms" do
@@ -607,7 +607,7 @@ class BootstrapFormTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           bootstrap_form_for(@user, layout: :horizontal) { |f| f.email_field :email, label_col: "col-sm-1" }
   end
 
@@ -622,7 +622,7 @@ class BootstrapFormTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           bootstrap_form_for(@user, layout: :horizontal, label_col: "col-md-2",
                                                     control_col: "col-md-10") { |f| f.form_group { f.submit } }
   end
@@ -638,7 +638,7 @@ class BootstrapFormTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           bootstrap_form_for(@user, layout: :horizontal, label_col: "col-sm-4 col-md-2",
                                                     control_col: "col-sm-8 col-md-10") { |f| f.form_group { f.submit } }
   end
@@ -655,7 +655,7 @@ class BootstrapFormTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           bootstrap_form_for(@user, layout: :horizontal) { |f| f.email_field :email, control_col: "col-sm-5" }
   end
 
@@ -673,7 +673,7 @@ class BootstrapFormTest < ActionView::TestCase
     HTML
     actual = bootstrap_form_for(@user,
                                 layout: :horizontal) { |f| f.email_field :email, add_control_col_class: "custom-class" }
-    assert_equivalent_xml expected, actual
+    assert_equivalent_html expected, actual
   end
 
   test "the field contains the error and is not wrapped in div.field_with_errors when bootstrap_form_for is used" do
@@ -695,7 +695,7 @@ class BootstrapFormTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "the field is wrapped with div.field_with_errors when form_for is used" do
@@ -716,12 +716,12 @@ class BootstrapFormTest < ActionView::TestCase
           <div class="field_with_errors">
             <input aria-required="true" required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           </div>
-          <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</span>
+          <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</div>
           <small class="form-text text-muted">This is required</small>
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "help is preserved when inline_errors: false is passed to bootstrap_form_for" do
@@ -742,7 +742,7 @@ class BootstrapFormTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "help translations do not escape HTML when _html is appended to the name" do
@@ -762,7 +762,7 @@ class BootstrapFormTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   ensure
     I18n.backend.store_translations(:en, activerecord: { help: { user: { email_html: nil } } })
   end
@@ -775,7 +775,7 @@ class BootstrapFormTest < ActionView::TestCase
         <input class="form-control" id="other_model_email" name="other_model[email]" type="text" />
       </div>
     HTML
-    assert_equivalent_xml expected, builder.text_field(:email)
+    assert_equivalent_html expected, builder.text_field(:email)
   end
 
   test "errors_on hide attribute name in message" do
@@ -784,7 +784,7 @@ class BootstrapFormTest < ActionView::TestCase
 
     expected = '<div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</div>'
 
-    assert_equivalent_xml expected, @builder.errors_on(:email, hide_attribute_name: true)
+    assert_equivalent_html expected, @builder.errors_on(:email, hide_attribute_name: true)
   end
 
   test "errors_on use custom CSS classes" do
@@ -793,6 +793,6 @@ class BootstrapFormTest < ActionView::TestCase
 
     expected = '<div class="custom-error-class">Email can’t be blank, Email is too short (minimum is 5 characters)</div>'
 
-    assert_equivalent_xml expected, @builder.errors_on(:email, custom_class: "custom-error-class")
+    assert_equivalent_html expected, @builder.errors_on(:email, custom_class: "custom-error-class")
   end
 end

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -402,8 +402,8 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="form-check mb-3">
-          <input class="form-check-input" id="misc" name="misc" type="checkbox" value="1" />
           <input #{autocomplete_attr} name="misc" type="hidden" value="0" />
+          <input class="form-check-input" id="misc" name="misc" type="checkbox" value="1" />
           <label class="form-check-label" for="misc"> Misc</label>
         </div>
       </form>

--- a/test/bootstrap_other_components_test.rb
+++ b/test/bootstrap_other_components_test.rb
@@ -16,7 +16,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "static control can have custom_id" do
@@ -30,7 +30,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "static control doesn't require an actual attribute" do
@@ -44,7 +44,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "static control doesn't require a name" do
@@ -58,7 +58,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "static control support a nil value" do
@@ -72,7 +72,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "static control won't overwrite a control_class that is passed by the user" do
@@ -86,7 +86,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "custom control does't wrap given block in a p tag" do
@@ -100,7 +100,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
         <div class="col-sm-10">this is a test</div>
       </div>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "custom control doesn't require an actual attribute" do
@@ -114,7 +114,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
         <div class="col-sm-10">this is a test</div>
       </div>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "custom control doesn't require a name" do
@@ -128,14 +128,14 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
         <div class="col-sm-10">Custom Control</div>
       </div>
     HTML
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "regular button uses proper css classes" do
     expected = <<~HTML
       <button class="btn btn-secondary" extra="extra arg" name="button" type="submit"><span>I'm HTML!</span> in a button!</button>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @builder.button(
                             "<span>I'm HTML!</span> in a button!".html_safe,
                             extra: "extra arg"
@@ -146,43 +146,43 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
     expected = <<~HTML
       <button class="btn btn-secondary test-button" name="button" type="submit"><span>I'm HTML!</span> in a button!</button>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @builder.button("<span>I'm HTML!</span> in a button!".html_safe, extra_class: "test-button")
   end
 
   test "submit button defaults to rails action name" do
     expected = '<input class="btn btn-secondary" name="commit" type="submit" value="Create User" />'
-    assert_equivalent_xml expected, @builder.submit
+    assert_equivalent_html expected, @builder.submit
   end
 
   test "submit button uses default button classes" do
     expected = '<input class="btn btn-secondary" name="commit" type="submit" value="Submit Form" />'
-    assert_equivalent_xml expected, @builder.submit("Submit Form")
+    assert_equivalent_html expected, @builder.submit("Submit Form")
   end
 
   test "submit button can have extra css classes" do
     expected = '<input class="btn btn-secondary test-button" name="commit" type="submit" value="Submit Form" />'
-    assert_equivalent_xml expected, @builder.submit("Submit Form", extra_class: "test-button")
+    assert_equivalent_html expected, @builder.submit("Submit Form", extra_class: "test-button")
   end
 
   test "override submit button classes" do
     expected = '<input class="btn btn-primary" name="commit" type="submit" value="Submit Form" />'
-    assert_equivalent_xml expected, @builder.submit("Submit Form", class: "btn btn-primary")
+    assert_equivalent_html expected, @builder.submit("Submit Form", class: "btn btn-primary")
   end
 
   test "primary button uses proper css classes" do
     expected = '<input class="btn btn-primary" extra="extra arg" name="commit" type="submit" value="Submit Form" />'
-    assert_equivalent_xml expected, @builder.primary("Submit Form", extra: "extra arg")
+    assert_equivalent_html expected, @builder.primary("Submit Form", extra: "extra arg")
   end
 
   test "primary button can have extra css classes" do
     expected = '<input class="btn btn-primary test-button" name="commit" type="submit" value="Submit Form" />'
-    assert_equivalent_xml expected, @builder.primary("Submit Form", extra_class: "test-button")
+    assert_equivalent_html expected, @builder.primary("Submit Form", extra_class: "test-button")
   end
 
   test "primary button can render as HTML button" do
     expected = %q(<button class="btn btn-primary" name="button" type="submit"><span>I'm HTML!</span> Submit Form</button>)
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @builder.primary("<span>I'm HTML!</span> Submit Form".html_safe,
                                            render_as_button: true)
   end
@@ -192,11 +192,11 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
       "<span>I'm HTML!</span> Submit Form".html_safe
     end
     expected = %q(<button class="btn btn-primary" name="button" type="submit"><span>I'm HTML!</span> Submit Form</button>)
-    assert_equivalent_xml expected, output
+    assert_equivalent_html expected, output
   end
 
   test "override primary button classes" do
     expected = '<input class="btn btn-primary disabled" name="commit" type="submit" value="Submit Form" />'
-    assert_equivalent_xml expected, @builder.primary("Submit Form", class: "btn btn-primary disabled")
+    assert_equivalent_html expected, @builder.primary("Submit Form", class: "btn btn-primary disabled")
   end
 end

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -14,7 +14,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.radio_button(:misc, "1", label: "This is a radio button", extra: "extra arg")
+    assert_equivalent_html expected, @builder.radio_button(:misc, "1", label: "This is a radio button", extra: "extra arg")
   end
 
   test "radio_button no label" do
@@ -25,7 +25,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       </div>
     HTML
     # &#8203; is a zero-width space.
-    assert_equivalent_xml expected, @builder.radio_button(:misc, "1", label: "&#8203;".html_safe)
+    assert_equivalent_html expected, @builder.radio_button(:misc, "1", label: "&#8203;".html_safe)
   end
 
   test "radio_button with error is wrapped correctly" do
@@ -45,7 +45,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     actual = bootstrap_form_for(@user) do |f|
       f.radio_button(:misc, "1", label: "This is a radio button", error_message: true)
     end
-    assert_equivalent_xml expected, actual
+    assert_equivalent_html expected, actual
   end
 
   test "radio_button disabled label is set correctly" do
@@ -57,7 +57,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.radio_button(:misc, "1", label: "This is a radio button", disabled: true)
+    assert_equivalent_html expected, @builder.radio_button(:misc, "1", label: "This is a radio button", disabled: true)
   end
 
   test "radio_button label class is set correctly" do
@@ -69,7 +69,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.radio_button(:misc, "1", label: "This is a radio button", label_class: "btn")
+    assert_equivalent_html expected, @builder.radio_button(:misc, "1", label: "This is a radio button", label_class: "btn")
   end
 
   test "radio_button 'id' attribute is used to specify label 'for' attribute" do
@@ -81,7 +81,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.radio_button(:misc, "1", label: "This is a radio button", id: "custom_id")
+    assert_equivalent_html expected, @builder.radio_button(:misc, "1", label: "This is a radio button", id: "custom_id")
   end
 
   test "radio_button inline label is set correctly" do
@@ -93,7 +93,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.radio_button(:misc, "1", label: "This is a radio button", inline: true)
+    assert_equivalent_html expected, @builder.radio_button(:misc, "1", label: "This is a radio button", inline: true)
   end
 
   test "radio_button inline label is set correctly from form level" do
@@ -111,7 +111,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     actual = bootstrap_form_for(@user, layout: :inline) do |f|
       f.radio_button(:misc, "1", label: "This is a radio button")
     end
-    assert_equivalent_xml expected, actual
+    assert_equivalent_html expected, actual
   end
 
   test "radio_button disabled inline label is set correctly" do
@@ -123,7 +123,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.radio_button(:misc, "1", label: "This is a radio button", inline: true, disabled: true)
+    assert_equivalent_html expected, @builder.radio_button(:misc, "1", label: "This is a radio button", inline: true, disabled: true)
   end
 
   test "radio_button inline label class is set correctly" do
@@ -135,7 +135,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @builder.radio_button(:misc, "1", label: "This is a radio button", inline: true, label_class: "btn")
   end
 
@@ -154,7 +154,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @builder.collection_radio_buttons(:misc, collection, :id, :street,
                                                             label: "This is a radio button collection", help: "With a help!")
   end
@@ -175,7 +175,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected, @builder.collection_radio_buttons(:misc, collection, :id, :street)
+    assert_equivalent_html expected, @builder.collection_radio_buttons(:misc, collection, :id, :street)
   end
 
   test "collection_radio_buttons renders multiple radios with error correctly" do
@@ -202,7 +202,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     actual = bootstrap_form_for(@user) do |f|
       f.collection_radio_buttons(:misc, collection, :id, :street)
     end
-    assert_equivalent_xml expected, actual
+    assert_equivalent_html expected, actual
   end
 
   test "collection_radio_buttons renders inline radios correctly" do
@@ -221,7 +221,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected, @builder.collection_radio_buttons(:misc, collection, :id, :street, inline: true)
+    assert_equivalent_html expected, @builder.collection_radio_buttons(:misc, collection, :id, :street, inline: true)
   end
 
   test "collection_radio_buttons renders with checked option correctly" do
@@ -240,7 +240,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected, @builder.collection_radio_buttons(:misc, collection, :id, :street, checked: 1)
+    assert_equivalent_html expected, @builder.collection_radio_buttons(:misc, collection, :id, :street, checked: 1)
   end
 
   test "collection_radio_buttons renders label defined by Proc correctly" do
@@ -256,7 +256,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @builder.collection_radio_buttons(:misc, collection, :id, proc { |a| a.street.reverse },
                                                             label: "This is a radio button collection", help: "With a help!")
   end
@@ -274,7 +274,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @builder.collection_radio_buttons(:misc, collection, proc { |a| "address_#{a.id}" },
                                                             :street, label: "This is a radio button collection",
                                                                      help: "With a help!")
@@ -296,7 +296,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected, @builder.collection_radio_buttons(:misc, collection, :id, proc { |a| a.street.reverse })
+    assert_equivalent_html expected, @builder.collection_radio_buttons(:misc, collection, :id, proc { |a| a.street.reverse })
   end
 
   test "collection_radio_buttons renders multiple radios with value defined by Proc correctly" do
@@ -315,7 +315,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected, @builder.collection_radio_buttons(:misc, collection, proc { |a| "address_#{a.id}" }, :street)
+    assert_equivalent_html expected, @builder.collection_radio_buttons(:misc, collection, proc { |a| "address_#{a.id}" }, :street)
   end
 
   test "collection_radio_buttons renders label defined by lambda correctly" do
@@ -331,7 +331,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @builder.collection_radio_buttons(:misc, collection, :id, ->(a) { a.street.reverse },
                                                             label: "This is a radio button collection", help: "With a help!")
   end
@@ -349,7 +349,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @builder.collection_radio_buttons(:misc, collection, ->(a) { "address_#{a.id}" },
                                                             :street, label: "This is a radio button collection",
                                                                      help: "With a help!")
@@ -371,7 +371,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected, @builder.collection_radio_buttons(:misc, collection, :id, ->(a) { a.street.reverse })
+    assert_equivalent_html expected, @builder.collection_radio_buttons(:misc, collection, :id, ->(a) { a.street.reverse })
   end
 
   test "collection_radio_buttons renders multiple radios with value defined by lambda correctly" do
@@ -390,7 +390,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_xml expected, @builder.collection_radio_buttons(:misc, collection, ->(a) { "address_#{a.id}" }, :street)
+    assert_equivalent_html expected, @builder.collection_radio_buttons(:misc, collection, ->(a) { "address_#{a.id}" }, :street)
   end
 
   test "radio button skip label" do
@@ -399,7 +399,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         <input class="form-check-input position-static" id="user_misc_1" name="user[misc]" type="radio" value="1" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.radio_button(:misc, "1", label: "This is a radio button", skip_label: true)
+    assert_equivalent_html expected, @builder.radio_button(:misc, "1", label: "This is a radio button", skip_label: true)
   end
 
   test "radio button hide label" do
@@ -409,7 +409,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         <label class="form-check-label visually-hidden" for="user_misc_1">This is a radio button</label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.radio_button(:misc, "1", label: "This is a radio button", hide_label: true)
+    assert_equivalent_html expected, @builder.radio_button(:misc, "1", label: "This is a radio button", hide_label: true)
   end
 
   test "radio button with custom wrapper class" do
@@ -421,7 +421,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @builder.radio_button(:misc, "1", label: "This is a radio button", wrapper_class: "custom-class")
   end
 
@@ -434,7 +434,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @builder.radio_button(:misc, "1", label: "This is a radio button", inline: true,
                                                             wrapper_class: "custom-class")
   end
@@ -448,7 +448,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.radio_button(:misc, "0", label: "This is a radio button", required: true)
+    assert_equivalent_html expected, @builder.radio_button(:misc, "0", label: "This is a radio button", required: true)
   end
 
   test "a required attribute as radiobutton" do
@@ -460,6 +460,6 @@ class BootstrapRadioButtonTest < ActionView::TestCase
         </label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.radio_button(:email, "0", label: "This is a radio button")
+    assert_equivalent_html expected, @builder.radio_button(:email, "0", label: "This is a radio button")
   end
 end

--- a/test/bootstrap_rich_text_area_test.rb
+++ b/test/bootstrap_rich_text_area_test.rb
@@ -29,7 +29,7 @@ if Rails::VERSION::STRING > "6"
           </div>
         HTML
       end
-      assert_equivalent_xml expected, form_with_builder.rich_text_area(:life_story, extra: "extra arg")
+      assert_equivalent_html expected, form_with_builder.rich_text_area(:life_story, extra: "extra arg")
     end
 
     def data_blob_url_template

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -21,7 +21,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         <select class="form-select" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.time_zone_select(:misc)
+    assert_equivalent_html expected, @builder.time_zone_select(:misc)
   end
 
   test "time zone selects are wrapped correctly with wrapper" do
@@ -31,7 +31,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         <select class="form-select" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.time_zone_select(:misc, nil, wrapper: { class: "none-margin" })
+    assert_equivalent_html expected, @builder.time_zone_select(:misc, nil, wrapper: { class: "none-margin" })
   end
 
   test "time zone selects are wrapped correctly with error" do
@@ -46,7 +46,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.time_zone_select(:misc) }
+    assert_equivalent_html expected, bootstrap_form_for(@user) { |f| f.time_zone_select(:misc) }
   end
 
   test "selects are wrapped correctly" do
@@ -59,7 +59,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         </select>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.select(:status, [["activated", 1], ["blocked", 2]], extra: "extra arg")
+    assert_equivalent_html expected, @builder.select(:status, [["activated", 1], ["blocked", 2]], extra: "extra arg")
   end
 
   test "bootstrap_specific options are handled correctly" do
@@ -73,7 +73,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         <small class="form-text text-muted">Help!</small>
       </div>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @builder.select(:status,
                                           [
                                             ["activated", 1],
@@ -95,7 +95,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         </select>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.select(:status, [["activated", 1], ["blocked", 2]], prompt: "Please Select")
+    assert_equivalent_html expected, @builder.select(:status, [["activated", 1], ["blocked", 2]], prompt: "Please Select")
   end
 
   test "selects with both options and html_options are wrapped correctly" do
@@ -109,7 +109,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         </select>
       </div>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @builder.select(:status, [["activated", 1], ["blocked", 2]], { prompt: "Please Select" },
                                           class: "my-select", extra: "extra arg")
   end
@@ -125,7 +125,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         </select>
       </div>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @builder.select(:status, [["activated", 1], ["blocked", 2]], { prompt: "Please Select" }, id: "custom_id")
   end
 
@@ -143,7 +143,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.select(:status, [["activated", 1], ["blocked", 2]], prepend: "Before", append: "After")
+    assert_equivalent_html expected, @builder.select(:status, [["activated", 1], ["blocked", 2]], prepend: "Before", append: "After")
   end
 
   test "selects with block use block as content" do
@@ -160,7 +160,7 @@ class BootstrapSelectsTest < ActionView::TestCase
       tag.option { "Option 1" } +
         tag.option { "Option 2" }
     end
-    assert_equivalent_xml expected, select
+    assert_equivalent_html expected, select
   end
 
   test "selects render labels properly" do
@@ -173,7 +173,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         </select>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.select(:status, [["activated", 1], ["blocked", 2]], label: "User Status")
+    assert_equivalent_html expected, @builder.select(:status, [["activated", 1], ["blocked", 2]], label: "User Status")
   end
 
   test "collection_selects are wrapped correctly" do
@@ -183,7 +183,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         <select class="form-select" id="user_status" name="user[status]"></select>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.collection_select(:status, [], :id, :name, extra: "extra arg")
+    assert_equivalent_html expected, @builder.collection_select(:status, [], :id, :name, extra: "extra arg")
   end
 
   test "collection_selects are wrapped correctly with wrapper" do
@@ -193,7 +193,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         <select class="form-select" id="user_status" name="user[status]"></select>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.collection_select(:status, [], :id, :name, wrapper: { class: "none-margin" })
+    assert_equivalent_html expected, @builder.collection_select(:status, [], :id, :name, wrapper: { class: "none-margin" })
   end
 
   test "collection_selects are wrapped correctly with error" do
@@ -208,7 +208,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.collection_select(:status, [], :id, :name) }
+    assert_equivalent_html expected, bootstrap_form_for(@user) { |f| f.collection_select(:status, [], :id, :name) }
   end
 
   test "collection_selects with options are wrapped correctly" do
@@ -220,7 +220,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         </select>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.collection_select(:status, [], :id, :name, prompt: "Please Select")
+    assert_equivalent_html expected, @builder.collection_select(:status, [], :id, :name, prompt: "Please Select")
   end
 
   test "collection_selects with options and html_options are wrapped correctly" do
@@ -232,7 +232,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         </select>
       </div>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @builder.collection_select(:status, [], :id, :name, { prompt: "Please Select" }, class: "my-select")
   end
 
@@ -249,7 +249,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @builder.collection_select(:status, [], :id, :name,
                                                      { prepend: "Before", append: "After", prompt: "Please Select" })
   end
@@ -261,7 +261,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         <select class="form-select" id="user_status" name="user[status]"></select>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.grouped_collection_select(:status, [], :last, :first, :to_s, :to_s, extra: "extra arg")
+    assert_equivalent_html expected, @builder.grouped_collection_select(:status, [], :last, :first, :to_s, :to_s, extra: "extra arg")
   end
 
   test "grouped_collection_selects are wrapped correctly with wrapper" do
@@ -271,7 +271,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         <select class="form-select" id="user_status" name="user[status]"></select>
       </div>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @builder.grouped_collection_select(:status, [], :last, :first, :to_s, :to_s, wrapper_class: "none-margin")
   end
 
@@ -287,7 +287,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         </div>
       </form>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           bootstrap_form_for(@user) { |f| f.grouped_collection_select(:status, [], :last, :first, :to_s, :to_s) }
   end
 
@@ -300,7 +300,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         </select>
       </div>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @builder.grouped_collection_select(:status, [], :last, :first, :to_s, :to_s, prompt: "Please Select")
   end
 
@@ -313,7 +313,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         </select>
       </div>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @builder.grouped_collection_select(:status, [], :last, :first, :to_s, :to_s, { prompt: "Please Select" },
                                                              class: "my-select")
   end
@@ -331,7 +331,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         </div>
       </div>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @builder.grouped_collection_select(:status, [], :last, :first, :to_s, :to_s,
                                                              { prepend: "Before", append: "After", prompt: "Please Select" })
   end
@@ -354,7 +354,7 @@ class BootstrapSelectsTest < ActionView::TestCase
           </div>
         </div>
       HTML
-      assert_equivalent_xml expected, @builder.date_select(:misc)
+      assert_equivalent_html expected, @builder.date_select(:misc)
     end
   end
 
@@ -376,7 +376,7 @@ class BootstrapSelectsTest < ActionView::TestCase
           </div>
         </div>
       HTML
-      assert_equivalent_xml expected, @builder.date_select(:misc, wrapper_class: "none-margin", extra: "extra arg")
+      assert_equivalent_html expected, @builder.date_select(:misc, wrapper_class: "none-margin", extra: "extra arg")
     end
   end
 
@@ -403,7 +403,7 @@ class BootstrapSelectsTest < ActionView::TestCase
           </div>
         </form>
       HTML
-      assert_equivalent_xml expected, bootstrap_form_for(@user, layout: :horizontal) { |f| f.date_select(:misc) }
+      assert_equivalent_html expected, bootstrap_form_for(@user, layout: :horizontal) { |f| f.date_select(:misc) }
     end
   end
 
@@ -430,7 +430,7 @@ class BootstrapSelectsTest < ActionView::TestCase
           </div>
         </form>
       HTML
-      assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.date_select(:misc) }
+      assert_equivalent_html expected, bootstrap_form_for(@user) { |f| f.date_select(:misc) }
     end
   end
 
@@ -456,7 +456,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         </div>
       HTML
 
-      assert_equivalent_xml expected, @builder.date_select(:misc, include_blank: true)
+      assert_equivalent_html expected, @builder.date_select(:misc, include_blank: true)
     end
   end
 
@@ -481,7 +481,7 @@ class BootstrapSelectsTest < ActionView::TestCase
           </div>
         </div>
       HTML
-      assert_equivalent_xml expected, @builder.date_select(:misc, { include_blank: true }, class: "my-date-select")
+      assert_equivalent_html expected, @builder.date_select(:misc, { include_blank: true }, class: "my-date-select")
     end
   end
 
@@ -504,7 +504,7 @@ class BootstrapSelectsTest < ActionView::TestCase
           </div>
         </div>
       HTML
-      assert_equivalent_xml expected, @builder.time_select(:misc, extra: "extra arg")
+      assert_equivalent_html expected, @builder.time_select(:misc, extra: "extra arg")
     end
   end
 
@@ -532,7 +532,7 @@ class BootstrapSelectsTest < ActionView::TestCase
           </div>
         </form>
       HTML
-      assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.time_select(:misc) }
+      assert_equivalent_html expected, bootstrap_form_for(@user) { |f| f.time_select(:misc) }
     end
   end
 
@@ -557,7 +557,7 @@ class BootstrapSelectsTest < ActionView::TestCase
           </div>
         </div>
       HTML
-      assert_equivalent_xml expected, @builder.time_select(:misc, include_blank: true)
+      assert_equivalent_html expected, @builder.time_select(:misc, include_blank: true)
     end
   end
 
@@ -582,7 +582,7 @@ class BootstrapSelectsTest < ActionView::TestCase
           </div>
         </div>
       HTML
-      assert_equivalent_xml expected, @builder.time_select(:misc, { include_blank: true }, class: "my-time-select")
+      assert_equivalent_html expected, @builder.time_select(:misc, { include_blank: true }, class: "my-time-select")
     end
   end
 
@@ -612,7 +612,7 @@ class BootstrapSelectsTest < ActionView::TestCase
           </div>
         </div>
       HTML
-      assert_equivalent_xml expected, @builder.datetime_select(:misc)
+      assert_equivalent_html expected, @builder.datetime_select(:misc)
     end
   end
 
@@ -647,7 +647,7 @@ class BootstrapSelectsTest < ActionView::TestCase
           </div>
         </form>
       HTML
-      assert_equivalent_xml expected, bootstrap_form_for(@user) { |f| f.datetime_select(:misc) }
+      assert_equivalent_html expected, bootstrap_form_for(@user) { |f| f.datetime_select(:misc) }
     end
   end
 
@@ -682,7 +682,7 @@ class BootstrapSelectsTest < ActionView::TestCase
           </div>
         </div>
       HTML
-      assert_equivalent_xml expected, @builder.datetime_select(:misc, include_blank: true)
+      assert_equivalent_html expected, @builder.datetime_select(:misc, include_blank: true)
     end
   end
 
@@ -717,7 +717,7 @@ class BootstrapSelectsTest < ActionView::TestCase
           </div>
         </div>
       HTML
-      assert_equivalent_xml expected, @builder.datetime_select(:misc,
+      assert_equivalent_html expected, @builder.datetime_select(:misc,
                                                                { include_blank: true },
                                                                class: "my-datetime-select",
                                                                extra: "extra arg")
@@ -734,7 +734,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         </select>
       </div>
     HTML
-    assert_equivalent_xml expected,
+    assert_equivalent_html expected,
                           @builder.select(:misc,
                                           [["Apple", 1], ["Grape", 2]],
                                           {
@@ -754,7 +754,7 @@ class BootstrapSelectsTest < ActionView::TestCase
         <label class="form-label" for="user_misc">Misc</label>
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.select(:misc, [["Apple", 1], ["Grape", 2]], floating: true)
+    assert_equivalent_html expected, @builder.select(:misc, [["Apple", 1], ["Grape", 2]], floating: true)
   end
 
   def blank_option

--- a/test/bootstrap_without_fields_test.rb
+++ b/test/bootstrap_without_fields_test.rb
@@ -9,6 +9,6 @@ class BootstrapWithoutFieldsTest < ActionView::TestCase
     expected = <<~HTML
       <input id="user_misc" name="user[misc]" type="color" value="#000000"/>
     HTML
-    assert_equivalent_xml expected, @builder.color_field_without_bootstrap(:misc)
+    assert_equivalent_html expected, @builder.color_field_without_bootstrap(:misc)
   end
 end

--- a/test/special_form_class_models_test.rb
+++ b/test/special_form_class_models_test.rb
@@ -25,7 +25,7 @@ class SpecialFormClassModelsTest < ActionView::TestCase
         <input class="form-control" id="user_misc" name="user[misc]" type="date" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.date_field(:misc)
+    assert_equivalent_html expected, @builder.date_field(:misc)
   end
 
   test "Nil models are supported for form builder" do
@@ -45,7 +45,7 @@ class SpecialFormClassModelsTest < ActionView::TestCase
         <input class="form-control" id="user_misc" name="user[misc]" type="date" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.date_field(:misc)
+    assert_equivalent_html expected, @builder.date_field(:misc)
   end
 
   test "Objects without model names are supported for form builder" do
@@ -67,6 +67,6 @@ class SpecialFormClassModelsTest < ActionView::TestCase
         <input class="form-control" id="user_misc" name="user[misc]" type="date" />
       </div>
     HTML
-    assert_equivalent_xml expected, @builder.date_field(:misc)
+    assert_equivalent_html expected, @builder.date_field(:misc)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -54,17 +54,16 @@ class ActionView::TestCase
     end
   end
 
-  # Expected and actual are wrapped in a root tag to ensure proper XML structure
-  def assert_equivalent_xml(expected, actual)
+  def assert_equivalent_html(expected, actual)
     expected = expected.tr("’", "'") if Rails::VERSION::STRING < "7.1"
-    expected_xml        = Nokogiri::XML("<test-xml>\n#{expected}\n</test-xml>") { |config| config.default_xml.noblanks }
-    actual_xml          = Nokogiri::XML("<test-xml>\n#{actual}\n</test-xml>") { |config| config.default_xml.noblanks }
+    expected_html        = Nokogiri::HTML.fragment(expected) { |config| config.default_xml.noblanks }
+    actual_html          = Nokogiri::HTML.fragment(actual) { |config| config.default_xml.noblanks }
 
-    expected_xml = sort_attributes(expected_xml)
-    actual_xml = sort_attributes(actual_xml)
+    expected_html = sort_attributes(expected_html)
+    actual_html = sort_attributes(actual_html)
 
     equivalent = EquivalentXml.equivalent?(
-      expected_xml, actual_xml, element_order: true
+      expected_html, actual_html, element_order: true
     ) do |a, b, result|
       looser_result = equivalent_with_looser_criteria?(a, b, result)
       break false unless looser_result
@@ -74,8 +73,8 @@ class ActionView::TestCase
     assert equivalent, lambda {
       # using a lambda because diffing is expensive
       Diffy::Diff.new(
-        expected_xml.root.to_xml(indent: 2),
-        actual_xml.root.to_xml(indent: 2)
+        expected_html.to_html(indent: 2),
+        actual_html.to_html(indent: 2)
       ).to_s(:color)
     }
   end


### PR DESCRIPTION
In working on a new implementation, it began to look like tests were passing when they shouldn't have passed. I made a branch off `main` and confirmed that we weren't testing the order of elements, which is significant in HTML.

Once that was fixed, it turned out that our code for handling some of the variations was also passing tests that it shouldn't have been passing. A couple of more changes fixed that.

Finally, three tests were failing because the expected strings were incorrect, but the other issues mentioned above were hiding that the tests should have failed.

In the process of fixing, we changed to use Nokogiri's HTML instead of XML. And to make it clear, the assertion helper was changed in all the test files.

Fixes: #674