### PR TITLE
fix: make alert message programmatically focusable

### DIFF
--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -9,7 +9,7 @@ module BootstrapForm
         css = options[:class] || "alert alert-danger"
         return unless object.respond_to?(:errors) && object.errors.full_messages.any?
 
-        tag.div class: css do
+        tag.div class: css, tabindex: "-1" do
           if options[:error_summary] == false
             title
           else


### PR DESCRIPTION
This makes it possible for downstream consumers to use JavaScript to focus on the alert to satisfy https://www.w3.org/WAI/WCAG21/Understanding/on-focus.html