### PR TITLE
Omit the `multiple` attribute for checkbox collection hidden field.

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,7 +718,7 @@ This generates:
     <label class="form-check-label" for="user_skill_level_2">Farming</label>
   </div>
 </div>
-<input autocomplete="off" id="user_skills" multiple name="user[skills][]" type="hidden" value="">
+<input autocomplete="off" id="user_skills" name="user[skills][]" type="hidden" value="">
 <div class="mb-3">
   <label class="form-label" for="user_skills">Skills</label>
   <div class="form-check">

--- a/lib/bootstrap_form/inputs/collection_check_boxes.rb
+++ b/lib/bootstrap_form/inputs/collection_check_boxes.rb
@@ -15,7 +15,7 @@ module BootstrapForm
           end
 
           if args.extract_options!.symbolize_keys!.delete(:include_hidden) { true }
-            html.prepend hidden_field(args.first, value: "", multiple: true)
+            html.prepend hidden_field(args.first, value: "", name: field_name(args[0], multiple: true))
           end
           html
         end

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -170,7 +170,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders the form_group correctly" do
     collection = [Address.new(id: 1, street: "Foobar")]
     expected = <<~HTML
-      <input #{autocomplete_attr} id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{autocomplete_attr} id="user_misc" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">This is a checkbox collection</label>
         <div class="form-check">
@@ -188,7 +188,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders multiple checkboxes correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<~HTML
-      <input #{autocomplete_attr} id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{autocomplete_attr} id="user_misc" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -213,7 +213,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     struct = Struct.new(:id, :name)
     collection = [struct.new(1, "Foo"), struct.new("二", "Bar")]
     expected = <<~HTML
-      <input #{autocomplete_attr} id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{autocomplete_attr} id="user_misc" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -233,7 +233,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders inline checkboxes correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<~HTML
-      <input #{autocomplete_attr} id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{autocomplete_attr} id="user_misc" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check form-check-inline">
@@ -258,7 +258,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders with checked option correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<~HTML
-      <input #{autocomplete_attr} id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{autocomplete_attr} id="user_misc" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -285,7 +285,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders with multiple checked options correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<~HTML
-      <input #{autocomplete_attr} id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{autocomplete_attr} id="user_misc" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -308,7 +308,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes sanitizes values when generating label `for`" do
     collection = [Address.new(id: 1, street: "Foo St")]
     expected = <<~HTML
-      <input #{autocomplete_attr} id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{autocomplete_attr} id="user_misc" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -325,7 +325,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders multiple checkboxes with labels defined by Proc :text_method correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<~HTML
-      <input #{autocomplete_attr} id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{autocomplete_attr} id="user_misc" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -349,7 +349,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders multiple checkboxes with values defined by Proc :value_method correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<~HTML
-      <input #{autocomplete_attr} id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{autocomplete_attr} id="user_misc" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -373,7 +373,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders multiple checkboxes with labels defined by lambda :text_method correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<~HTML
-      <input #{autocomplete_attr} id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{autocomplete_attr} id="user_misc" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -397,7 +397,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders multiple checkboxes with values defined by lambda :value_method correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<~HTML
-      <input #{autocomplete_attr} id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{autocomplete_attr} id="user_misc" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -422,7 +422,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders with checked option correctly with Proc :value_method" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<~HTML
-      <input #{autocomplete_attr} id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{autocomplete_attr} id="user_misc" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -449,7 +449,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
   test "collection_check_boxes renders with multiple checked options correctly with lambda :value_method" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<~HTML
-      <input #{autocomplete_attr} id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+      <input #{autocomplete_attr} id="user_misc" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
         <div class="form-check">
@@ -520,7 +520,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <input #{autocomplete_attr} id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+        <input #{autocomplete_attr} id="user_misc" name="user[misc][]" type="hidden" value="" />
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="form-check">
@@ -571,7 +571,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<~HTML
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
-        <input #{autocomplete_attr} id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" />
+        <input #{autocomplete_attr} id="user_misc" name="user[misc][]" type="hidden" value="" />
         <div class="mb-3">
           <label class="form-label" for="user_misc">Misc</label>
           <div class="form-check">


### PR DESCRIPTION
Fixes #421