### PR TITLE
Revert to simple ' in error messages

### DIFF
--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -188,7 +188,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
             <span class="input-group-text">$</span>
             <input required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
             <span class="input-group-text">.00</span>
-            <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</span>
+            <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</span>
           </div>
         </div>
       </form>
@@ -404,7 +404,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
     expected = <<~HTML
       <div class="mb-3">
         <p class="form-control-plaintext">Bar</p>
-        <div class="invalid-feedback" style="display: block;">can’t be blank, is too short (minimum is 5 characters)</div>
+        <div class="invalid-feedback" style="display: block;">can't be blank, is too short (minimum is 5 characters)</div>
       </div>
     HTML
     assert_equivalent_html expected, output
@@ -466,7 +466,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <div class="field_with_errors">
           <input required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="email" />
         </div>
-        <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</div>
+        <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
       </div>
     HTML
     output = @builder.email_field(:email, wrapper_class: "none-margin")
@@ -487,7 +487,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <div class="none-margin">
           <label class="form-label required" for="user_email">Email</label>
           <input required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
-          <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</div>
+          <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
           <small class="form-text text-muted">This is required</small>
         </div>
       </form>

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -466,7 +466,7 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label class="form-label required text-danger" for="user_email">Email can’t be blank, is too short (minimum is 5 characters)</label>
+          <label class="form-label required text-danger" for="user_email">Email can't be blank, is too short (minimum is 5 characters)</label>
           <input required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
         </div>
       </form>
@@ -482,9 +482,9 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label class="form-label required text-danger" for="user_email">Email can’t be blank, is too short (minimum is 5 characters)</label>
+          <label class="form-label required text-danger" for="user_email">Email can't be blank, is too short (minimum is 5 characters)</label>
           <input required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
-          <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</span>
+          <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</span>
         </div>
       </form>
     HTML
@@ -501,9 +501,9 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post">
         #{'<input name="utf8" type="hidden" value="&#x2713;"/>' unless ::Rails::VERSION::STRING >= '6'}
         <div class="mb-3">
-          <label class="form-label required text-danger" for="user_email">Your e-mail address can’t be blank, is too short (minimum is 5 characters)</label>
+          <label class="form-label required text-danger" for="user_email">Your e-mail address can't be blank, is too short (minimum is 5 characters)</label>
           <input required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
-          <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</div>
+          <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
         </div>
       </form>
     HTML
@@ -520,7 +520,7 @@ class BootstrapFormTest < ActionView::TestCase
       <div class="alert alert-danger">
         <p>Please fix the following errors:</p>
         <ul class="rails-bootstrap-forms-error-summary">
-          <li>Email can’t be blank</li>
+          <li>Email can't be blank</li>
           <li>Email is too short (minimum is 5 characters)</li>
           <li>Terms must be accepted</li>
         </ul>
@@ -537,7 +537,7 @@ class BootstrapFormTest < ActionView::TestCase
       <div class="my-css-class">
         <p>Please fix the following errors:</p>
         <ul class="rails-bootstrap-forms-error-summary">
-          <li>Email can’t be blank</li>
+          <li>Email can't be blank</li>
           <li>Email is too short (minimum is 5 characters)</li>
           <li>Terms must be accepted</li>
         </ul>
@@ -560,7 +560,7 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="alert alert-danger">
           <p>Please fix the following errors:</p>
           <ul class="rails-bootstrap-forms-error-summary">
-            <li>Email can’t be blank</li>
+            <li>Email can't be blank</li>
             <li>Email is too short (minimum is 5 characters)</li>
             <li>Terms must be accepted</li>
           </ul>
@@ -601,7 +601,7 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="alert alert-danger">
           <p>Please fix the following errors:</p>
           <ul class="rails-bootstrap-forms-error-summary">
-            <li>Email can’t be blank</li>
+            <li>Email can't be blank</li>
             <li>Email is too short (minimum is 5 characters)</li>
             <li>Terms must be accepted</li>
           </ul>
@@ -617,7 +617,7 @@ class BootstrapFormTest < ActionView::TestCase
 
     expected = <<~HTML
       <ul class="rails-bootstrap-forms-error-summary">
-        <li>Email can’t be blank</li>
+        <li>Email can't be blank</li>
         <li>Email is too short (minimum is 5 characters)</li>
         <li>Terms must be accepted</li>
       </ul>
@@ -637,7 +637,7 @@ class BootstrapFormTest < ActionView::TestCase
     assert @user.invalid?
 
     expected = <<~HTML
-      <div class="invalid-feedback">Email can’t be blank, Email is too short (minimum is 5 characters)</div>
+      <div class="invalid-feedback">Email can't be blank, Email is too short (minimum is 5 characters)</div>
     HTML
     assert_equivalent_html expected, @builder.errors_on(:email)
   end
@@ -737,7 +737,7 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="mb-3">
           <label class="form-label required" for="user_email">Email</label>
           <input required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
-          <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</div>
+          <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
           <small class="form-text text-muted">This is required</small>
         </div>
       </form>
@@ -763,7 +763,7 @@ class BootstrapFormTest < ActionView::TestCase
           <div class="field_with_errors">
             <input required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           </div>
-          <div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</div>
+          <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
           <small class="form-text text-muted">This is required</small>
         </div>
       </form>
@@ -829,7 +829,7 @@ class BootstrapFormTest < ActionView::TestCase
     @user.email = nil
     assert @user.invalid?
 
-    expected = '<div class="invalid-feedback">can’t be blank, is too short (minimum is 5 characters)</div>'
+    expected = '<div class="invalid-feedback">can\'t be blank, is too short (minimum is 5 characters)</div>'
 
     assert_equivalent_html expected, @builder.errors_on(:email, hide_attribute_name: true)
   end
@@ -838,7 +838,7 @@ class BootstrapFormTest < ActionView::TestCase
     @user.email = nil
     assert @user.invalid?
 
-    expected = '<div class="custom-error-class">Email can’t be blank, Email is too short (minimum is 5 characters)</div>'
+    expected = '<div class="custom-error-class">Email can\'t be blank, Email is too short (minimum is 5 characters)</div>'
 
     assert_equivalent_html expected, @builder.errors_on(:email, custom_class: "custom-error-class")
   end

--- a/test/special_form_class_models_test.rb
+++ b/test/special_form_class_models_test.rb
@@ -79,7 +79,7 @@ class SpecialFormClassModelsTest < ActionView::TestCase
         <div class="field_with_errors">
           <input class="form-control is-invalid" id="user_password" name="user[password]" required="required" type="text">
         </div>
-        <div class="invalid-feedback">can#{Rails::VERSION::MAJOR < 7 ? "'" : '’'}t be blank</div>
+        <div class="invalid-feedback">can't be blank</div>
       </div>
     HTML
     assert_equivalent_html expected, @builder.text_field(:password)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -56,7 +56,6 @@ class ActionView::TestCase
   end
 
   def assert_equivalent_html(expected, actual)
-    expected = expected.tr("’", "'") if Rails::VERSION::STRING < "7.1"
     expected_html        = Nokogiri::HTML.fragment(expected) { |config| config.default_xml.noblanks }
     actual_html          = Nokogiri::HTML.fragment(actual) { |config| config.default_xml.noblanks }
 


### PR DESCRIPTION
Rails has reverted the proposed change to put a "smart apostrophe" in error messages, so test cases against edge were failing. This PR removes the conditionals that were added for testing against edge/7.1.

https://github.com/rails/rails/commit/acfa0454058c535c1352ddab91c93ca914f0805a
