### PR TITLE
Rake Without `bundle exec` and Clean Up Warnings

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -2,4 +2,4 @@
 # yarn lockfile v1
 
 
-lastUpdateCheck 1761786460258
+lastUpdateCheck 1762373771610

--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -14,11 +14,11 @@ gem "sqlite3", ">= 2.1"
 gem "stimulus-rails"
 gem "thruster", require: false
 gem "turbo-rails"
-gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
+gem "tzinfo-data", platforms: %i[windows jruby]
 
 group :development, :test do
   gem "brakeman", require: false
-  gem "debug", platforms: %i[mri mingw x64_mingw]
+  gem "debug", platforms: %i[mri windows]
 end
 
 group :development do

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -310,4 +310,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   2.5.9
+   2.7.2

--- a/gemfiles/common.gemfile
+++ b/gemfiles/common.gemfile
@@ -20,6 +20,7 @@ end
 group :development, :test do
   gem "debug"
   gem "ostruct" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.5.0")
+  gem "warning"
 end
 
 group :ci do

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -69,7 +69,7 @@ module BootstrapForm
 
     def add_default_form_attributes_and_form_inline(options)
       options[:html] ||= {}
-      options[:html].reverse_merge!(BootstrapForm.configuration.default_form_attributes)
+      options[:html].reverse_merge!(BootstrapForm.config.default_form_attributes)
 
       return unless options[:layout] == :inline
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,12 @@
 ENV["RAILS_ENV"] ||= "test"
 
+puts "BUNDLE_GEMFILE: #{ENV.fetch('BUNDLE_GEMFILE', nil)}" # rubocop/ignore Rails/Output
+
+require "warning"
+mail_gem_path = Gem::Specification.find_by_name("mail").full_gem_path
+Warning.ignore(:not_reached, mail_gem_path)
+Warning.ignore(/warning: assigned but unused variable - testEof/, mail_gem_path)
+
 require "diffy"
 require "nokogiri"
 require "equivalent-xml"


### PR DESCRIPTION
- Run the tests with Ruby wanrings enabled -- they'll sometimes catch real problems.
- Adds to the test runner to use the right version of bundler, which cleans up some warnings.
- Ignore some other warnings that come from gems we have no control over.

No changes to how the gem functions when in use.