### PR TITLE
Update to capybara screenshot diff breaks tests

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -12,7 +12,7 @@
 
 	// The optional 'workspaceFolder' property is the path VS Code should open by default when
 	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
-	"workspaceFolder": "/app",
+	"workspaceFolder": "/home/dev/app",
 	// "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}"
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
@@ -34,5 +34,5 @@
 	// "customizations": {},
 
 	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "reid"
+	// "remoteUser": "devcontainer"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -52,10 +52,12 @@ demo/.yarn-integrity
 demo/vendor/bundle
 
 # For stuff that gets created if using the Dockerfile image
+# These are likely no longer needed.
 /.bundle/
 .cache/
 vendor/bundle
 
+# Neither are many of these, I think.
 # or .local/share/pry/pry_history if you need to be more exact
 .local/
 .irb_history

--- a/compose.yml
+++ b/compose.yml
@@ -4,13 +4,14 @@
 # https://medium.com/@retrorubies/chrome-as-a-service-for-rails-testing-b1a45e70fec1
 services:
   web:
-    image: lenchoreyes/jade:rails-app-${RUBY_VERSION:-3.3}-sqlite-${DISTRO:-bookworm}
+    image: lenchoreyes/jade:rails-app-${RUBY_VERSION:-4.0}-sqlite-trixie
     stdin_open: true
     tty: true
+    user: "dev:dev"
     volumes:
-      - .:/app:cached
+      - .:/home/dev/app
+      - dev_home:/home/dev
     environment:
-      - HISTFILE=/app/.bash_history
       - SELENIUM_HOST=selenium
       - SELENIUM_PORT=4444
       - TEST_APP_HOST=web
@@ -18,6 +19,7 @@ services:
     ports:
       - "3000"
       - "3001"
+      - "5990"
     command: /bin/bash
 
   selenium:
@@ -34,3 +36,6 @@ services:
       - LANG_WHICH=en
     ports:
       - "7900"
+
+volumes:
+  dev_home:

--- a/demo/test/system/bootstrap_test.rb
+++ b/demo/test/system/bootstrap_test.rb
@@ -37,6 +37,7 @@ class BootstrapTest < ApplicationSystemTestCase
     screenshot_group :readme
 
     readme = File.read(File.expand_path("../../../README.md", __dir__))
+    screenshot_index = 0
     augmented_readme = readme.gsub(REGEXP) do |_|
       erb = Regexp.last_match(1)
       header = Regexp.last_match(2)
@@ -49,7 +50,6 @@ class BootstrapTest < ApplicationSystemTestCase
 
         visit fragment_path erb: wrapped_erb
         wrapper = find(".fragment")
-        i = @screenshot_counter
         screenshot :example, crop: bounds(wrapper)
         wrapper = wrapper.find("form") if wrapped_erb != erb
         html = wrapper["innerHTML"].strip.gsub("><", ">\n<")
@@ -65,8 +65,9 @@ class BootstrapTest < ApplicationSystemTestCase
         end
         html = doc.to_html
         image = <<~MD
-          ![Example #{i}](demo/doc/screenshots/bootstrap/readme/#{format('%02i', i)}_example.png "Example #{i}")
+          ![Example #{screenshot_index}](demo/doc/screenshots/bootstrap/readme/#{format('%02i', screenshot_index)}_example.png "Example #{screenshot_index}")
         MD
+        screenshot_index += 1
         html = <<~MD
 
           #{header || 'Generated HTML:'}


### PR DESCRIPTION
The system tests depended on an internal variable in `capybara_screenshot_diff` that changed since the last time I updated dependencies.