### PR TITLE
Add help option for check_box

### DIFF
--- a/lib/bootstrap_form/inputs/check_box.rb
+++ b/lib/bootstrap_form/inputs/check_box.rb
@@ -28,7 +28,7 @@ module BootstrapForm
         if layout == :inline && !options[:multiple]
           tag.div(class: "col") { content }
         elsif layout == :horizontal && !options[:multiple]
-          form_group(layout: layout_in_effect(options[:layout]), label_col: options[:label_col]) { content }
+          form_group(layout: layout_in_effect(options[:layout]), label_col: options[:label_col], help: options[:help]) { content }
         else
           content
         end


### PR DESCRIPTION
Based on https://github.com/bootstrap-ruby/bootstrap_form/pull/686 this allows to provide also `help` option in the arguments:

```haml
= f.check_box :is_active, help: 'If checked, this item is active and will be used.'
```

![image](https://github.com/bootstrap-ruby/bootstrap_form/assets/2313005/a60fa825-b08e-43d6-9e84-30491df05aeb)
