### PR TITLE
Still trying to handle rich_textarea

### DIFF
--- a/demo/config/initializers/filter_parameter_logging.rb
+++ b/demo/config/initializers/filter_parameter_logging.rb
@@ -3,6 +3,6 @@
 # Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
-Rails.application.config.filter_parameters += [
-  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc
+Rails.application.config.filter_parameters += %i[
+  passw email secret token _key crypt salt certificate otp ssn cvv cvc
 ]

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -1,9 +1,15 @@
 # require 'bootstrap_form/aliasing'
 
 module BootstrapForm
-  class FormBuilder < ActionView::Helpers::FormBuilder
+  class FormBuilder < ActionView::Helpers::FormBuilder # rubocop:disable Metrics/ClassLength
     attr_reader :layout, :label_col, :control_col, :has_error, :inline_errors,
                 :label_errors, :acts_like_form_tag
+
+    class << self
+      def redefine_rich_text_area?
+        ActionView::Helpers::FormBuilder.instance_methods.any? { _1 == :rich_text_area }
+      end
+    end
 
     include BootstrapForm::Helpers::Field
     include BootstrapForm::Helpers::Bootstrap
@@ -32,7 +38,7 @@ module BootstrapForm
     include BootstrapForm::Inputs::PhoneField
     include BootstrapForm::Inputs::RadioButton
     include BootstrapForm::Inputs::RangeField
-    include BootstrapForm::Inputs::RichTextArea if Gem.loaded_specs["actiontext"]
+    include BootstrapForm::Inputs::RichTextArea if redefine_rich_text_area?
     include BootstrapForm::Inputs::SearchField
     include BootstrapForm::Inputs::Select
     include BootstrapForm::Inputs::Submit


### PR DESCRIPTION
All other attempts seemed to be too clever. I could get tests to pass in this repo, but then `bootstrap_form` wouldn't work in a Rails app without ActionText. Or vice versa.

Finally, this PR does the obvious: Check if the class responds to `rich_text_area`. FIngers crossed.

Also, I didn't investigate when I broke the support for an app not to include Trix. This is going to be a weakness going forward, compounded by the fact that Rails is going to drop Trix for Lexxy.