### PR TITLE
Fix: Add missing form-control-color class for color_field

### DIFF
--- a/lib/bootstrap_form/inputs/base.rb
+++ b/lib/bootstrap_form/inputs/base.rb
@@ -10,6 +10,7 @@ module BootstrapForm
           define_method :"#{field_name}_with_bootstrap" do |name, options={}|
             warn_deprecated_layout_value(options)
             options = options.reverse_merge(control_class: "form-range") if field_name == :range_field
+            options = options.reverse_merge(control_class: "form-control form-control-color") if field_name == :color_field
             form_group_builder(name, options) do
               prepend_and_append_input(name, options) do
                 options[:placeholder] ||= name if options[:floating]

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -9,7 +9,7 @@ class BootstrapFieldsTest < ActionView::TestCase
     expected = <<~HTML
       <div class="mb-3">
         <label class="form-label" for="user_misc">Misc</label>
-        <input class="form-control" id="user_misc" name="user[misc]" type="color" value="#000000" />
+        <input class="form-control form-control-color" id="user_misc" name="user[misc]" type="color" value="#000000" />
       </div>
     HTML
     assert_equivalent_html expected, @builder.color_field(:misc)


### PR DESCRIPTION
<img width="84" alt="Screenshot 2024-10-11 at 15 01 26" src="https://github.com/user-attachments/assets/14aa622d-64ab-4ecd-ad15-394177ba5211">
