### PR TITLE
Don't raise exception for label_as_placeholder when no model in `bootstrap_form_with`

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -34,6 +34,9 @@ jobs:
       matrix:
         ruby-version: [ '3.4', '3.3', '3.2', 'ruby-head' ]
         gemfile: [ '8.1', '8.0', '7.2', 'edge' ]
+        exclude:
+          - ruby-version: 3.2
+          - gemfiles: 'edge'
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:

--- a/gemfiles/7.2.gemfile
+++ b/gemfiles/7.2.gemfile
@@ -3,6 +3,7 @@ eval File.read(gems), binding, gems # rubocop: disable Security/Eval
 
 gem "bigdecimal" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0")
 gem "drb" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0")
+gem "minitest", "~> 5.0"
 gem "mutex_m" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0")
 gem "rails", "~> 7.2.0"
 gem "sprockets-rails", require: "sprockets/railtie"

--- a/gemfiles/8.0.gemfile
+++ b/gemfiles/8.0.gemfile
@@ -3,6 +3,7 @@ eval File.read(gems), binding, gems # rubocop: disable Security/Eval
 
 gem "bigdecimal" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0")
 gem "drb" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0")
+gem "minitest", "~> 5.0"
 gem "mutex_m" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0")
 gem "propshaft"
 gem "rails", "~> 8.0.1"

--- a/gemfiles/common.gemfile
+++ b/gemfiles/common.gemfile
@@ -9,6 +9,7 @@ group :test do
   gem "chunky_png", "~> 1.4"
   gem "diffy"
   gem "equivalent-xml"
+  gem "minitest-mock"
   gem "mocha"
   gem "selenium-webdriver"
 end

--- a/lib/bootstrap_form/form_group_builder.rb
+++ b/lib/bootstrap_form/form_group_builder.rb
@@ -107,7 +107,7 @@ module BootstrapForm
     end
 
     def form_group_placeholder(options, method)
-      form_group_label_text(options[:label]) || object.class.human_attribute_name(method)
+      form_group_label_text(options[:label]) || (object && object.class.human_attribute_name(method)) || method.to_s.humanize # rubocop:disable Style/SafeNavigation
     end
   end
 end

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -118,6 +118,16 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equivalent_html expected, @builder.text_field(:email, label_as_placeholder: true)
   end
 
+  test "label as placeholder with form_with" do
+    expected = <<~HTML
+      <div class="mb-3">
+        <label class="visually-hidden required" for="user_email">Email</label>
+        <input required="required" class="form-control" id="user_email" placeholder="Email" name="user[email]" type="text" value="steve@example.com" />
+      </div>
+    HTML
+    assert_equivalent_html expected, form_with_builder.text_field(:email, label_as_placeholder: true, required: true)
+  end
+
   test "adding prepend text" do
     expected = <<~HTML
       <div class="mb-3">

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -41,10 +41,10 @@ class ActionView::TestCase
   end
 
   # Originally only used in one test file but placed here in case it's needed in others in the future.
+  # This simulartes `form_with` without a model, which tests aspects that wouldn't otherwise
+  # be tested.
   def form_with_builder
-    builder = nil
-    bootstrap_form_with(model: @user) { |f| builder = f }
-    builder
+    BootstrapForm::FormBuilder.new(:user, false, self, {})
   end
 
   def sort_attributes(doc)


### PR DESCRIPTION
Fields using `label_as_placeholder` in forms created with `bootstrap_form_with` and _no_ model (e.g. only `scope`) would raise an exception.

Closes: #786.