### PR TITLE
Update bin/dev to set port

### DIFF
--- a/demo/Procfile.dev
+++ b/demo/Procfile.dev
@@ -1,3 +1,3 @@
-web: bundle exec bin/rails server -p ${TEST_APP_PORT:-3000} -b 0.0.0.0
+web: bundle exec bin/rails server -b 0.0.0.0
 js: yarn build --watch
 css: yarn build:css --watch

--- a/demo/bin/dev
+++ b/demo/bin/dev
@@ -5,4 +5,7 @@ if ! gem list foreman -i --silent; then
   gem install foreman
 fi
 
+# Default to port 3000 if not specified
+export PORT="${PORT:-3000}"
+
 exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
`bin/dev` wasn't setting the PORT environment variable, so our code was setting the port in other places, and as a result, maintainers were sometimes surprised by behaviour when testing. The behaviour should now be more consistent with normal Rails practice, when using the demo app.