### PR TITLE
Remove aria-required attribute from semantic element `input`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This generates the following HTML:
 <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
   <div class="mb-3">
     <label class="form-label required" for="user_email">Email</label>
-    <input aria-required="true" class="form-control" id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
+    <input class="form-control" id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
   </div>
   <div class="mb-3">
     <label class="form-label" for="user_password">Password</label>
@@ -143,7 +143,7 @@ This generates:
 <form accept-charset="UTF-8" action="/users" method="post">
   <div class="mb-3">
     <label class="form-label required" for="user_email">Email</label>
-    <input aria-required="true" class="form-control" id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
+    <input class="form-control" id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
   </div>
   <div class="mb-3">
     <label class="form-label" for="user_password">Password</label>
@@ -276,7 +276,7 @@ This generates:
 ```html
 <div class="mb-3">
   <label class="custom-class required" for="user_email">Email</label>
-  <input aria-required="true" class="form-control" id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
+  <input class="form-control" id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
 </div>
 ```
 
@@ -292,7 +292,7 @@ This generates:
 ```html
 <div class="mb-3">
   <label class="visually-hidden required" for="user_email">Email</label>
-  <input aria-required="true" class="form-control" id="user_email" name="user[email]" placeholder="Email" required="required" type="email" value="">
+  <input class="form-control" id="user_email" name="user[email]" placeholder="Email" required="required" type="email" value="">
 </div>
 ```
 
@@ -310,7 +310,7 @@ This generates:
 ```html
 <div class="mb-3">
   <label class="form-label required" for="user_email">Email</label>
-  <input aria-required="true" class="custom-class" id="user_email" name="user[email]" required="required" type="text" value="steve@example.com">
+  <input class="custom-class" id="user_email" name="user[email]" required="required" type="text" value="steve@example.com">
 </div>
 ```
 
@@ -440,7 +440,7 @@ This generates:
 <div class="mb-3">
   <label class="form-label required" for="user_email">Email</label>
   <div class="input-group input-group-lg">
-    <input aria-required="true" class="form-control" id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
+    <input class="form-control" id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
     <input class="btn btn-primary" data-disable-with="Subscribe" name="commit" type="submit" value="Subscribe">
   </div>
 </div>
@@ -505,7 +505,7 @@ Generated HTML:
 
 ```html
 <div class="mb-3">
-  <input aria-required="true" class="form-control" id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
+  <input class="form-control" id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
 </div>
 ```
 
@@ -773,7 +773,7 @@ This generates:
 ```html
 <div class="mb-3">
   <label class="form-label required" for="user_email">Email</label>
-  <input aria-required="true" class="form-control-plaintext" id="user_email" name="user[email]" readonly required="required" type="text" value="steve@example.com">
+  <input class="form-control-plaintext" id="user_email" name="user[email]" readonly required="required" type="text" value="steve@example.com">
 </div>
 ```
 
@@ -793,7 +793,7 @@ This generates:
   <div class="mb-3 row">
     <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
     <div class="col-sm-10">
-      <input aria-required="true" class="form-control-plaintext" id="user_email" name="user[email]" readonly required="required" type="text" value="steve@example.com">
+      <input class="form-control-plaintext" id="user_email" name="user[email]" readonly required="required" type="text" value="steve@example.com">
     </div>
   </div>
 </form>
@@ -1054,7 +1054,7 @@ This generates:
 <form accept-charset="UTF-8" action="/users" class="new_user row row-cols-auto g-3 align-items-center" id="new_user" method="post">
   <div class="col">
     <label class="visually-hidden required" for="user_email">Email</label>
-    <input aria-required="true" class="form-control" id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
+    <input class="form-control" id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
   </div>
   <div class="col">
     <label class="visually-hidden" for="user_password">Password</label>
@@ -1116,7 +1116,7 @@ This generates:
   <div class="mb-3 row">
     <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
     <div class="col-sm-10">
-      <input aria-required="true" class="form-control" id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
+      <input class="form-control" id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
     </div>
   </div>
   <div class="mb-3 row">
@@ -1163,7 +1163,7 @@ This generates:
   <div class="mb-3 row">
     <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
     <div class="col-sm-10">
-      <input aria-required="true" class="form-control" id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
+      <input class="form-control" id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
     </div>
   </div>
   <div class="mb-3 row">
@@ -1229,7 +1229,7 @@ This generates:
   <div class="mb-3 row">
     <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
     <div class="col-sm-10">
-      <input aria-required="true" class="form-control" id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
+      <input class="form-control" id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
     </div>
   </div>
   <div class="mb-3 row">
@@ -1270,7 +1270,7 @@ This generates:
   <div class="mb-3 row">
     <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
     <div class="col-sm-10">
-      <input aria-required="true" class="form-control" id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
+      <input class="form-control" id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
     </div>
   </div>
   <div class="row">
@@ -1321,7 +1321,7 @@ This generates:
 ```html
 <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
   <div class="mb-3 form-floating">
-    <input aria-required="true" class="form-control" id="user_email" name="user[email]" placeholder="Email" required="required" type="email" value="steve@example.com">
+    <input class="form-control" id="user_email" name="user[email]" placeholder="Email" required="required" type="email" value="steve@example.com">
     <label class="form-label required" for="user_email">Email</label>
   </div>
   <div class="mb-3 form-floating">
@@ -1366,7 +1366,7 @@ Generated HTML:
 <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
   <div class="mb-3">
     <label class="form-label required" for="user_email">Email</label>
-    <input aria-required="true" class="form-control is-invalid" id="user_email" name="user[email]" required="required" type="email" value="steve.example.com">
+    <input class="form-control is-invalid" id="user_email" name="user[email]" required="required" type="email" value="steve.example.com">
     <div class="invalid-feedback">is invalid</div>
   </div>
 </form>
@@ -1398,7 +1398,7 @@ Generated HTML:
 <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
   <div class="mb-3">
     <label class="form-label required text-danger" for="user_email">Email is invalid</label>
-    <input aria-required="true" class="form-control is-invalid" id="user_email" name="user[email]" required="required" type="email" value="steve.example.com">
+    <input class="form-control is-invalid" id="user_email" name="user[email]" required="required" type="email" value="steve.example.com">
   </div>
 </form>
 ```
@@ -1560,7 +1560,7 @@ This generates:
 ```html
 <div class="mb-3">
   <label class="form-label required" for="user_login">New Username</label>
-  <input aria-required="true" class="form-control" id="user_login" name="user[login]" required="required" type="password">
+  <input class="form-control" id="user_login" name="user[login]" required="required" type="password">
 </div>
 <div class="mb-3">
   <label class="form-label" for="user_password">New Password</label>
@@ -1645,7 +1645,7 @@ Generated HTML:
     <div class="col-auto">
       <div class="mb-3">
         <label class="form-label required" for="user_email">Email</label>
-        <input aria-required="true" class="form-control" disabled id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
+        <input class="form-control" disabled id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
       </div>
     </div>
     <div class="col-auto">

--- a/lib/bootstrap_form/helpers/field.rb
+++ b/lib/bootstrap_form/helpers/field.rb
@@ -4,11 +4,7 @@ module BootstrapForm
       def required_field_options(options, method)
         required = required_field?(options, method)
         {}.tap do |option|
-          if required
-            option[:required] = true
-            option[:aria] ||= {}
-            option[:aria][:required] = true
-          end
+          option[:required] = true if required
         end
       end
 

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -623,7 +623,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<~HTML
       <div class="form-check mb-3">
         <input #{autocomplete_attr} name="user[terms]" type="hidden" value="0" />
-        <input aria-required="true" class="form-check-input" id="user_terms" name="user[terms]" required="required" type="checkbox" value="1"/>
+        <input class="form-check-input" id="user_terms" name="user[terms]" required="required" type="checkbox" value="1"/>
         <label class="form-check-label required" for="user_terms">I agree to the terms</label>
       </div>
     HTML
@@ -634,7 +634,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<~HTML
       <div class="form-check mb-3">
         <input #{autocomplete_attr} name="user[email]" type="hidden" value="0"/>
-        <input aria-required="true" class="form-check-input" id="user_email" name="user[email]" required="required" type="checkbox" value="1"/>
+        <input class="form-check-input" id="user_email" name="user[email]" required="required" type="checkbox" value="1"/>
         <label class="form-check-label" for="user_email">Email</label>
       </div>
     HTML

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -108,7 +108,7 @@ class BootstrapFieldsTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
           <label class="form-label required" for="address_user_id">User</label>
-          <input aria-required="true" class="form-control is-invalid" id="address_user_id" name="address[user_id]" required="required" type="text"/>
+          <input class="form-control is-invalid" id="address_user_id" name="address[user_id]" required="required" type="text"/>
           <div class="invalid-feedback">must exist</div>
         </div>
       </form>
@@ -219,7 +219,7 @@ class BootstrapFieldsTest < ActionView::TestCase
     expected = <<~HTML
       <div class="mb-3">
         <label class="form-label required" for="user_email">Email</label>
-        <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+        <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
     assert_equivalent_html expected, @builder.text_field(:email)
@@ -230,7 +230,7 @@ class BootstrapFieldsTest < ActionView::TestCase
       <div class="mb-3 g-3">
         <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
-          <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+          <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
         </div>
       </div>
     HTML
@@ -243,7 +243,7 @@ class BootstrapFieldsTest < ActionView::TestCase
       <div class="bogus-2 row">
         <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
-          <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+          <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
         </div>
       </div>
     HTML
@@ -256,7 +256,7 @@ class BootstrapFieldsTest < ActionView::TestCase
       <div class="bogus-1 row">
         <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
-          <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+          <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
         </div>
       </div>
     HTML
@@ -268,7 +268,7 @@ class BootstrapFieldsTest < ActionView::TestCase
       <div class="bogus-2 row">
         <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
-          <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+          <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
         </div>
       </div>
     HTML
@@ -280,7 +280,7 @@ class BootstrapFieldsTest < ActionView::TestCase
     expected = <<~HTML
       <div class="mb-3">
         <label class="form-label required" for="custom_id">Email</label>
-        <input aria-required="true" required="required" class="form-control" id="custom_id" name="user[email]" type="text" value="steve@example.com" />
+        <input required="required" class="form-control" id="custom_id" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
     assert_equivalent_html expected, @builder.text_field(:email, id: :custom_id)
@@ -468,7 +468,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "can have a floating label" do
     expected = <<~HTML
       <div class="mb-3 form-floating">
-        <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" placeholder="Email" />
+        <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" placeholder="Email" />
         <label class="form-label required" for="user_email">Email</label>
       </div>
     HTML

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -9,7 +9,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     expected = <<~HTML
       <div class="mb-3">
         <label class="form-label required" for="user_email">Email Address</label>
-        <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+        <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
     assert_equivalent_html expected, @builder.text_field(:email, label: "Email Address")
@@ -19,7 +19,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     expected = <<~HTML
       <div class="mb-3">
         <label class="form-label required" for="user_email">Email Address</label>
-        <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+        <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
     assert_equivalent_html expected, @builder.text_field(:email, label: { text: "Email Address" })
@@ -29,7 +29,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     expected = <<~HTML
       <div class="mb-3">
         <label class="visually-hidden required" for="user_email">Email</label>
-        <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+        <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
     assert_equivalent_html expected, @builder.text_field(:email, hide_label: true)
@@ -39,7 +39,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     expected = <<~HTML
       <div class="mb-3">
         <label class="btn required" for="user_email">Email</label>
-        <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+        <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
     assert_equivalent_html expected, @builder.text_field(:email, label_class: "btn")
@@ -49,7 +49,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     expected = <<~HTML
       <div class="mb-3">
         <label class="btn required" for="user_email">Email</label>
-        <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+        <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
     assert_equivalent_html expected, @builder.text_field(:email, label: { class: "btn" })
@@ -59,7 +59,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     expected = <<~HTML
       <div class="mb-3">
         <label class="btn required" for="user_email">Email Address</label>
-        <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+        <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
     assert_equivalent_html expected, @builder.text_field(:email, label: { class: "btn", text: "Email Address" })
@@ -68,7 +68,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "skipping a label" do
     expected = <<~HTML
       <div class="mb-3">
-        <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+        <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
     assert_equivalent_html expected, @builder.text_field(:email, skip_label: true)
@@ -100,7 +100,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     expected = <<~HTML
       <div class="mb-3">
         <label class="form-label required" for="user_comments">Comments</label>
-        <input aria-required="true" class="form-control" id="user_comments" name="user[comments]" type="text" value="my comment" required="required" />
+        <input class="form-control" id="user_comments" name="user[comments]" type="text" value="my comment" required="required" />
       </div>
     HTML
     assert_equivalent_html expected, @builder.text_field(:comments, required: true)
@@ -110,7 +110,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     expected = <<~HTML
       <div class="mb-3">
         <label class="visually-hidden required" for="user_email">Email</label>
-        <input aria-required="true" required="required" class="form-control" id="user_email" placeholder="Email" name="user[email]" type="text" value="steve@example.com" />
+        <input required="required" class="form-control" id="user_email" placeholder="Email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
     assert_equivalent_html expected, @builder.text_field(:email, label_as_placeholder: true)
@@ -122,7 +122,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <label class="form-label required" for="user_email">Email</label>
         <div class="input-group">
           <span class="input-group-text">@</span>
-          <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+          <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
         </div>
       </div>
     HTML
@@ -134,7 +134,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       <div class="mb-3">
         <label class="form-label required" for="user_email">Email</label>
         <div class="input-group">
-          <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+          <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
           <span class="input-group-text">.00</span>
         </div>
       </div>
@@ -145,7 +145,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "append and prepend button" do
     prefix = '<div class="mb-3"><label class="form-label required" for="user_email">Email</label><div class="input-group">'
     field = <<~HTML
-      <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+      <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
     HTML
     button_src = link_to("Click", "#", class: "btn btn-secondary")
     button_prepend = button_src
@@ -167,7 +167,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <label class="form-label required" for="user_email">Email</label>
         <div class="input-group">
           <span class="input-group-text">$</span>
-          <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+          <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
           <span class="input-group-text">.00</span>
         </div>
       </div>
@@ -186,7 +186,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
           <label class="form-label required" for="user_email">Email</label>
           <div class="input-group">
             <span class="input-group-text">$</span>
-            <input aria-required="true" required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
+            <input required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
             <span class="input-group-text">.00</span>
             <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</span>
           </div>
@@ -200,7 +200,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     expected = <<~HTML
       <div class="mb-3">
         <label class="form-label required" for="user_email">Email</label>
-        <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+        <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
         <small class="form-text text-muted">This is required</small>
       </div>
     HTML
@@ -212,7 +212,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       <div class="mb-3 row">
         <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
-          <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+          <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
           <small class="form-text text-muted">This is required</small>
         </div>
       </div>
@@ -464,7 +464,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
           <label class="form-label required" for="user_email">Email</label>
         </div>
         <div class="field_with_errors">
-          <input aria-required="true" required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="email" />
+          <input required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="email" />
         </div>
         <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</div>
       </div>
@@ -486,7 +486,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="none-margin">
           <label class="form-label required" for="user_email">Email</label>
-          <input aria-required="true" required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
+          <input required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</div>
           <small class="form-text text-muted">This is required</small>
         </div>
@@ -540,7 +540,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       <div class="mb-3 row">
         <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
-          <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+          <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
         </div>
       </div>
     HTML
@@ -559,7 +559,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "rendering without wrapper" do
     expected = <<~HTML
-      <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+      <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
     HTML
     assert_equivalent_html expected, @builder.text_field(:email, wrapper: false)
   end
@@ -578,7 +578,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     expected = <<~HTML
       <div class="mb-3">
         <label class="form-label required" for="user_email">Email</label>
-        <input aria-required="true" required="required" autofocus="autofocus" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+        <input required="required" autofocus="autofocus" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
     assert_equivalent_html expected, @builder.text_field(:email, autofocus: true)
@@ -603,7 +603,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 col-auto g-3">
           <label class="form-label me-sm-2 required" for="user_email">Email</label>
-          <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
+          <input required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
         </div>
       </form>
     HTML
@@ -643,7 +643,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       <div class="mb-3">
         <label class="form-label required" for="user_email">Email</label>
         <div class="input-group input-group-lg">
-          <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
+          <input required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
           <input class="btn btn-primary" name="commit" type="submit" value="Subscribe" />
         </div>
       </div>

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -21,7 +21,7 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="mb-3 row">
           <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
           <div class="col-sm-10">
-            <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
+            <input required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
           </div>
         </div>
         <div class="form-check mb-3">
@@ -72,7 +72,7 @@ class BootstrapFormTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 col-auto g-3">
           <label class="form-label me-sm-2 required" for="user_email">Email</label>
-          <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
+          <input required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
         </div>
         <div class="form-check form-check-inline mb-3">
           <input #{autocomplete_attr} name="user[terms]" type="hidden" value="0" />
@@ -130,7 +130,7 @@ class BootstrapFormTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="col">
           <label class="form-label me-sm-2 required" for="user_email">Email</label>
-          <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
+          <input required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
         </div>
         <div class="col">
           <div class="form-check form-check-inline">
@@ -178,7 +178,7 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="mb-3 row">
           <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
           <div class="col-sm-10">
-            <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
+            <input required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
           </div>
         </div>
         <div class="mb-3 row">
@@ -232,7 +232,7 @@ class BootstrapFormTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
           <label class="form-label required" for="user_email">Email</label>
-          <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
+          <input required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
         </div>
         <div class="mb-3 row">
           <div class="col-sm-10 offset-sm-2">
@@ -282,7 +282,7 @@ class BootstrapFormTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3 col-auto g-3">
           <label class="form-label me-sm-2 required" for="user_email">Email</label>
-          <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
+          <input required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
         </div>
         <div class="mb-3 row">
           <div class="col-sm-10 offset-sm-2">
@@ -333,7 +333,7 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="mb-3 row">
           <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
           <div class="col-sm-10">
-            <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
+            <input required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
           </div>
         </div>
       </form>
@@ -361,7 +361,7 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         <div class="mb-3">
           <label class="form-label required" for="user_email">Email</label>
-          <input aria-required="true" class="form-control" id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
+          <input class="form-control" id="user_email" name="user[email]" required="required" type="email" value="steve@example.com">
         </div>
       </form>
     HTML
@@ -424,7 +424,7 @@ class BootstrapFormTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
           <label class="form-label required" for="ID">Email</label>
-          <input aria-required="true" required="required" class="form-control" id="ID" name="NAME" type="text" value="steve@example.com" />
+          <input required="required" class="form-control" id="ID" name="NAME" type="text" value="steve@example.com" />
         </div>
       </form>
     HTML
@@ -467,7 +467,7 @@ class BootstrapFormTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
           <label class="form-label required text-danger" for="user_email">Email can’t be blank, is too short (minimum is 5 characters)</label>
-          <input aria-required="true" required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
+          <input required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
         </div>
       </form>
     HTML
@@ -483,7 +483,7 @@ class BootstrapFormTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
           <label class="form-label required text-danger" for="user_email">Email can’t be blank, is too short (minimum is 5 characters)</label>
-          <input aria-required="true" required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
+          <input required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</span>
         </div>
       </form>
@@ -502,7 +502,7 @@ class BootstrapFormTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
           <label class="form-label required text-danger" for="user_email">Your e-mail address can’t be blank, is too short (minimum is 5 characters)</label>
-          <input aria-required="true" required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
+          <input required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</div>
         </div>
       </form>
@@ -649,7 +649,7 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="mb-3 row">
           <label class="col-form-label col-sm-1 required" for="user_email">Email</label>
           <div class="col-sm-10">
-            <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
+            <input required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
           </div>
         </div>
       </form>
@@ -697,7 +697,7 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="mb-3 row">
           <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
           <div class="col-sm-5">
-            <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
+            <input required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
           </div>
         </div>
       </form>
@@ -713,7 +713,7 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="mb-3 row">
           <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
           <div class="col-sm-10 custom-class">
-            <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
+            <input required="required" class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" />
           </div>
         </div>
       </form>
@@ -736,7 +736,7 @@ class BootstrapFormTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
           <label class="form-label required" for="user_email">Email</label>
-          <input aria-required="true" required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
+          <input required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</div>
           <small class="form-text text-muted">This is required</small>
         </div>
@@ -761,7 +761,7 @@ class BootstrapFormTest < ActionView::TestCase
             <label class="form-label required" for="user_email">Email</label>
           </div>
           <div class="field_with_errors">
-            <input aria-required="true" required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
+            <input required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           </div>
           <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</div>
           <small class="form-text text-muted">This is required</small>
@@ -784,7 +784,7 @@ class BootstrapFormTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
           <label class="form-label required" for="user_email">Email</label>
-          <input aria-required="true" required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
+          <input required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           <small class="form-text text-muted">This is required</small>
         </div>
       </form>
@@ -804,7 +804,7 @@ class BootstrapFormTest < ActionView::TestCase
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
           <label class="form-label required" for="user_email">Email</label>
-          <input aria-required="true" required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
+          <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
           <small class="form-text text-muted">This is <strong>useful</strong> help</small>
         </div>
       </form>

--- a/test/bootstrap_other_components_test.rb
+++ b/test/bootstrap_other_components_test.rb
@@ -12,7 +12,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
       <div class="mb-3 row">
         <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
-          <input aria-required="true" required="required" class="form-control-plaintext" id="user_email" extra="extra arg" name="user[email]" readonly="readonly" type="text" value="steve@example.com"/>
+          <input required="required" class="form-control-plaintext" id="user_email" extra="extra arg" name="user[email]" readonly="readonly" type="text" value="steve@example.com"/>
         </div>
       </div>
     HTML
@@ -26,7 +26,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
       <div class="mb-3 row">
         <label class="col-form-label col-sm-2 required" for="custom_id">Email</label>
         <div class="col-sm-10">
-          <input aria-required="true" required="required" class="form-control-plaintext" id="custom_id" name="user[email]" readonly="readonly" type="text" value="steve@example.com"/>
+          <input required="required" class="form-control-plaintext" id="custom_id" name="user[email]" readonly="readonly" type="text" value="steve@example.com"/>
         </div>
       </div>
     HTML
@@ -82,7 +82,7 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
       <div class="mb-3 row">
         <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
-          <input aria-required="true" required="required" class="test_class form-control-plaintext" id="user_email" name="user[email]" readonly="readonly" type="text" value="steve@example.com"/>
+          <input required="required" class="test_class form-control-plaintext" id="user_email" name="user[email]" readonly="readonly" type="text" value="steve@example.com"/>
         </div>
       </div>
     HTML

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -443,7 +443,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "a required radiobutton" do
     expected = <<~HTML
       <div class="form-check">
-        <input aria-required="true" class="form-check-input" id="user_misc_0" name="user[misc]" required="required" type="radio" value="0" />
+        <input class="form-check-input" id="user_misc_0" name="user[misc]" required="required" type="radio" value="0" />
         <label class="form-check-label" for="user_misc_0">
           This is a radio button
         </label>
@@ -455,7 +455,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
   test "a required attribute as radiobutton" do
     expected = <<~HTML
       <div class="form-check">
-        <input aria-required="true" class="form-check-input" id="user_email_0" name="user[email]" required="required" type="radio" value="0" />
+        <input class="form-check-input" id="user_email_0" name="user[email]" required="required" type="radio" value="0" />
         <label class="form-check-label" for="user_email_0">
           This is a radio button
         </label>

--- a/test/special_form_class_models_test.rb
+++ b/test/special_form_class_models_test.rb
@@ -77,7 +77,7 @@ class SpecialFormClassModelsTest < ActionView::TestCase
           <label class="form-label required" for="user_password">Password</label>
         </div>
         <div class="field_with_errors">
-          <input aria-required="true" class="form-control is-invalid" id="user_password" name="user[password]" required="required" type="text">
+          <input class="form-control is-invalid" id="user_password" name="user[password]" required="required" type="text">
         </div>
         <div class="invalid-feedback">can#{Rails::VERSION::MAJOR < 7 ? "'" : '’'}t be blank</div>
       </div>


### PR DESCRIPTION
Per the MDN docs, the aria-required attribute is only necessary on non-semantic elements. The `input` element is a semantic element and so aria-required is not necessary -- just `required` is sufficient and achieves the same result. An example of a non-semantic element is `div` which is not used by the project.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required

> When a semantic HTML <input>, <select>, or <textarea> must have a
> value, it should have the required attribute applied to it.
>
> ...
>
> When form controls are created using non-semantic elements, such as a
> <div> with a role of checkbox, the aria-required attribute should be
> included, with a value of true, to indicate to assistive technologies
> that user input is required on the element for the form to be
> submittable.

By removing the unnecessary attribute, there is less noise in the rendered HTML and less total HTML.