### PR TITLE
Add frozen_string_literal and RuboCop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,7 @@ AllCops:
     - gemfiles/vendor/bundle/**/*
     - vendor/bundle/**/*
     - Guardfile
+    - test/dummy/**/*
     - vendor/**/*
 
 Layout/LineLength:
@@ -97,9 +98,6 @@ Style/DoubleNegation:
 Style/EmptyMethod:
   Enabled: false
 
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
 Style/NumericPredicate:
   Enabled: false
 
@@ -108,3 +106,18 @@ Style/StringLiterals:
 
 Style/TrivialAccessors:
   AllowPredicates: true
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always # or 'always' or 'never' depending on your preference
+  SafeAutoCorrect: true # Set to true for safe autocorrection, false if you need to review changes
+  Exclude:
+    - ./**/Gemfile*
+    - bootstrap_form.gemspec
+    - Dangerfile
+    - demo/config/**/*
+    - demo/config.ru
+    - demo/db/migrate/**/*
+    - gemfiles/*
+    - Rakefile
+    - Vagrantfile

--- a/.yarnrc
+++ b/.yarnrc
@@ -2,4 +2,4 @@
 # yarn lockfile v1
 
 
-lastUpdateCheck 1762373771610
+lastUpdateCheck 1762552807228

--- a/demo/app/controllers/application_controller.rb
+++ b/demo/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
 end

--- a/demo/app/controllers/bootstrap_controller.rb
+++ b/demo/app/controllers/bootstrap_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class BootstrapController < ApplicationController
   def form
     load_models

--- a/demo/app/controllers/users_controller.rb
+++ b/demo/app/controllers/users_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UsersController < ApplicationController
   def create
     redirect_to root_path

--- a/demo/app/helpers/bootstrap_helper.rb
+++ b/demo/app/helpers/bootstrap_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BootstrapHelper
   def form_with_source(&)
     form_html = capture(&)

--- a/demo/app/models/address.rb
+++ b/demo/app/models/address.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Address < ApplicationRecord
   belongs_to :user
 

--- a/demo/app/models/application_record.rb
+++ b/demo/app/models/application_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/demo/app/models/faux_user.rb
+++ b/demo/app/models/faux_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class FauxUser
   attr_accessor :email, :password, :comments, :misc
 

--- a/demo/app/models/model_user.rb
+++ b/demo/app/models/model_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ModelUser
   include ActiveModel::Model
 

--- a/demo/app/models/skill.rb
+++ b/demo/app/models/skill.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Skill
   attr_accessor :id, :name
 

--- a/demo/app/models/super_user.rb
+++ b/demo/app/models/super_user.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class SuperUser < User
 end

--- a/demo/app/models/user.rb
+++ b/demo/app/models/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class User < ApplicationRecord
   attr_accessor :remember_me
 

--- a/demo/test/application_system_test_case.rb
+++ b/demo/test/application_system_test_case.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "capybara_screenshot_diff/minitest"
 

--- a/demo/test/controllers/bootstrap_controller_test.rb
+++ b/demo/test/controllers/bootstrap_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class BootstrapControllerTest < ActionDispatch::IntegrationTest

--- a/demo/test/controllers/users_controller_test.rb
+++ b/demo/test/controllers/users_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class UsersControllerTest < ActionDispatch::IntegrationTest

--- a/demo/test/system/bootstrap_test.rb
+++ b/demo/test/system/bootstrap_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 require "capybara_screenshot_diff/minitest"
 

--- a/lib/bootstrap_form.rb
+++ b/lib/bootstrap_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "action_view"
 require "action_pack"
 require "bootstrap_form/action_view_extensions/form_helper"

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # require 'bootstrap_form/aliasing'
 
 module BootstrapForm

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BootstrapForm
   module Helpers
     module Bootstrap

--- a/lib/bootstrap_form/helpers/field.rb
+++ b/lib/bootstrap_form/helpers/field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BootstrapForm
   module Helpers
     module Field

--- a/lib/bootstrap_form/inputs/inputs_collection.rb
+++ b/lib/bootstrap_form/inputs/inputs_collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BootstrapForm
   module Inputs
     module InputsCollection

--- a/lib/bootstrap_form/inputs/submit.rb
+++ b/lib/bootstrap_form/inputs/submit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BootstrapForm
   module Inputs
     module Submit

--- a/lib/bootstrap_form/version.rb
+++ b/lib/bootstrap_form/version.rb
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
+
 module BootstrapForm
-  VERSION = "5.5.0".freeze
-  REQUIRED_RAILS_VERSION = ">= 7.2".freeze
+  VERSION = "5.5.0"
+  REQUIRED_RAILS_VERSION = ">= 7.2"
 end

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 class BootstrapCheckboxTest < ActionView::TestCase

--- a/test/bootstrap_configuration_test.rb
+++ b/test/bootstrap_configuration_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 class BootstrapConfigurationTest < ActionView::TestCase

--- a/test/bootstrap_fields_for_test.rb
+++ b/test/bootstrap_fields_for_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 class BootstrapFieldsForTest < ActionView::TestCase

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 class BootstrapFieldsTest < ActionView::TestCase

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 class BootstrapFormGroupTest < ActionView::TestCase
@@ -671,8 +673,8 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
   test "non-default column span on form isn't mutated" do
     frozen_horizontal_builder = BootstrapForm::FormBuilder.new(:user, @user, self, layout: :horizontal,
-                                                                                   label_col: "col-sm-3".freeze,
-                                                                                   control_col: "col-sm-9".freeze)
+                                                                                   label_col: "col-sm-3",
+                                                                                   control_col: "col-sm-9")
     output = frozen_horizontal_builder.form_group { "test" }
 
     expected = '<div class="mb-3 row"><div class="col-sm-9 offset-sm-3">test</div></div>'

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 class BootstrapFormTest < ActionView::TestCase

--- a/test/bootstrap_other_components_test.rb
+++ b/test/bootstrap_other_components_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 class BootstrapOtherComponentsTest < ActionView::TestCase

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 class BootstrapRadioButtonTest < ActionView::TestCase

--- a/test/bootstrap_rich_text_area_test.rb
+++ b/test/bootstrap_rich_text_area_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 require "minitest/mock"
 

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 class BootstrapSelectsTest < ActionView::TestCase

--- a/test/bootstrap_without_fields_test.rb
+++ b/test/bootstrap_without_fields_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 class BootstrapWithoutFieldsTest < ActionView::TestCase

--- a/test/special_form_class_models_test.rb
+++ b/test/special_form_class_models_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 class SpecialFormClassModelsTest < ActionView::TestCase

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 ENV["RAILS_ENV"] ||= "test"
 
-puts "BUNDLE_GEMFILE: #{ENV.fetch('BUNDLE_GEMFILE', nil)}" # rubocop/ignore Rails/Output
+puts "BUNDLE_GEMFILE: #{ENV.fetch('BUNDLE_GEMFILE', nil)}" # rubocop:disable Rails/Output
 
 require "warning"
 mail_gem_path = Gem::Specification.find_by_name("mail").full_gem_path


### PR DESCRIPTION
I don't know of a reason why we wouldn't use frozen string literals everywhere.