### PR TITLE
Allow file to be -pended

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,4 @@ gem "drb" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0")
 gem "mutex_m" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0")
 gem "rails", BootstrapForm::REQUIRED_RAILS_VERSION
 gem "sprockets-rails", require: "sprockets/railtie"
-gem "sqlite3", "~> 1.4"
+gem "sqlite3", ">= 1.4"

--- a/demo/app/models/user.rb
+++ b/demo/app/models/user.rb
@@ -10,12 +10,12 @@ class User < ApplicationRecord
   validates :status, presence: true, if: -> { age > 42 }
   validates :misc, presence: true, unless: -> { feet == 5 }
 
-  has_one :address
+  has_one :address, dependent: nil
   accepts_nested_attributes_for :address
 
   has_rich_text(:life_story)
 
-  def always
+  def always # rubocop:disable Naming/PredicateMethod
     true
   end
 

--- a/lib/bootstrap_form/inputs/collection_check_boxes.rb
+++ b/lib/bootstrap_form/inputs/collection_check_boxes.rb
@@ -34,11 +34,11 @@ module BootstrapForm
           def field_name_shim(object_name, method_name, *method_names, multiple: false, index: nil)
             names = method_names.map! { |name| "[#{name}]" }.join
             if object_name.blank?
-              "#{method_name}#{names}#{multiple ? '[]' : ''}"
+              "#{method_name}#{names}#{'[]' if multiple}"
             elsif index
-              "#{object_name}[#{index}][#{method_name}]#{names}#{multiple ? '[]' : ''}"
+              "#{object_name}[#{index}][#{method_name}]#{names}#{'[]' if multiple}"
             else
-              "#{object_name}[#{method_name}]#{names}#{multiple ? '[]' : ''}"
+              "#{object_name}[#{method_name}]#{names}#{'[]' if multiple}"
             end
           end
         end

--- a/lib/bootstrap_form/inputs/file_field.rb
+++ b/lib/bootstrap_form/inputs/file_field.rb
@@ -10,7 +10,7 @@ module BootstrapForm
         def file_field_with_bootstrap(name, options={})
           options = options.reverse_merge(control_class: "form-control")
           form_group_builder(name, options) do
-            input_with_error(name) do
+            prepend_and_append_input(name, options) do
               file_field_without_bootstrap(name, options)
             end
           end

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -195,6 +195,32 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equivalent_html expected, bootstrap_form_for(@user) { |f| f.text_field :email, prepend: "$", append: ".00" }
   end
 
+  test "file field with prepend text" do
+    expected = <<~HTML
+      <div class="mb-3">
+        <label class="form-label" for="user_avatar">Avatar</label>
+        <div class="input-group">
+          <span class="input-group-text">before</span>
+          <input class="form-control" id="user_avatar" name="user[avatar]" type="file" />
+        </div>
+      </div>
+    HTML
+    assert_equivalent_html expected, @builder.file_field(:avatar, prepend: "before")
+  end
+
+  test "file field with append text" do
+    expected = <<~HTML
+      <div class="mb-3">
+        <label class="form-label" for="user_avatar">Avatar</label>
+        <div class="input-group">
+          <input class="form-control" id="user_avatar" name="user[avatar]" type="file" />
+          <span class="input-group-text">after</span>
+        </div>
+      </div>
+    HTML
+    assert_equivalent_html expected, @builder.file_field(:avatar, append: "after")
+  end
+
   test "help messages for default forms" do
     expected = <<~HTML
       <div class="mb-3">

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -221,6 +221,25 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equivalent_html expected, @builder.file_field(:avatar, append: "after")
   end
 
+  test "file field with append and prepend button" do
+    prefix = '<div class="mb-3"><label class="form-label" for="user_avatar">Avatar</label><div class="input-group">'
+    field = <<~HTML
+      <input class="form-control" id="user_avatar" name="user[avatar]" type="file" />
+    HTML
+    button_src = link_to("Click", "#", class: "btn btn-secondary")
+    button_prepend = button_src
+    button_append = button_src
+    suffix = "</div></div>"
+    after_button = prefix + field + button_append + suffix
+    before_button = prefix + button_prepend + field + suffix
+    both_button = prefix + button_prepend + field + button_append + suffix
+    multiple_button = prefix + button_prepend + button_prepend + field + button_append + button_append + suffix
+    assert_equivalent_html after_button, @builder.file_field(:avatar, append: button_src)
+    assert_equivalent_html before_button, @builder.file_field(:avatar, prepend: button_src)
+    assert_equivalent_html both_button, @builder.file_field(:avatar, append: button_src, prepend: button_src)
+    assert_equivalent_html multiple_button, @builder.file_field(:avatar, append: [button_src] * 2, prepend: [button_src] * 2)
+  end
+
   test "help messages for default forms" do
     expected = <<~HTML
       <div class="mb-3">


### PR DESCRIPTION
The file input appears to be treated like any of the other input types in Bootstrap 5. This branch simply removes the previous behavior of forcing it to be wrapped in `input_with_error`, which does not allow options, and instead uses `prepend_and_append_input`, which does. This is the same pattern used in the text input, for example. Errors are handled inside of the `prepend_and_append_input` method, so there's no loss of proper feedback after an invalid submit.