### PR TITLE
Draft PR Is This What We Meant To Do?

### DIFF
--- a/lib/bootstrap_form/inputs/collection_check_boxes.rb
+++ b/lib/bootstrap_form/inputs/collection_check_boxes.rb
@@ -7,7 +7,7 @@ module BootstrapForm
       include Base
       include InputsCollection
 
-      included do
+      included do # rubocop:disable Metrics/BlockLength
         def collection_check_boxes_with_bootstrap(*args)
           html = inputs_collection(*args) do |name, value, options|
             options[:multiple] = true
@@ -26,7 +26,20 @@ module BootstrapForm
           def field_name(method, *methods, multiple: false, index: @options[:index])
             object_name = @options.fetch(:as) { @object_name }
 
-            @template.field_name(object_name, method, *methods, index: index, multiple: multiple)
+            field_name_shim(object_name, method, *methods, index: index, multiple: multiple)
+          end
+
+          private
+
+          def field_name_shim(object_name, method_name, *method_names, multiple: false, index: nil)
+            names = method_names.map! { |name| "[#{name}]" }.join
+            if object_name.blank?
+              "#{method_name}#{names}#{multiple ? '[]' : ''}"
+            elsif index
+              "#{object_name}[#{index}][#{method_name}]#{names}#{multiple ? '[]' : ''}"
+            else
+              "#{object_name}[#{method_name}]#{names}#{multiple ? '[]' : ''}"
+            end
           end
         end
       end

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -473,19 +473,6 @@ class BootstrapCheckboxTest < ActionView::TestCase
                                                                      :street, checked: collection)
   end
 
-  if Rails::VERSION::MAJOR < 7
-    def field_name(object_name, method_name, *method_names, multiple: false, index: nil)
-      names = method_names.map! { |name| "[#{name}]" }.join
-      if object_name.blank?
-        "#{method_name}#{names}#{multiple ? '[]' : ''}"
-      elsif index
-        "#{object_name}[#{index}][#{method_name}]#{names}#{multiple ? '[]' : ''}"
-      else
-        "#{object_name}[#{method_name}]#{names}#{multiple ? '[]' : ''}"
-      end
-    end
-  end
-
   test "collection_check_boxes renders with include_hidden options correctly" do
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<~HTML


### PR DESCRIPTION
In response to #717 . Is this what we needed to maintain Rails 6.1 compatibility with the Rails 7.1 `field_name` method?

Feel free to ignore this PR, or take it over and fix it.