### PR TITLE
do not alias rich text area if it is not defined

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,9 +37,6 @@ Layout/LineLength:
 Layout/SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: no_space
 
-Lint/SuppressedException:
-  Enabled: false
-
 Metrics/AbcSize:
   Max: 18
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,9 @@ Layout/LineLength:
 Layout/SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: no_space
 
+Lint/SuppressedException:
+  Enabled: false
+
 Metrics/AbcSize:
   Max: 18
   Exclude:
@@ -45,6 +48,7 @@ Metrics/AbcSize:
 
 Metrics/BlockLength:
   Exclude:
+    - "lib/bootstrap_form/inputs/base.rb"
     - "demo/config/**/*"
     - "demo/test/**/*"
     - "test/**/*"

--- a/lib/bootstrap_form/inputs/base.rb
+++ b/lib/bootstrap_form/inputs/base.rb
@@ -40,7 +40,7 @@ module BootstrapForm
         def bootstrap_alias(field_name)
           alias_method "#{field_name}_without_bootstrap".to_sym, field_name
           alias_method field_name, "#{field_name}_with_bootstrap".to_sym
-        rescue NameError # rubocop:disable Lint/SupressedException
+        rescue NameError # rubocop:disable Lint/SuppressedException
         end
       end
 

--- a/lib/bootstrap_form/inputs/base.rb
+++ b/lib/bootstrap_form/inputs/base.rb
@@ -34,6 +34,7 @@ module BootstrapForm
         def bootstrap_alias(field_name)
           alias_method "#{field_name}_without_bootstrap".to_sym, field_name
           alias_method field_name, "#{field_name}_with_bootstrap".to_sym
+        rescue NameError
         end
       end
 

--- a/lib/bootstrap_form/inputs/base.rb
+++ b/lib/bootstrap_form/inputs/base.rb
@@ -40,7 +40,7 @@ module BootstrapForm
         def bootstrap_alias(field_name)
           alias_method "#{field_name}_without_bootstrap".to_sym, field_name
           alias_method field_name, "#{field_name}_with_bootstrap".to_sym
-        rescue NameError
+        rescue NameError # rubocop:disable Lint/SupressedException
         end
       end
 

--- a/lib/bootstrap_form/inputs/base.rb
+++ b/lib/bootstrap_form/inputs/base.rb
@@ -31,6 +31,12 @@ module BootstrapForm
           bootstrap_alias field_name
         end
 
+        # Creates the methods *_without_bootstrap and *_with_bootstrap.
+        #
+        # If your application did not include the rails gem for one of the dsl
+        # methods, then a name error is raised and suppressed. This can happen
+        # if your application does not include the actiontext dependency due to
+        # `rich_text_area` not being defined.
         def bootstrap_alias(field_name)
           alias_method "#{field_name}_without_bootstrap".to_sym, field_name
           alias_method field_name, "#{field_name}_with_bootstrap".to_sym

--- a/lib/bootstrap_form/inputs/rich_text_area.rb
+++ b/lib/bootstrap_form/inputs/rich_text_area.rb
@@ -16,9 +16,7 @@ module BootstrapForm
           end
         end
 
-        if defined?(rich_text_area)
-          bootstrap_alias :rich_text_area
-        end
+        bootstrap_alias :rich_text_area
       end
     end
   end

--- a/lib/bootstrap_form/inputs/rich_text_area.rb
+++ b/lib/bootstrap_form/inputs/rich_text_area.rb
@@ -16,7 +16,9 @@ module BootstrapForm
           end
         end
 
-        bootstrap_alias :rich_text_area
+        if defined?(rich_text_area)
+          bootstrap_alias :rich_text_area
+        end
       end
     end
   end


### PR DESCRIPTION
We experienced an error with eager loading in staging for bootstrap_form. This small if statement resolves that issue.