### PR TITLE
Relax sprockets rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ eval File.read(gems), binding, gems # rubocop: disable Security/Eval
 require "#{__dir__}/lib/bootstrap_form/version"
 
 gem "rails", BootstrapForm::REQUIRED_RAILS_VERSION
-gem "sprockets-rails", "< 3.5.0", require: "sprockets/railtie"
+gem "sprockets-rails", require: "sprockets/railtie"
 
 gem "bigdecimal" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0")
 gem "drb" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0")

--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -10,7 +10,7 @@ gem "htmlbeautifier"
 gem "jbuilder"
 gem "jsbundling-rails"
 gem "puma"
-gem "sprockets-rails", "< 3.5.0", require: "sprockets/railtie"
+gem "sprockets-rails", require: "sprockets/railtie"
 gem "sqlite3", "~> 1.4"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
       capybara (>= 2, < 4)
       chunky_png (~> 1.3)
     chunky_png (1.4.0)
-    concurrent-ruby (1.3.1)
+    concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     crass (1.0.6)
     cssbundling-rails (1.4.0)
@@ -214,8 +214,8 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.8)
       io-console (~> 0.5)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.2.9)
+      strscan
     rubyzip (2.3.2)
     selenium-webdriver (4.21.1)
       base64 (~> 0.2)
@@ -225,9 +225,9 @@ GEM
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
-    sprockets-rails (3.4.2)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
+    sprockets-rails (3.5.1)
+      actionpack (>= 6.1)
+      activesupport (>= 6.1)
       sprockets (>= 3.0.0)
     sqlite3 (1.7.3-aarch64-linux)
     sqlite3 (1.7.3-arm-linux)
@@ -275,7 +275,7 @@ DEPENDENCIES
   puma
   rails (~> 7.1.1)
   selenium-webdriver
-  sprockets-rails (< 3.5.0)
+  sprockets-rails
   sqlite3 (~> 1.4)
   tzinfo-data
   web-console

--- a/gemfiles/7.1.gemfile
+++ b/gemfiles/7.1.gemfile
@@ -6,4 +6,4 @@ gem "drb" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0")
 gem "mutex_m" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0")
 gem "rails", "~> 7.1.0"
 gem "sqlite3", "~> 1.4"
-gem "sprockets-rails", "< 3.5.0", require: "sprockets/railtie"
+gem "sprockets-rails", require: "sprockets/railtie"

--- a/gemfiles/edge.gemfile
+++ b/gemfiles/edge.gemfile
@@ -6,4 +6,4 @@ gem "drb" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0")
 gem "mutex_m" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0")
 gem "rails", git: "https://github.com/rails/rails.git", branch: "main"
 gem "sqlite3"
-gem "sprockets-rails", "< 3.5.0", require: "sprockets/railtie"
+gem "sprockets-rails", require: "sprockets/railtie"


### PR DESCRIPTION
The bug in `sprockets-rails` 3.5.0 was fixed so 3.5.1 and beyond should be okay.