### PR TITLE
Remove the require expression for action text in lib/bootstrap_form.rb

### DIFF
--- a/lib/bootstrap_form.rb
+++ b/lib/bootstrap_form.rb
@@ -1,13 +1,3 @@
-# NOTE: The rich_text_area and rich_text_area_tag helpers are defined in a file
-# with a different name and not in the usual autoload-reachable way.
-# The following line is definitely need to make `bootstrap_form` work.
-# rubocop:disable Lint/SuppressedException
-begin
-  require "#{Gem::Specification.find_by_name('actiontext').gem_dir}/app/helpers/action_text/tag_helper"
-rescue Gem::MissingSpecError
-end
-# rubocop:enable Lint/SuppressedException
-
 require "action_view"
 require "action_pack"
 require "bootstrap_form/action_view_extensions/form_helper"


### PR DESCRIPTION
This require was added in e6f5b09209147143ebdb83032a50e9758cfdc2ab to add ActionText support.

Instead of eagerly loading the module, allow the Rails engine subsystem to load the helpers as necessary.

Eagerly loading the module has the downside of defining the module ActionText even when the engine is not in use. Defining the module like this can "trick" other gems into erroneously loading their ActionText support, which may lead to confusing and out of context error messages.

Fixes #719