### PR TITLE
`inline: true` generates the same CSS for the collection label as lay…

### DIFF
--- a/lib/bootstrap_form/inputs/inputs_collection.rb
+++ b/lib/bootstrap_form/inputs/inputs_collection.rb
@@ -8,7 +8,7 @@ module BootstrapForm
       private
 
       def inputs_collection(name, collection, value, text, options={})
-        options[:label] ||= { class: group_label_class(options[:layout]) }
+        options[:label] ||= { class: group_label_class(field_layout(options)) }
         options[:inline] ||= layout_inline?(options[:layout])
 
         form_group_builder(name, options) do
@@ -23,6 +23,8 @@ module BootstrapForm
           inputs
         end
       end
+
+      def field_layout(options) = options[:layout] || (:inline if options[:inline] == true)
 
       def group_label_class(field_layout)
         if layout_horizontal?(field_layout)

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -256,7 +256,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
     expected = <<~HTML
       <input #{autocomplete_attr_55336} id="user_misc" name="user[misc][]" type="hidden" value="" />
       <div class="mb-3">
-        <label class="form-label" for="user_misc">Misc</label>
+        <label class="form-check form-check-inline ps-0" for="user_misc">Misc</label>
         <div class="form-check form-check-inline">
           <input class="form-check-input" id="user_misc_1" name="user[misc][]" type="checkbox" value="1" />
           <label class="form-check-label" for="user_misc_1">
@@ -272,8 +272,7 @@ class BootstrapCheckboxTest < ActionView::TestCase
       </div>
     HTML
 
-    assert_equivalent_html expected, @builder.collection_check_boxes(:misc, collection, :id, :street,
-                                                                     inline: true)
+    assert_equivalent_html expected, @builder.collection_check_boxes(:misc, collection, :id, :street, inline: true)
   end
 
   test "collection_check_boxes renders with checked option correctly" do

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -209,7 +209,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: "Foo"), Address.new(id: 2, street: "Bar")]
     expected = <<~HTML
       <div class="mb-3">
-        <label class="form-label" for="user_misc">Misc</label>
+        <label class="form-check form-check-inline ps-0" for="user_misc">Misc</label>
         <div class="form-check form-check-inline">
           <input class="form-check-input" id="user_misc_1" name="user[misc]" type="radio" value="1" />
           <label class="form-check-label" for="user_misc_1"> Foo</label>


### PR DESCRIPTION
This PR makes `inline: true` generate the same CSS for the collection label as `layout: :inline`. This applies to `collection_checkboxes` and `collection_radio_buttons`. See the changes in the test cases of this PR for details, and compare to the `layout: :inline` test cases ([example](https://github.com/bootstrap-ruby/bootstrap_form/blob/d652b17dd041a474a6772b803e3e4dfb72eeabab/test/bootstrap_form_test.rb#L140-L148)) in `test/bootstrap_form_test.rb`.

While this is a breaking change in some senses (it changes the generated marktup), I would classify it more as a bug fix. The previous mark-up would not have give the expected layout. So either the programmer worked around it some other way, or they didn't want `inline: true` in the first place, and can simply remove `inline: true`.

Closes: #777 .