### PR TITLE
Remove conditional on environment

### DIFF
--- a/lib/bootstrap_form/engine.rb
+++ b/lib/bootstrap_form/engine.rb
@@ -9,7 +9,7 @@ module BootstrapForm
 
     config.bootstrap_form = BootstrapForm.config
     config.bootstrap_form.default_form_attributes ||= {}
-    config.bootstrap_form.group_around_collections = Rails.env.development? if config.bootstrap_form.group_around_collections.nil?
+    config.bootstrap_form.group_around_collections ||= false
 
     initializer "bootstrap_form.configure" do |app|
       BootstrapForm.config = app.config.bootstrap_form


### PR DESCRIPTION
#779 introduced a configuration option, that for some reason defaulted differently in development than in production. This was not good. This PR makes the configuration option the same across environments.

Closes: #792 