### PR TITLE
Bootstrap 5.3: Deprecated the .text-muted utility and $text-muted Sas…

### DIFF
--- a/OLD-README.md
+++ b/OLD-README.md
@@ -110,7 +110,7 @@ This generates:
   <div class="form-group">
     <label for="user_password">Password</label>
     <input class="form-control" type="password" name="user[password]" />
-    <small class="form-text text-muted">A good password should be at least six characters long</small>
+    <small class="form-text text-body-secondary">A good password should be at least six characters long</small>
   </div>
   <div class="form-check">
     <input name="user[remember_me]" type="hidden" value="0">

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ This generates:
   <div class="mb-3">
     <label class="form-label" for="user_password">Password</label>
     <input class="form-control" id="user_password" name="user[password]" type="password">
-    <small class="form-text text-muted">A good password should be at least six characters long</small>
+    <small class="form-text text-body-secondary">A good password should be at least six characters long</small>
   </div>
   <div class="form-check mb-3">
     <input autocomplete="off" name="user[remember_me]" type="hidden" value="0">
@@ -368,7 +368,7 @@ This generates:
 <div class="mb-3">
   <label class="form-label" for="user_password">Password</label>
   <input class="form-control" id="user_password" name="user[password]" type="password">
-  <small class="form-text text-muted">Must be at least 6 characters long</small>
+  <small class="form-text text-body-secondary">Must be at least 6 characters long</small>
 </div>
 ```
 
@@ -607,7 +607,7 @@ This generates:
     <input class="form-check-input" id="user_skill_level_2" name="user[skill_level]" type="radio" value="2">
     <label class="form-check-label" for="user_skill_level_2">Advanced</label>
   </div>
-  <small class="form-text text-muted">Optional Help Text</small>
+  <small class="form-text text-body-secondary">Optional Help Text</small>
 </div>
 <div class="mb-3">
   <div class="form-check mb-3">

--- a/lib/bootstrap_form/components/hints.rb
+++ b/lib/bootstrap_form/components/hints.rb
@@ -10,7 +10,7 @@ module BootstrapForm
       def generate_help(name, help_text)
         return if help_text == false
 
-        help_klass ||= "form-text text-muted"
+        help_klass ||= "form-text text-body-secondary"
         help_text ||= get_help_text_by_i18n_key(name)
         help_tag ||= :small
 

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -177,7 +177,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
           <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_misc_1">Foobar</label>
         </div>
-        <small class="form-text text-muted">With a help!</small>
+        <small class="form-text text-body-secondary">With a help!</small>
       </div>
     HTML
 

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -158,7 +158,7 @@ class BootstrapFieldsTest < ActionView::TestCase
       <div class="mb-3">
         <label class="form-label" for="user_password">Password</label>
         <input class="form-control" id="user_password" name="user[password]" type="password" />
-        <small class="form-text text-muted">A good password should be at least six characters long</small>
+        <small class="form-text text-body-secondary">A good password should be at least six characters long</small>
       </div>
     HTML
     assert_equivalent_html expected, @builder.password_field(:password)

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -201,7 +201,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       <div class="mb-3">
         <label class="form-label required" for="user_email">Email</label>
         <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
-        <small class="form-text text-muted">This is required</small>
+        <small class="form-text text-body-secondary">This is required</small>
       </div>
     HTML
     assert_equivalent_html expected, @builder.text_field(:email, help: "This is required")
@@ -213,7 +213,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
           <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
-          <small class="form-text text-muted">This is required</small>
+          <small class="form-text text-body-secondary">This is required</small>
         </div>
       </div>
     HTML
@@ -225,7 +225,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       <div class="mb-3">
         <label class="form-label" for="user_password">Password</label>
         <input class="form-control" id="user_password" name="user[password]" type="text" value="secret" />
-        <small class="form-text text-muted">A good password should be at least six characters long</small>
+        <small class="form-text text-body-secondary">A good password should be at least six characters long</small>
       </div>
     HTML
     assert_equivalent_html expected, @builder.text_field(:password)
@@ -246,7 +246,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
       <div class="mb-3">
         <label class="form-label" for="user_password">Password</label>
         <input class="form-control" id="user_password" name="user[password]" type="text" value="secret" />
-        <small class="form-text text-muted">A <strong>good</strong> password should be at least six characters long</small>
+        <small class="form-text text-body-secondary">A <strong>good</strong> password should be at least six characters long</small>
       </div>
     HTML
     assert_equivalent_html expected, @builder.text_field(:password)
@@ -488,7 +488,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
           <label class="form-label required" for="user_email">Email</label>
           <input required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
-          <small class="form-text text-muted">This is required</small>
+          <small class="form-text text-body-secondary">This is required</small>
         </div>
       </form>
     HTML

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -738,7 +738,7 @@ class BootstrapFormTest < ActionView::TestCase
           <label class="form-label required" for="user_email">Email</label>
           <input required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
-          <small class="form-text text-muted">This is required</small>
+          <small class="form-text text-body-secondary">This is required</small>
         </div>
       </form>
     HTML
@@ -764,7 +764,7 @@ class BootstrapFormTest < ActionView::TestCase
             <input required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
           </div>
           <div class="invalid-feedback">can't be blank, is too short (minimum is 5 characters)</div>
-          <small class="form-text text-muted">This is required</small>
+          <small class="form-text text-body-secondary">This is required</small>
         </div>
       </form>
     HTML
@@ -785,7 +785,7 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="mb-3">
           <label class="form-label required" for="user_email">Email</label>
           <input required="required" class="form-control is-invalid" id="user_email" name="user[email]" type="text" />
-          <small class="form-text text-muted">This is required</small>
+          <small class="form-text text-body-secondary">This is required</small>
         </div>
       </form>
     HTML
@@ -805,7 +805,7 @@ class BootstrapFormTest < ActionView::TestCase
         <div class="mb-3">
           <label class="form-label required" for="user_email">Email</label>
           <input required="required" class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
-          <small class="form-text text-muted">This is <strong>useful</strong> help</small>
+          <small class="form-text text-body-secondary">This is <strong>useful</strong> help</small>
         </div>
       </form>
     HTML

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -151,7 +151,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
             Foobar
           </label>
         </div>
-        <small class="form-text text-muted">With a help!</small>
+        <small class="form-text text-body-secondary">With a help!</small>
       </div>
     HTML
 
@@ -253,7 +253,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
           <label class="form-check-label" for="user_misc_1"> rabooF</label>
         </div>
-        <small class="form-text text-muted">With a help!</small>
+        <small class="form-text text-body-secondary">With a help!</small>
       </div>
     HTML
 
@@ -271,7 +271,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
           <input class="form-check-input" id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
           <label class="form-check-label" for="user_misc_address_1"> Foobar</label>
         </div>
-        <small class="form-text text-muted">With a help!</small>
+        <small class="form-text text-body-secondary">With a help!</small>
       </div>
     HTML
 
@@ -328,7 +328,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
           <label class="form-check-label" for="user_misc_1"> rabooF</label>
         </div>
-        <small class="form-text text-muted">With a help!</small>
+        <small class="form-text text-body-secondary">With a help!</small>
       </div>
     HTML
 
@@ -346,7 +346,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
           <input class="form-check-input" id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" />
           <label class="form-check-label" for="user_misc_address_1"> Foobar</label>
         </div>
-        <small class="form-text text-muted">With a help!</small>
+        <small class="form-text text-body-secondary">With a help!</small>
       </div>
     HTML
 

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -70,7 +70,7 @@ class BootstrapSelectsTest < ActionView::TestCase
           <option value="1">activated</option>
           <option value="2">blocked</option>
         </select>
-        <small class="form-text text-muted">Help!</small>
+        <small class="form-text text-body-secondary">Help!</small>
       </div>
     HTML
     assert_equivalent_html expected,


### PR DESCRIPTION
…s variable. It’s been replaced by .text-body-secondary and $body-secondary-color.

https://getbootstrap.com/docs/5.3/migration/