### PR TITLE
Don't set required and aria-required for attributes with conditional presence validators

### DIFF
--- a/demo/app/models/user.rb
+++ b/demo/app/models/user.rb
@@ -10,6 +10,10 @@ class User < ApplicationRecord
   validates :email, presence: true, length: { minimum: 5 }
   validates :terms, acceptance: { accept: true }
 
+  # Conditional (always disabled) validators used in tests
+  validates :status, presence: true, if: -> { age > 42 }
+  validates :misc, presence: true, unless: -> { feet == 5 }
+
   has_one :address
   accepts_nested_attributes_for :address
 

--- a/lib/bootstrap_form/components/validation.rb
+++ b/lib/bootstrap_form/components/validation.rb
@@ -26,7 +26,7 @@ module BootstrapForm
         target = obj.instance_of?(Class) ? obj : obj.class
         return false unless target.respond_to? :validators_on
 
-        presence_validator?(target_validators(target, attribute)) ||
+        presence_validator?(target_unconditional_validators(target, attribute)) ||
           required_association?(target, attribute)
       end
 
@@ -35,12 +35,14 @@ module BootstrapForm
           next unless a.is_a?(ActiveRecord::Reflection::BelongsToReflection)
           next unless a.foreign_key == attribute.to_s
 
-          presence_validator?(target_validators(target, name))
+          presence_validator?(target_unconditional_validators(target, name))
         end
       end
 
-      def target_validators(target, attribute)
-        target.validators_on(attribute).map(&:class)
+      def target_unconditional_validators(target, attribute)
+        target.validators_on(attribute)
+              .reject { |validator| validator.options[:if].present? || validator.options[:unless].present? }
+              .map(&:class)
       end
 
       def presence_validator?(target_validators)

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -644,4 +644,26 @@ class BootstrapCheckboxTest < ActionView::TestCase
     HTML
     assert_equivalent_html expected, @builder.check_box(:email, label: "Email")
   end
+
+  test "an attribute with required and if is not marked as required" do
+    expected = <<~HTML
+      <div class="form-check mb-3">
+        <input #{autocomplete_attr} name="user[status]" type="hidden" value="0"/>
+        <input class="form-check-input" id="user_status" name="user[status]" type="checkbox" value="1"/>
+        <label class="form-check-label" for="user_status">Status</label>
+      </div>
+    HTML
+    assert_equivalent_html expected, @builder.check_box(:status, label: "Status")
+  end
+
+  test "an attribute with presence validator and unless is not marked as required" do
+    expected = <<~HTML
+      <div class="form-check mb-3">
+        <input #{autocomplete_attr} name="user[misc]" type="hidden" value="0"/>
+        <input class="form-check-input" id="user_misc" name="user[misc]" type="checkbox" value="1"/>
+        <label class="form-check-label" for="user_misc">Misc</label>
+      </div>
+    HTML
+    assert_equivalent_html expected, @builder.check_box(:misc)
+  end
 end


### PR DESCRIPTION
After the nice addition in: https://github.com/bootstrap-ruby/bootstrap_form/pull/664 I've run into issues with attributes that have conditional presence validators (:if and :unless). This PR fixes that, so the required HTML-attributes are only added when we are sure the attributes are always required.