### PR TITLE
Fix joins not to make strings unsafe

### DIFF
--- a/lib/bootstrap_form/components/labels.rb
+++ b/lib/bootstrap_form/components/labels.rb
@@ -43,7 +43,7 @@ module BootstrapForm
       end
 
       def label_text(name, options)
-        label = options[:text] || object&.class.try(:human_attribute_name, name)&.html_safe
+        label = options[:text] || object&.class&.try(:human_attribute_name, name)&.html_safe # rubocop:disable Rails/OutputSafety
         if label_errors && error?(name)
           (" ".html_safe + get_error_messages(name)).prepend(label)
         else

--- a/lib/bootstrap_form/components/labels.rb
+++ b/lib/bootstrap_form/components/labels.rb
@@ -43,10 +43,11 @@ module BootstrapForm
       end
 
       def label_text(name, options)
+        label = options[:text] || object&.class.try(:human_attribute_name, name)&.html_safe
         if label_errors && error?(name)
-          (options[:text] || object.class.human_attribute_name(name)).to_s + " #{get_error_messages(name)}"
+          (" ".html_safe + get_error_messages(name)).prepend(label)
         else
-          options[:text] || object&.class.try(:human_attribute_name, name)
+          label
         end
       end
     end

--- a/lib/bootstrap_form/components/validation.rb
+++ b/lib/bootstrap_form/components/validation.rb
@@ -81,7 +81,8 @@ module BootstrapForm
           end
         end
 
-        object.errors[name].join(", ")
+        safe_join(object.errors[name], ", ")
+        # object.errors[name].join(", ")
       end
       # rubocop:enable Metrics/AbcSize
     end

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -45,6 +45,8 @@ module BootstrapForm
     include BootstrapForm::Inputs::UrlField
     include BootstrapForm::Inputs::WeekField
 
+    include ActionView::Helpers::OutputSafetyHelper
+
     delegate :content_tag, :capture, :concat, :tag, to: :@template
 
     def initialize(object_name, object, template, options)
@@ -66,8 +68,8 @@ module BootstrapForm
       return unless options[:layout] == :inline
 
       options[:html][:class] =
-        ([*options[:html][:class]&.split(/\s+/)] + %w[row row-cols-auto g-3 align-items-center])
-        .compact.uniq.join(" ")
+        safe_join(([*options[:html][:class]&.split(/\s+/)] + %w[row row-cols-auto g-3 align-items-center])
+        .compact.uniq, " ")
     end
 
     def fields_for_with_bootstrap(record_name, record_object=nil, fields_options={}, &block)

--- a/lib/bootstrap_form/form_group_builder.rb
+++ b/lib/bootstrap_form/form_group_builder.rb
@@ -91,7 +91,7 @@ module BootstrapForm
       css_options = html_options || options
       # Add control_class; allow it to be overridden by :control_class option
       control_classes = css_options.delete(:control_class) { control_class }
-      css_options[:class] = [control_classes, css_options[:class]].compact.join(" ")
+      css_options[:class] = safe_join([control_classes, css_options[:class]].compact, " ")
       css_options[:class] << " is-invalid" if error?(method)
       css_options[:placeholder] = form_group_placeholder(options, method) if options[:label_as_placeholder]
       css_options

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -1,6 +1,8 @@
 module BootstrapForm
   module Helpers
     module Bootstrap
+      include ActionView::Helpers::OutputSafetyHelper
+
       def alert_message(title, options={})
         css = options[:class] || "alert alert-danger"
         return unless object.respond_to?(:errors) && object.errors.full_messages.any?
@@ -31,11 +33,12 @@ module BootstrapForm
         custom_class = options[:custom_class] || false
 
         tag.div class: custom_class || "invalid-feedback" do
-          if hide_attribute_name
-            object.errors[name].join(", ")
+          errors = if hide_attribute_name
+            object.errors[name]
           else
-            object.errors.full_messages_for(name).join(", ")
+            object.errors.full_messages_for(name)
           end
+          safe_join(errors, ", ")
         end
       end
 
@@ -93,7 +96,7 @@ module BootstrapForm
         tags = [*options[key]].map do |item|
           input_group_content(item)
         end
-        ActiveSupport::SafeBuffer.new(tags.join)
+        safe_join(tags)
       end
     end
   end

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -34,10 +34,10 @@ module BootstrapForm
 
         tag.div class: custom_class || "invalid-feedback" do
           errors = if hide_attribute_name
-            object.errors[name]
-          else
-            object.errors.full_messages_for(name)
-          end
+                     object.errors[name]
+                   else
+                     object.errors.full_messages_for(name)
+                   end
           safe_join(errors, ", ")
         end
       end

--- a/lib/bootstrap_form/inputs/rich_text_area.rb
+++ b/lib/bootstrap_form/inputs/rich_text_area.rb
@@ -10,7 +10,7 @@ module BootstrapForm
         def rich_text_area_with_bootstrap(name, options={})
           form_group_builder(name, options) do
             prepend_and_append_input(name, options) do
-              options[:class] = ["trix-content", options[:class]].compact.join(" ")
+              options[:class] = safe_join(["trix-content", options[:class]].compact, " ")
               rich_text_area_without_bootstrap(name, options)
             end
           end


### PR DESCRIPTION
The basic `String#join` makes its output unsafe in all cases. This might have been causing unwanted and problematic escaping in some cases. This PR removes the use of `String#join`. It _should_ still escape unsafe strings passed in from the calling code, while not escaping anything that is already safe. However, that's something reviewers should put some thoughts into, and comment on.

This PR may cause some text to be escaped that wasn't previously escaped, but those cases would have been potentially security vulnerabilities, so I think it's justifiable in closing that possible loophole. The fix would be for the calling code to pass its string as `string.html_safe` if the code is confident the string is safe (i.e. it doesn't come from the user or the database or something external). If the string wasn't safe, then it _should_ get escaped.